### PR TITLE
Handle trailing padding in inventory parser

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -255,6 +255,9 @@ func parseInventory(data []byte) ([]byte, bool) {
 	if cmd != kInvCmdNone {
 		return nil, false
 	}
+	for len(data) > 0 && data[0] == 0 {
+		data = data[1:]
+	}
 	return data, true
 }
 

--- a/draw_test.go
+++ b/draw_test.go
@@ -158,3 +158,14 @@ func TestParseInventory(t *testing.T) {
 		t.Fatalf("ok=%v rest=%v", ok, rest)
 	}
 }
+
+func TestParseInventoryTrailingPadding(t *testing.T) {
+	data := []byte{byte(kInvCmdAdd), 0x00, 0x01}
+	data = append(data, []byte("foo")...)
+	data = append(data, 0)       // name terminator
+	data = append(data, 0, 0, 0) // padding after commands
+	rest, ok := parseInventory(data)
+	if !ok || len(rest) != 0 {
+		t.Fatalf("ok=%v rest=%v", ok, rest)
+	}
+}


### PR DESCRIPTION
## Summary
- consume zero padding after inventory commands before returning
- add unit test covering inventory data with trailing padding

## Testing
- `go test -run TestParseInventoryTrailingPadding -count=1` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890686ef1c0832a86fc322fad31a82f