### PR TITLE
Add structured logging helpers for error and debug output

### DIFF
--- a/game.go
+++ b/game.go
@@ -601,7 +601,7 @@ func sendInputLoop(ctx context.Context, conn net.Conn) {
 	defer ticker.Stop()
 	for {
 		if err := sendPlayerInput(conn); err != nil {
-			fmt.Printf("send player input: %v\n", err)
+			logError("send player input: %v", err)
 		}
 		select {
 		case <-ctx.Done():
@@ -614,7 +614,7 @@ func sendInputLoop(ctx context.Context, conn net.Conn) {
 func udpReadLoop(ctx context.Context, conn net.Conn) {
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-			fmt.Printf("udp deadline: %v\n", err)
+			logError("udp deadline: %v", err)
 			return
 		}
 		m, err := readUDPMessage(conn)
@@ -627,7 +627,7 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 					continue
 				}
 			}
-			fmt.Printf("udp read error: %v\n", err)
+			logError("udp read error: %v", err)
 			return
 		}
 		tag := binary.BigEndian.Uint16(m[:2])
@@ -638,7 +638,7 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 		if txt := decodeMessage(m); txt != "" {
 			addMessage("udpReadLoop: decodeMessage: " + txt)
 		} else {
-			fmt.Printf("udp msg tag %d len %d\n", tag, len(m))
+			logDebug("udp msg tag %d len %d", tag, len(m))
 		}
 	}
 }
@@ -647,7 +647,7 @@ func tcpReadLoop(ctx context.Context, conn net.Conn) {
 loop:
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-			fmt.Printf("set read deadline: %v\n", err)
+			logError("set read deadline: %v", err)
 			break
 		}
 		m, err := readTCPMessage(conn)
@@ -660,7 +660,7 @@ loop:
 					continue
 				}
 			}
-			fmt.Printf("read error: %v\n", err)
+			logError("read error: %v", err)
 			break
 		}
 		tag := binary.BigEndian.Uint16(m[:2])
@@ -672,7 +672,7 @@ loop:
 			//fmt.Println(txt)
 			addMessage("tcpReadLoop: decodeMessage: " + txt)
 		} else {
-			fmt.Printf("msg tag %d len %d\n", tag, len(m))
+			logDebug("msg tag %d len %d", tag, len(m))
 		}
 		select {
 		case <-ctx.Done():

--- a/imgpool.go
+++ b/imgpool.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -55,6 +54,6 @@ func recycleTempImage(img *ebiten.Image) {
 	if len(imgPool[s]) < maxUnusedSprites {
 		imgPool[s] = append(imgPool[s], img)
 	} else {
-		fmt.Println("recycleTempImage: full")
+		logDebug("recycleTempImage: full")
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var (
+	errorLogger *log.Logger
+	debugLogger *log.Logger
+)
+
+func setupLogging(debug bool) {
+	logDir := filepath.Join("logs", "errors")
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		fmt.Printf("could not create log directory: %v\n", err)
+	}
+	ts := time.Now().Format("20060102-150405")
+
+	errPath := filepath.Join(logDir, fmt.Sprintf("error-%s.log", ts))
+	errFile, err := os.Create(errPath)
+	var errWriter io.Writer = os.Stdout
+	if err == nil {
+		errWriter = io.MultiWriter(os.Stdout, errFile)
+	}
+	errorLogger = log.New(errWriter, "", log.LstdFlags)
+	log.SetOutput(errWriter)
+
+	dbgPath := filepath.Join(logDir, fmt.Sprintf("debug-%s.log", ts))
+	dbgFile, err := os.Create(dbgPath)
+	var dbgWriter io.Writer
+	if err == nil {
+		if debug {
+			dbgWriter = io.MultiWriter(os.Stdout, dbgFile)
+		} else {
+			dbgWriter = dbgFile
+		}
+	} else {
+		if debug {
+			dbgWriter = os.Stdout
+		} else {
+			dbgWriter = io.Discard
+		}
+	}
+	debugLogger = log.New(dbgWriter, "", log.LstdFlags)
+}
+
+func logError(format string, v ...interface{}) {
+	if errorLogger != nil {
+		errorLogger.Printf(format, v...)
+	}
+	if !silent {
+		addMessage(fmt.Sprintf(format, v...))
+	}
+}
+
+func logDebug(format string, v ...interface{}) {
+	if debugLogger != nil {
+		debugLogger.Printf(format, v...)
+	}
+}

--- a/update.go
+++ b/update.go
@@ -113,7 +113,7 @@ func autoUpdate(resp []byte, dataDir string) error {
 	}
 	base = strings.TrimRight(base, "/")
 	clientVer := binary.BigEndian.Uint32(resp[4:8])
-	fmt.Printf("Client version: %v\n", clientVer)
+	logDebug("Client version: %v", clientVer)
 	imgVer := binary.BigEndian.Uint32(resp[8:12])
 	sndVer := binary.BigEndian.Uint32(resp[12:16])
 	imgURL := fmt.Sprintf("%v/data/CL_Images.%d.gz", base, imgVer>>8)
@@ -121,7 +121,7 @@ func autoUpdate(resp []byte, dataDir string) error {
 	imgPath := filepath.Join(dataDir, "CL_Images")
 	if err := downloadGZ(imgURL, imgPath); err != nil {
 		alt := fmt.Sprintf("%v/data/CL_Images.tgz", base)
-		fmt.Printf("download %v failed: %v; trying %v\n", imgURL, err, alt)
+		logError("download %v failed: %v; trying %v", imgURL, err, alt)
 		if err := downloadTGZ(alt, dataDir); err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ func autoUpdate(resp []byte, dataDir string) error {
 	sndPath := filepath.Join(dataDir, "CL_Sounds")
 	if err := downloadGZ(sndURL, sndPath); err != nil {
 		alt := fmt.Sprintf("%v/data/CL_Sounds.tgz", base)
-		fmt.Printf("download %v failed: %v; trying %v\n", sndURL, err, alt)
+		logError("download %v failed: %v; trying %v", sndURL, err, alt)
 		if err := downloadTGZ(alt, dataDir); err != nil {
 			return err
 		}

--- a/util.go
+++ b/util.go
@@ -105,8 +105,8 @@ func loadAdditionalErrorNames() {
 
 func init() { loadAdditionalErrorNames() }
 
-var debug bool = true
-var logFile *os.File
+var debug bool
+var silent bool
 var ackFrame int32
 var resendFrame int32
 var commandNum uint32 = 1


### PR DESCRIPTION
## Summary
- add `setupLogging`, `logError`, and `logDebug` helpers to centralize logging and write to timestamped files
- replace scattered fmt.Printf calls with new helpers in network loops, login flow, and update logic
- gate debug logging behind `-debug` flag while always recording to dedicated log files
- forward error logs to on-screen messages unless `-silent` is supplied

## Testing
- `go test ./...` *(fails: Xrandr.h not found; ALSA pkg-config missing)*

------
https://chatgpt.com/codex/tasks/task_e_688f870f4778832aa6c17f2c7489ee7d