### PR TITLE
Add optional bubble debug overlay

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	flag.BoolVar(&onion, "blend", false, "frame blending (smoother animations)")
 	flag.BoolVar(&denoise, "denoise", false, "apply image denoising filter")
 	flag.BoolVar(&showPlanes, "planes", false, "draw plane and type for each sprite")
+	flag.BoolVar(&showBubbles, "bubble", false, "draw bubble debug boxes")
 	clientVer := flag.Int("client-version", 1440, "client version number (for testing)")
 	flag.BoolVar(&debug, "debug", false, "verbose/debug logging")
 	flag.BoolVar(&silent, "silent", false, "suppress on-screen error messages")


### PR DESCRIPTION
## Summary
- add `-bubble` flag to render red debug boxes where speech bubbles would appear
- parse and retain bubble coordinates so they can be drawn with the debug flag

## Testing
- `go build ./...`
- `go test ./...` *(fails: GLFW library not initialized, DISPLAY variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890419bf4dc832a9710f87206f5d9ea