### PR TITLE
Respect UI clicks and improve click-to-walk

### DIFF
--- a/game.go
+++ b/game.go
@@ -237,15 +237,27 @@ func (g *Game) Update() error {
 		} else {
 			keyWalk = false
 		}
+
+		mx, my := ebiten.CursorPosition()
+		overUI := pointInUI(mx, my)
+
 		if clickToToggle {
-			if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
+			if !overUI && inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 				if walkToggled {
 					walkToggled = false
 				} else {
-					x, y := ebiten.CursorPosition()
-					walkTargetX = int16(x/scale - fieldCenterX)
-					walkTargetY = int16(y/scale - fieldCenterY)
+					walkTargetX = int16(mx/scale - fieldCenterX)
+					walkTargetY = int16(my/scale - fieldCenterY)
 					walkToggled = true
+				}
+			}
+			if walkToggled {
+				w, h := eui.ScreenSize()
+				if overUI || mx < 0 || my < 0 || mx >= w || my >= h {
+					walkToggled = false
+				} else {
+					walkTargetX = int16(mx/scale - fieldCenterX)
+					walkTargetY = int16(my/scale - fieldCenterY)
 				}
 			}
 		} else {

--- a/input_ui.go
+++ b/input_ui.go
@@ -1,0 +1,26 @@
+package main
+
+import "github.com/Distortions81/EUI/eui"
+
+// pointInUI reports whether the given screen coordinate lies within any EUI window or overlay.
+func pointInUI(x, y int) bool {
+	fx, fy := float32(x), float32(y)
+	for _, win := range eui.Windows() {
+		if !win.Open {
+			continue
+		}
+		pos := win.GetPos()
+		size := win.GetSize()
+		if fx >= pos.X && fx < pos.X+size.X && fy >= pos.Y && fy < pos.Y+size.Y {
+			return true
+		}
+	}
+	for _, ov := range eui.Overlays() {
+		pos := ov.GetPos()
+		size := ov.GetSize()
+		if fx >= pos.X && fx < pos.X+size.X && fy >= pos.Y && fy < pos.Y+size.Y {
+			return true
+		}
+	}
+	return false
+}

--- a/network.go
+++ b/network.go
@@ -111,6 +111,9 @@ func sendPlayerInput(connection net.Conn) error {
 	baseX := int16(x/scale - fieldCenterX)
 	baseY := int16(y/scale - fieldCenterY)
 	baseDown := ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
+	if pointInUI(x, y) {
+		baseDown = false
+	}
 
 	mouseX, mouseY, mouseDown = baseX, baseY, baseDown
 	if keyWalk {


### PR DESCRIPTION
## Summary
- Update click-to-walk so toggled walking follows the cursor and stops when leaving the window or hovering UI
- Allow UI layers to consume mouse clicks so they don't trigger movement

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689042cbf3f8832a874d6a0e04432ab5