### PR TITLE
Send input after drawstate

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -159,35 +159,38 @@ func pictureShift(prev, cur []framePicture) (int, int, bool) {
 	return best[0], best[1], true
 }
 
-// handleDrawState decodes the packed draw state message.
+// handleDrawState decodes the packed draw state message and returns true when
+// parsing succeeds.
 //
 // Frames coming from the live server are XOR-obfuscated using SimpleEncrypt,
 // while movie files store the data unencrypted. We therefore try to parse the
 // raw payload first and only fall back to applying SimpleEncrypt when the
 // unencrypted attempt fails validation.
-func handleDrawState(m []byte) {
+func handleDrawState(m []byte) bool {
 	frameCounter++
 
 	if len(m) < 11 { // 2 byte tag + 9 bytes minimum
-		return
+		return false
 	}
 
 	data := append([]byte(nil), m[2:]...)
 
 	// First try parsing the payload as-is.
 	if parseDrawState(data) {
-		return
+		return true
 	}
 
 	// If parsing failed, assume the packet was XOR-obfuscated and retry.
 	simpleEncrypt(data)
-	if !parseDrawState(data) {
-		n := len(data)
-		if n > 16 {
-			n = 16
-		}
-		logDebug("failed to parse draw state: % x", data[:n])
+	if parseDrawState(data) {
+		return true
 	}
+	n := len(data)
+	if n > 16 {
+		n = 16
+	}
+	logDebug("failed to parse draw state: % x", data[:n])
+	return false
 }
 
 // parseDrawState decodes the draw state data. It returns false when the packet

--- a/draw_test.go
+++ b/draw_test.go
@@ -24,7 +24,9 @@ func TestHandleDrawStateInfoStrings(t *testing.T) {
 	data = append(data, stateData...)
 
 	m := append([]byte{0, 0}, data...)
-	handleDrawState(m)
+	if !handleDrawState(m) {
+		t.Fatalf("handleDrawState failed")
+	}
 
 	got := getMessages()
 	if len(got) != 2 || got[0] != msg1 || got[1] != msg2 {
@@ -54,7 +56,9 @@ func TestHandleDrawStateEncryptedInfoStrings(t *testing.T) {
 
 	m := append([]byte{0, 0}, data...)
 	simpleEncrypt(m[2:])
-	handleDrawState(m)
+	if !handleDrawState(m) {
+		t.Fatalf("handleDrawState failed")
+	}
 
 	got := getMessages()
 	if len(got) != 2 || got[0] != msg1 || got[1] != msg2 {
@@ -93,7 +97,9 @@ func TestHandleDrawStateUsesDescriptorName(t *testing.T) {
 	data = append(data, stateData...)
 
 	m := append([]byte{0, 0}, data...)
-	handleDrawState(m)
+	if !handleDrawState(m) {
+		t.Fatalf("handleDrawState failed")
+	}
 
 	expected := "Tsune yells, " + msg
 	got := getMessages()
@@ -126,7 +132,9 @@ func TestHandleDrawStateSounds(t *testing.T) {
 	data = append(data, stateData...)
 
 	m := append([]byte{0, 0}, data...)
-	handleDrawState(m)
+	if !handleDrawState(m) {
+		t.Fatalf("handleDrawState failed")
+	}
 
 	if len(played) != 2 || played[0] != 1 || played[1] != 515 {
 		t.Fatalf("played = %#v", played)

--- a/game.go
+++ b/game.go
@@ -644,21 +644,6 @@ func runGame(ctx context.Context) {
 	}
 }
 
-func sendInputLoop(ctx context.Context, conn net.Conn) {
-	ticker := time.NewTicker(200 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		if err := sendPlayerInput(conn); err != nil {
-			logError("send player input: %v", err)
-		}
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-	}
-}
-
 func udpReadLoop(ctx context.Context, conn net.Conn) {
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
@@ -680,7 +665,11 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 		}
 		tag := binary.BigEndian.Uint16(m[:2])
 		if tag == 2 { // kMsgDrawState
-			handleDrawState(m)
+			if handleDrawState(m) {
+				if err := sendPlayerInput(udpConn); err != nil {
+					logError("send player input: %v", err)
+				}
+			}
 			continue
 		}
 		if txt := decodeMessage(m); txt != "" {
@@ -713,7 +702,11 @@ loop:
 		}
 		tag := binary.BigEndian.Uint16(m[:2])
 		if tag == 2 { // kMsgDrawState
-			handleDrawState(m)
+			if handleDrawState(m) {
+				if err := sendPlayerInput(udpConn); err != nil {
+					logError("send player input: %v", err)
+				}
+			}
 			continue
 		}
 		if txt := decodeMessage(m); txt != "" {

--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func main() {
 			defer ticker.Stop()
 			for _, m := range frames {
 				if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
-					handleDrawState(m)
+					_ = handleDrawState(m)
 				}
 				if txt := decodeMessage(m); txt != "" {
 					//addMessage("clMov: decodeMessage: " + txt)
@@ -224,7 +224,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("tcp connect: %v", err)
 		}
-		udpConn, err := net.Dial("udp", host)
+		udpConn, err = net.Dial("udp", host)
 		if err != nil {
 			log.Fatalf("udp connect: %v", err)
 		}
@@ -376,11 +376,6 @@ func main() {
 		if result == 0 {
 			fmt.Println("login succeeded, reading messages (Ctrl-C to quit)...")
 
-			if err := sendPlayerInput(udpConn); err != nil {
-				logError("send player input: %v", err)
-			}
-
-			go sendInputLoop(ctx, udpConn)
 			go udpReadLoop(ctx, udpConn)
 			go tcpReadLoop(ctx, tcpConn)
 

--- a/network.go
+++ b/network.go
@@ -15,6 +15,9 @@ import (
 // tcpConn is the active TCP connection to the game server.
 var tcpConn net.Conn
 
+// udpConn is the active UDP connection to the game server.
+var udpConn net.Conn
+
 // sendClientIdentifiers transmits the client, image and sound versions to the server.
 func sendClientIdentifiers(connection net.Conn, clientVersion, imagesVersion, soundsVersion uint32) error {
 	const kMsgIdentifiers = 19


### PR DESCRIPTION
## Summary
- send player input only after a drawstate packet is parsed
- remove periodic input ticker and rely on latest server frame
- add udpConn global so loops can send input responses

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890437f4440832a89d45a564e814246