### PR TITLE
Handle mismatched sound sample rates

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/binary"
 	"log"
+	"math"
 	"path/filepath"
 	"sync"
 
@@ -23,33 +24,39 @@ var (
 		if s == nil || audioContext == nil {
 			return
 		}
-		if int(s.SampleRate) != audioContext.SampleRate() {
-			// ignore sounds with mismatched sample rate for now
-			return
-		}
 
-		var pcm []byte
+		srcRate := int(s.SampleRate)
+		dstRate := audioContext.SampleRate()
+
+		// Decode the sound data into 16-bit samples.
+		var samples []int16
 		switch s.Bits {
 		case 8:
-			pcm = make([]byte, len(s.Data)*2)
+			samples = make([]int16, len(s.Data))
 			for i, b := range s.Data {
 				v := int16(b) - 0x80
-				v <<= 8
-				pcm[2*i] = byte(v)
-				pcm[2*i+1] = byte(v >> 8)
+				samples[i] = v << 8
 			}
 		case 16:
 			if len(s.Data)%2 != 0 {
 				return
 			}
-			pcm = make([]byte, len(s.Data))
-			for i := 0; i < len(s.Data); i += 2 {
-				v := binary.BigEndian.Uint16(s.Data[i : i+2])
-				pcm[i] = byte(v)
-				pcm[i+1] = byte(v >> 8)
+			samples = make([]int16, len(s.Data)/2)
+			for i := 0; i < len(samples); i++ {
+				samples[i] = int16(binary.BigEndian.Uint16(s.Data[2*i : 2*i+2]))
 			}
 		default:
 			return
+		}
+
+		if srcRate != dstRate {
+			samples = resampleLinear(samples, srcRate, dstRate)
+		}
+
+		pcm := make([]byte, len(samples)*2)
+		for i, v := range samples {
+			pcm[2*i] = byte(v)
+			pcm[2*i+1] = byte(v >> 8)
 		}
 
 		p := audioContext.NewPlayerFromBytes(pcm)
@@ -66,6 +73,28 @@ var (
 		soundMu.Unlock()
 	}
 )
+
+// resampleLinear resamples the given 16-bit samples from srcRate to dstRate
+// using simple linear interpolation.
+func resampleLinear(src []int16, srcRate, dstRate int) []int16 {
+	if srcRate == dstRate || len(src) == 0 {
+		return append([]int16(nil), src...)
+	}
+	n := int(math.Round(float64(len(src)) * float64(dstRate) / float64(srcRate)))
+	dst := make([]int16, n)
+	ratio := float64(srcRate) / float64(dstRate)
+	for i := 0; i < n; i++ {
+		pos := float64(i) * ratio
+		idx := int(pos)
+		frac := pos - float64(idx)
+		if idx+1 < len(src) {
+			dst[i] = int16(float64(src[idx])*(1-frac) + float64(src[idx+1])*frac)
+		} else {
+			dst[i] = src[idx]
+		}
+	}
+	return dst
+}
 
 // loadSound retrieves and caches a sound by ID. The CL_Sounds archive is
 // opened on first use and individual sounds are parsed lazily.

--- a/sound_test.go
+++ b/sound_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2/audio"
+
+	"go_client/clsnd"
+)
+
+// TestPlaySoundResample ensures sounds with a sample rate different from the
+// audio context are resampled and produce audio bytes.
+func TestPlaySoundResample(t *testing.T) {
+	// Reset caches and players.
+	soundMu.Lock()
+	soundCache = make(map[uint16]*clsnd.Sound)
+	soundMu.Unlock()
+	soundPlayers = make(map[*audio.Player]struct{})
+
+	const id = uint16(1)
+	snd := &clsnd.Sound{
+		Data:       []byte{0x00, 0x01, 0x00, 0x02}, // two 16-bit samples
+		SampleRate: 11025,
+		Channels:   1,
+		Bits:       16,
+	}
+
+	soundMu.Lock()
+	soundCache[id] = snd
+	soundMu.Unlock()
+
+	playSound(id)
+
+	if len(soundPlayers) == 0 {
+		t.Fatalf("expected player to be created")
+	}
+	for p := range soundPlayers {
+		if !p.IsPlaying() {
+			t.Fatalf("expected player to be playing")
+		}
+		p.Close()
+	}
+}


### PR DESCRIPTION
## Summary
- Resample CLSND sound data to the audio context's sample rate using linear interpolation
- Add test ensuring non-22050Hz sounds are resampled and played

## Testing
- `xvfb-run go test ./...` *(fails: TestDecodeBubbleStripsTags, TestParseBackendInfo, TestParseBackendShare)*
- `xvfb-run go test -run TestPlaySoundResample -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6890500351d0832a9fadf0742feaa1c3