### PR TITLE
Centralize message dispatch

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -1,0 +1,27 @@
+package main
+
+import "encoding/binary"
+
+// dispatchMessage processes a raw server message. When hasHeader is true the
+// packet is expected to include the standard 16 byte header. The dispatcher will
+// invoke exactly one of the message handlers per packet.
+func dispatchMessage(m []byte, hasHeader bool) {
+	if len(m) == 0 {
+		return
+	}
+	if hasHeader {
+		if len(m) < 2 {
+			return
+		}
+		tag := binary.BigEndian.Uint16(m[:2])
+		if tag == 2 { // kMsgDrawState
+			handleDrawState(m)
+			return
+		}
+		if txt := decodeMessage(m); txt != "" {
+			addMessage(txt)
+		}
+		return
+	}
+	handleInfoText(m)
+}

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// helper to reset messages before each test
+func resetMessages() {
+	messageMu.Lock()
+	messages = nil
+	messageMu.Unlock()
+}
+
+func TestDispatchMessageDecode(t *testing.T) {
+	resetMessages()
+	// Build a packet with a simple bubble message "hi"
+	data := []byte{0x00, byte(kBubbleNormal), 'h', 'i', 0}
+	pkt := make([]byte, 16+len(data))
+	binary.BigEndian.PutUint16(pkt[0:2], 1) // arbitrary tag
+	copy(pkt[16:], data)
+	dispatchMessage(pkt, true)
+	msgs := getMessages()
+	if len(msgs) != 1 || msgs[0] != "hi" {
+		t.Fatalf("got messages %#v", msgs)
+	}
+}
+
+func TestDispatchMessageInfoText(t *testing.T) {
+	resetMessages()
+	dispatchMessage([]byte("hello"), false)
+	msgs := getMessages()
+	if len(msgs) != 1 || msgs[0] != "handleInfoText: bepstrip: hello" {
+		t.Fatalf("got messages %#v", msgs)
+	}
+}

--- a/draw.go
+++ b/draw.go
@@ -431,7 +431,7 @@ func parseDrawState(data []byte) bool {
 			stateData = stateData[1:]
 			break
 		}
-		handleInfoText(stateData[:idx])
+		dispatchMessage(stateData[:idx], false)
 		stateData = stateData[idx+1:]
 	}
 

--- a/game.go
+++ b/game.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"image/color"
 	"log"
@@ -729,16 +728,7 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 			logError("udp read error: %v", err)
 			return
 		}
-		tag := binary.BigEndian.Uint16(m[:2])
-		if tag == 2 { // kMsgDrawState
-			handleDrawState(m)
-			continue
-		}
-		if txt := decodeMessage(m); txt != "" {
-			addMessage("udpReadLoop: decodeMessage: " + txt)
-		} else {
-			logDebug("udp msg tag %d len %d", tag, len(m))
-		}
+		dispatchMessage(m, true)
 	}
 }
 
@@ -762,17 +752,7 @@ loop:
 			logError("read error: %v", err)
 			break
 		}
-		tag := binary.BigEndian.Uint16(m[:2])
-		if tag == 2 { // kMsgDrawState
-			handleDrawState(m)
-			continue
-		}
-		if txt := decodeMessage(m); txt != "" {
-			//fmt.Println(txt)
-			addMessage("tcpReadLoop: decodeMessage: " + txt)
-		} else {
-			logDebug("msg tag %d len %d", tag, len(m))
-		}
+		dispatchMessage(m, true)
 		select {
 		case <-ctx.Done():
 			break loop

--- a/movie.go
+++ b/movie.go
@@ -131,7 +131,7 @@ func parseGameState(gs []byte, version, revision uint16) {
 		return
 	}
 	if i := bytes.IndexByte(gs, 0); i >= 0 {
-		handleInfoText(gs[:i])
+		dispatchMessage(gs[:i], false)
 		gs = gs[i+1:]
 	}
 


### PR DESCRIPTION
## Summary
- Add dispatcher to route raw packets to decodeMessage, handleInfoText, or draw state handlers
- Use dispatcher in network loops and game state parsing to avoid duplicate chat entries
- Add tests ensuring single chat entry per packet

## Testing
- `CI=1 go test ./...` *(fails: X11 DISPLAY environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_689046d25ea0832ab38d02cd18f41df1