### PR TITLE
Add embedded splash screen

### DIFF
--- a/game.go
+++ b/game.go
@@ -305,6 +305,10 @@ func (g *Game) Update() error {
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {
+	if clmov == "" && tcpConn == nil && !noSplash {
+		drawSplash(screen)
+		return
+	}
 	snap := captureDrawSnapshot()
 	alpha, fade := computeInterpolation(snap.prevTime, snap.curTime)
 	//logDebug("Draw alpha=%.2f shift=(%d,%d) pics=%d", alpha, snap.picShiftX, snap.picShiftY, len(snap.pictures))

--- a/splash.go
+++ b/splash.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"image"
+	_ "image/png"
+	"log"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+//go:embed splash.png
+var splashPNG []byte
+
+var splashImg *ebiten.Image
+
+func init() {
+	img, _, err := image.Decode(bytes.NewReader(splashPNG))
+	if err != nil {
+		log.Printf("decode splash: %v", err)
+		return
+	}
+	splashImg = ebiten.NewImageFromImage(img)
+}
+
+func drawSplash(screen *ebiten.Image) {
+	if splashImg == nil {
+		return
+	}
+	sw, sh := screen.Size()
+	iw, ih := splashImg.Bounds().Dx(), splashImg.Bounds().Dy()
+	scaleX := float64(sw) / float64(iw)
+	scaleY := float64(sh) / float64(ih)
+	s := scaleX
+	if scaleY < s {
+		s = scaleY
+	}
+	op := &ebiten.DrawImageOptions{}
+	op.GeoM.Scale(s, s)
+	op.GeoM.Translate((float64(sw)-float64(iw)*s)/2, (float64(sh)-float64(ih)*s)/2)
+	screen.DrawImage(splashImg, op)
+}


### PR DESCRIPTION
## Summary
- embed `splash.png` and load at startup
- draw splash image scaled to screen before other content if not connected or playing a movie

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890659511d0832abcc04986d81e986d