### PR TITLE
Handle unknown medium bubble messages

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -42,6 +42,14 @@ func TestDecodeBubbleUnknownYellKeepsText(t *testing.T) {
 	}
 }
 
+func TestDecodeBubbleUnknownMedium(t *testing.T) {
+	data := []byte{0x00, byte(kBubbleNormal | kBubbleNotCommon), byte(kBubbleSylvan | kBubbleUnknownMedium), 'O', 'k', 0}
+	verb, text, _, lang, code, _ := decodeBubble(data)
+	if lang != "Sylvan" || verb != "says" || text != "" || code != kBubbleUnknownMedium {
+		t.Fatalf("got lang %v verb %v text %v code %x", lang, verb, text, code)
+	}
+}
+
 func TestDecodeBubbleEmptyAfterStripping(t *testing.T) {
 	data := []byte{0x00, byte(kBubbleNormal), 0x8A, 0xC2, 'p', 'n', 0}
 	if verb, txt, name, _, _, target := decodeBubble(data); verb != "" || txt != "" || name != "" || target != thinkNone {

--- a/draw.go
+++ b/draw.go
@@ -521,6 +521,8 @@ func parseDrawState(data []byte) bool {
 							switch code {
 							case kBubbleUnknownShort:
 								msg = fmt.Sprintf("%v %v, %v", name, verb, txt)
+							case kBubbleUnknownMedium:
+								msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
 							case kBubbleUnknownLong:
 								msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
 							default:
@@ -531,6 +533,8 @@ func parseDrawState(data []byte) bool {
 							switch code {
 							case kBubbleUnknownShort:
 								unknown = "something short"
+							case kBubbleUnknownMedium:
+								unknown = "something medium"
 							case kBubbleUnknownLong:
 								unknown = "something long"
 							default:


### PR DESCRIPTION
## Summary
- handle `kBubbleUnknownMedium` bubbles and add placeholder text
- test decoding of medium-length unknown language bubbles

## Testing
- `go test ./...` *(fails: X11/Xrandr header and ALSA pkg-config errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f902bebf4832a86737dba3ccdf2e7