### PR TITLE
Fix challenge offset in login handshake

### DIFF
--- a/main.go
+++ b/main.go
@@ -259,7 +259,7 @@ func main() {
 		if tag != kMsgChallenge {
 			log.Fatalf("unexpected msg tag %d", tag)
 		}
-		challenge := msg[8 : 8+16]
+		challenge := msg[16 : 16+16]
 
 		if account != "" || demo {
 			acct := account


### PR DESCRIPTION
## Summary
- fix challenge slice to skip the 16-byte header and read the full challenge

## Testing
- `go build ./...`
- `go test ./...` *(fails: "The DISPLAY environment variable is missing")*
- `go run . -account demo -account-pass demo -name demo -pass demo` *(fails: "The DISPLAY environment variable is missing")*


------
https://chatgpt.com/codex/tasks/task_e_68901c60fa60832aada46a17a2e20f20