### PR TITLE
Add keyboard movement and toggle walk option

### DIFF
--- a/game.go
+++ b/game.go
@@ -29,6 +29,12 @@ const epsilon = 0.003
 var mouseX, mouseY int16
 var mouseDown bool
 
+var keyWalk bool
+var keyX, keyY int16
+var clickToToggle bool
+var walkToggled bool
+var walkTargetX, walkTargetY int16
+
 var inputActive bool
 var inputText []rune
 var inputBg *ebiten.Image
@@ -207,6 +213,48 @@ func (g *Game) Update() error {
 		if inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
 			inputActive = true
 			inputText = inputText[:0]
+		}
+	}
+
+	if !inputActive {
+		dx, dy := 0, 0
+		if ebiten.IsKeyPressed(ebiten.KeyArrowLeft) || ebiten.IsKeyPressed(ebiten.KeyA) {
+			dx--
+		}
+		if ebiten.IsKeyPressed(ebiten.KeyArrowRight) || ebiten.IsKeyPressed(ebiten.KeyD) {
+			dx++
+		}
+		if ebiten.IsKeyPressed(ebiten.KeyArrowUp) || ebiten.IsKeyPressed(ebiten.KeyW) {
+			dy--
+		}
+		if ebiten.IsKeyPressed(ebiten.KeyArrowDown) || ebiten.IsKeyPressed(ebiten.KeyS) {
+			dy++
+		}
+		if dx != 0 || dy != 0 {
+			keyWalk = true
+			keyX = int16(dx * fieldCenterX)
+			keyY = int16(dy * fieldCenterY)
+		} else {
+			keyWalk = false
+		}
+		if clickToToggle {
+			if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
+				if walkToggled {
+					walkToggled = false
+				} else {
+					x, y := ebiten.CursorPosition()
+					walkTargetX = int16(x/scale - fieldCenterX)
+					walkTargetY = int16(y/scale - fieldCenterY)
+					walkToggled = true
+				}
+			}
+		} else {
+			walkToggled = false
+		}
+	} else {
+		keyWalk = false
+		if walkToggled {
+			walkToggled = false
 		}
 	}
 

--- a/network.go
+++ b/network.go
@@ -108,9 +108,17 @@ func sendPlayerInput(connection net.Conn) error {
 	flags := uint16(0)
 
 	x, y := ebiten.CursorPosition()
-	mouseX = int16(x/scale - fieldCenterX)
-	mouseY = int16(y/scale - fieldCenterY)
-	mouseDown = ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
+	baseX := int16(x/scale - fieldCenterX)
+	baseY := int16(y/scale - fieldCenterY)
+	baseDown := ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
+
+	mouseX, mouseY, mouseDown = baseX, baseY, baseDown
+	if keyWalk {
+		mouseX, mouseY, mouseDown = keyX, keyY, true
+	} else if clickToToggle {
+		mouseX, mouseY = walkTargetX, walkTargetY
+		mouseDown = walkToggled
+	}
 
 	if mouseDown {
 		flags = kPIMDownField

--- a/ui.go
+++ b/ui.go
@@ -96,6 +96,17 @@ func initUI() {
 	}
 	mainFlow.AddItem(anim)
 
+	toggle, toggleEvents := eui.NewCheckbox(&eui.ItemData{Text: "Click-to-Toggle Walk", Size: eui.Point{X: 150, Y: 24}, Checked: clickToToggle})
+	toggleEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			clickToToggle = ev.Checked
+			if !clickToToggle {
+				walkToggled = false
+			}
+		}
+	}
+	mainFlow.AddItem(toggle)
+
 	settingsWin.AddItem(mainFlow)
 	settingsWin.AddWindow(false)
 


### PR DESCRIPTION
## Summary
- Support WASD and arrow-key walking when chat input is closed
- Optionally walk using click-to-toggle with a new settings checkbox
- Ensure player input message respects new walking modes

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68903d0d8760832a9c684d951d918155