### PR TITLE
Expand settings options and enlarge toggle button

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -30,26 +30,7 @@ func setupLogging(debug bool) {
 	errorLogger = log.New(errWriter, "", log.LstdFlags)
 	log.SetOutput(errWriter)
 
-	if debug {
-		dbgPath := filepath.Join(logDir, fmt.Sprintf("debug-%s.log", ts))
-		dbgFile, err := os.Create(dbgPath)
-		var dbgWriter io.Writer
-		if err == nil {
-			if debug {
-				dbgWriter = io.MultiWriter(os.Stdout, dbgFile)
-			} else {
-				dbgWriter = dbgFile
-			}
-		} else {
-			if debug {
-				dbgWriter = os.Stdout
-			} else {
-				dbgWriter = io.Discard
-			}
-		}
-
-		debugLogger = log.New(dbgWriter, "", log.LstdFlags)
-	}
+	setDebugLogging(debug)
 }
 
 func logError(format string, v ...interface{}) {
@@ -64,5 +45,26 @@ func logError(format string, v ...interface{}) {
 func logDebug(format string, v ...interface{}) {
 	if debugLogger != nil {
 		debugLogger.Printf(format, v...)
+	}
+}
+
+func setDebugLogging(enabled bool) {
+	if enabled {
+		logDir := filepath.Join(baseDir, "logs", "errors")
+		if err := os.MkdirAll(logDir, 0755); err != nil {
+			fmt.Printf("could not create log directory: %v\n", err)
+		}
+		ts := time.Now().Format("20060102-150405")
+		dbgPath := filepath.Join(logDir, fmt.Sprintf("debug-%s.log", ts))
+		dbgFile, err := os.Create(dbgPath)
+		var dbgWriter io.Writer
+		if err == nil {
+			dbgWriter = io.MultiWriter(os.Stdout, dbgFile)
+		} else {
+			dbgWriter = os.Stdout
+		}
+		debugLogger = log.New(dbgWriter, "", log.LstdFlags)
+	} else {
+		debugLogger = nil
 	}
 }

--- a/ui.go
+++ b/ui.go
@@ -107,6 +107,50 @@ func initUI() {
 	}
 	mainFlow.AddItem(toggle)
 
+	bubbleCB, bubbleEvents := eui.NewCheckbox(&eui.ItemData{Text: "Bubble Test Mode", Size: eui.Point{X: 150, Y: 24}, Checked: showBubbles})
+	bubbleEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			showBubbles = ev.Checked
+		}
+	}
+	mainFlow.AddItem(bubbleCB)
+
+	debugCB, debugEvents := eui.NewCheckbox(&eui.ItemData{Text: "Debug Mode", Size: eui.Point{X: 150, Y: 24}, Checked: debug})
+	debugEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			debug = ev.Checked
+			setDebugLogging(debug)
+		}
+	}
+	mainFlow.AddItem(debugCB)
+
+	planesCB, planesEvents := eui.NewCheckbox(&eui.ItemData{Text: "Planes Debug", Size: eui.Point{X: 150, Y: 24}, Checked: showPlanes})
+	planesEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			showPlanes = ev.Checked
+		}
+	}
+	mainFlow.AddItem(planesCB)
+
+	silentCB, silentEvents := eui.NewCheckbox(&eui.ItemData{Text: "Silence Errors", Size: eui.Point{X: 150, Y: 24}, Checked: silent})
+	silentEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			silent = ev.Checked
+		}
+	}
+	mainFlow.AddItem(silentCB)
+
+	denoiseCB, denoiseEvents := eui.NewCheckbox(&eui.ItemData{Text: "Denoiser", Size: eui.Point{X: 150, Y: 24}, Checked: denoise})
+	denoiseEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			denoise = ev.Checked
+			if clImages != nil {
+				clImages.Denoise = denoise
+			}
+		}
+	}
+	mainFlow.AddItem(denoiseCB)
+
 	settingsWin.AddItem(mainFlow)
 	settingsWin.AddWindow(false)
 
@@ -117,7 +161,7 @@ func initUI() {
 		FlowType: eui.FLOW_HORIZONTAL,
 		PinTo:    eui.PIN_BOTTOM_RIGHT,
 	}
-	btn, btnEvents := eui.NewButton(&eui.ItemData{Text: "...", Size: eui.Point{X: 12, Y: 12}, FontSize: 9})
+	btn, btnEvents := eui.NewButton(&eui.ItemData{Text: "...", Size: eui.Point{X: 36, Y: 36}, FontSize: 27})
 	btnEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			settingsWin.Open = !settingsWin.Open


### PR DESCRIPTION
## Summary
- make settings button three times larger
- add toggles for bubble test, debug logging, plane display, silencing errors, and image denoising
- support runtime enabling of debug logging

## Testing
- `go build ./...`
- `go test ./...` *(fails: DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68905cca49a0832abde13b360a76b8aa