### PR TITLE
Add Sinc resampling with optional fast linear mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 	noSplash    bool
 	baseDir     string
 	soundTest   bool
+	fastSound   bool
 
 	loginRequest = make(chan struct{})
 )
@@ -61,8 +62,10 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "verbose/debug logging")
 	flag.BoolVar(&silent, "silent", false, "suppress on-screen error messages")
 	flag.BoolVar(&soundTest, "soundtest", false, "play sounds 1-100 and exit")
+	flag.BoolVar(&fastSound, "fast-sound", false, "use 22050Hz audio with linear resampling")
 
 	flag.Parse()
+	initSoundContext()
 	rand.Seed(time.Now().UnixNano())
 
 	initFont()

--- a/sound_test.go
+++ b/sound_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2/audio"
@@ -40,4 +41,21 @@ func TestPlaySoundResample(t *testing.T) {
 		}
 		p.Close()
 	}
+}
+
+// TestFastSoundContext verifies that enabling fastSound switches to a lower
+// sample rate and linear resampling.
+func TestFastSoundContext(t *testing.T) {
+	fastSound = true
+	initSoundContext()
+	if audioContext.SampleRate() != 22050 {
+		t.Fatalf("expected audio context sample rate 22050, got %d", audioContext.SampleRate())
+	}
+	src := []int16{0, 1000}
+	if got, want := resample(src, 44100, 22050), resampleLinear(src, 44100, 22050); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected linear resampler when fastSound is enabled")
+	}
+
+	fastSound = false
+	initSoundContext()
 }


### PR DESCRIPTION
## Summary
- add Sinc-based audio resampler and keep linear version
- introduce `-fast-sound` flag that switches to linear resampling at 22050 Hz
- cover fast-sound behavior with unit test

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68905bf17bd0832aa5a9c20335e2593a