### PR TITLE
Refactor draw state handling

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -159,28 +159,15 @@ func pictureShift(prev, cur []framePicture) (int, int, bool) {
 	return best[0], best[1], true
 }
 
-// handleDrawState decodes the packed draw state message.
-//
-// Frames coming from the live server are XOR-obfuscated using SimpleEncrypt,
-// while movie files store the data unencrypted. We therefore try to parse the
-// raw payload first and only fall back to applying SimpleEncrypt when the
-// unencrypted attempt fails validation.
-func handleDrawState(m []byte) {
+// handleDrawState decodes the packed draw state payload. The caller must
+// provide the unencrypted payload data without the leading message tag.
+func handleDrawState(data []byte) {
 	frameCounter++
 
-	if len(m) < 11 { // 2 byte tag + 9 bytes minimum
+	if len(data) < 9 { // minimum payload size
 		return
 	}
 
-	data := append([]byte(nil), m[2:]...)
-
-	// First try parsing the payload as-is.
-	if parseDrawState(data) {
-		return
-	}
-
-	// If parsing failed, assume the packet was XOR-obfuscated and retry.
-	simpleEncrypt(data)
 	if !parseDrawState(data) {
 		n := len(data)
 		if n > 16 {

--- a/draw_test.go
+++ b/draw_test.go
@@ -23,8 +23,7 @@ func TestHandleDrawStateInfoStrings(t *testing.T) {
 	data = append(data, 0)                  // mobile count
 	data = append(data, stateData...)
 
-	m := append([]byte{0, 0}, data...)
-	handleDrawState(m)
+	handleDrawState(data)
 
 	got := getMessages()
 	if len(got) != 2 || got[0] != msg1 || got[1] != msg2 {
@@ -52,9 +51,10 @@ func TestHandleDrawStateEncryptedInfoStrings(t *testing.T) {
 	data = append(data, 0)
 	data = append(data, stateData...)
 
-	m := append([]byte{0, 0}, data...)
-	simpleEncrypt(m[2:])
-	handleDrawState(m)
+	enc := append([]byte(nil), data...)
+	simpleEncrypt(enc) // encrypt
+	simpleEncrypt(enc) // decrypt before handling
+	handleDrawState(enc)
 
 	got := getMessages()
 	if len(got) != 2 || got[0] != msg1 || got[1] != msg2 {
@@ -92,8 +92,7 @@ func TestHandleDrawStateUsesDescriptorName(t *testing.T) {
 	data = append(data, 0)                  // mobile count
 	data = append(data, stateData...)
 
-	m := append([]byte{0, 0}, data...)
-	handleDrawState(m)
+	handleDrawState(data)
 
 	expected := "Tsune yells, " + msg
 	got := getMessages()
@@ -125,8 +124,7 @@ func TestHandleDrawStateSounds(t *testing.T) {
 	data = append(data, 0)                  // mobile count
 	data = append(data, stateData...)
 
-	m := append([]byte{0, 0}, data...)
-	handleDrawState(m)
+	handleDrawState(data)
 
 	if len(played) != 2 || played[0] != 1 || played[1] != 515 {
 		t.Fatalf("played = %#v", played)

--- a/game.go
+++ b/game.go
@@ -793,7 +793,8 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 		tag := binary.BigEndian.Uint16(m[:2])
 		if tag == 2 { // kMsgDrawState
 			noteFrame()
-			handleDrawState(m)
+			simpleEncrypt(m[2:])
+			handleDrawState(m[2:])
 			continue
 		}
 		if txt := decodeMessage(m); txt != "" {
@@ -827,7 +828,8 @@ loop:
 		tag := binary.BigEndian.Uint16(m[:2])
 		if tag == 2 { // kMsgDrawState
 			noteFrame()
-			handleDrawState(m)
+			simpleEncrypt(m[2:])
+			handleDrawState(m[2:])
 			continue
 		}
 		if txt := decodeMessage(m); txt != "" {

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func main() {
 			defer ticker.Stop()
 			for _, m := range frames {
 				if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
-					handleDrawState(m)
+					handleDrawState(m[2:])
 				}
 				if txt := decodeMessage(m); txt != "" {
 					//addMessage("clMov: decodeMessage: " + txt)


### PR DESCRIPTION
## Summary
- require handleDrawState to consume pre-decrypted payloads
- decrypt draw-state network messages in game loop before parsing
- feed movie draw-state frames directly without encryption fallback

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689052950078832a817e8a143f7a4460