### PR TITLE
Display server FPS in HUD

### DIFF
--- a/game.go
+++ b/game.go
@@ -57,6 +57,7 @@ var (
 	frameInterval = 200 * time.Millisecond
 	intervalHist  = map[int]int{}
 	frameMu       sync.Mutex
+	serverFPS     int
 )
 
 // drawState tracks information needed by the Ebiten renderer.
@@ -310,6 +311,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	drawScene(screen, snap, alpha, fade)
 	//drawNightOverlay(screen)
 	drawStatusBars(screen, snap, alpha)
+	drawServerFPS(screen, serverFPS)
 	drawMessages(screen, getMessages())
 	if inputActive {
 		drawInputOverlay(screen, string(inputText))
@@ -671,6 +673,18 @@ func drawMessages(screen *ebiten.Image, msgs []string) {
 	}
 }
 
+func drawServerFPS(screen *ebiten.Image, fps int) {
+	if fps <= 0 {
+		return
+	}
+	msg := fmt.Sprintf("FPS: %d", fps)
+	w, _ := text.Measure(msg, nameFace, 0)
+	op := &text.DrawOptions{}
+	op.GeoM.Translate(float64(gameAreaSizeX*scale)-w-float64(4*scale), float64(4*scale))
+	op.ColorScale.ScaleWithColor(color.White)
+	text.Draw(screen, msg, nameFace, op)
+}
+
 // drawInputOverlay renders the text entry box when chatting.
 func drawInputOverlay(screen *ebiten.Image, txt string) {
 	if inputBg == nil {
@@ -722,6 +736,7 @@ func noteFrame() {
 				if fps < 1 {
 					fps = 1
 				}
+				serverFPS = fps
 				frameInterval = time.Second / time.Duration(fps)
 			}
 		}


### PR DESCRIPTION
## Summary
- track server FPS in `noteFrame`
- show server FPS at the top-right corner of the HUD

## Testing
- `go test ./...` *(fails: GLFW library requires DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6890623e1f5c832ab6f2fea2766eb75a