### PR TITLE
Improve bubble parsing diagnostics

### DIFF
--- a/draw_test.go
+++ b/draw_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func TestHandleDrawStateInfoStrings(t *testing.T) {
 	messages = nil
@@ -160,6 +164,23 @@ func buildTruncatedDrawState(pictBits []byte) []byte {
 	return data
 }
 
+// buildBubbleDrawState constructs a minimal draw state packet with one bubble.
+// It returns the packet and the byte offset where the bubble begins.
+func buildBubbleDrawState(bubble []byte) ([]byte, int) {
+	stateData := []byte{0, 1}
+	stateData = append(stateData, bubble...)
+	data := make([]byte, 0, 21+len(bubble))
+	data = append(data, 0)                  // ackCmd
+	data = append(data, make([]byte, 8)...) // ackFrame + resendFrame
+	data = append(data, 0)                  // descriptor count
+	data = append(data, make([]byte, 7)...) // hp, sp, etc.
+	data = append(data, 0)                  // picture count
+	data = append(data, 0)                  // mobile count
+	data = append(data, stateData...)
+	off := len(data) - len(bubble)
+	return data, off
+}
+
 func TestParseDrawStateTruncatedPictureID(t *testing.T) {
 	messages = nil
 	state = drawState{}
@@ -167,7 +188,7 @@ func TestParseDrawStateTruncatedPictureID(t *testing.T) {
 	silent = true
 	defer func() { silent = oldSilent }()
 	data := buildTruncatedDrawState([]byte{0x00})
-	if parseDrawState(data) {
+	if err := parseDrawState(data); err == nil {
 		t.Fatalf("parseDrawState succeeded on truncated picture ID")
 	}
 }
@@ -179,8 +200,42 @@ func TestParseDrawStateTruncatedPictureData(t *testing.T) {
 	silent = true
 	defer func() { silent = oldSilent }()
 	data := buildTruncatedDrawState([]byte{0xff, 0xff, 0xff, 0xff})
-	if parseDrawState(data) {
+	if err := parseDrawState(data); err == nil {
 		t.Fatalf("parseDrawState succeeded on truncated picture data")
+	}
+}
+
+func TestParseDrawStateBubbleErrors(t *testing.T) {
+	messages = nil
+	state = drawState{}
+	oldSilent := silent
+	silent = true
+	defer func() { silent = oldSilent }()
+
+	// Missing terminator.
+	bubble := []byte{0, byte(kBubbleYell), 'h', 'i'}
+	data, off := buildBubbleDrawState(bubble)
+	if err := parseDrawState(data); err == nil {
+		t.Fatalf("parseDrawState succeeded on unterminated bubble")
+	} else {
+		wantLen := len(bubble)
+		msg := err.Error()
+		if !strings.Contains(msg, "bubble=0") || !strings.Contains(msg, fmt.Sprintf("off=%d", off)) || !strings.Contains(msg, fmt.Sprintf("len=%d", wantLen)) {
+			t.Fatalf("error %q missing details", msg)
+		}
+	}
+
+	// Truncated far bubble coordinates.
+	bubble = []byte{0, kBubbleFar}
+	data, off = buildBubbleDrawState(bubble)
+	if err := parseDrawState(data); err == nil {
+		t.Fatalf("parseDrawState succeeded on truncated far bubble")
+	} else {
+		wantLen := len(bubble)
+		msg := err.Error()
+		if !strings.Contains(msg, "bubble=0") || !strings.Contains(msg, fmt.Sprintf("off=%d", off)) || !strings.Contains(msg, fmt.Sprintf("len=%d", wantLen)) {
+			t.Fatalf("error %q missing details", msg)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- provide detailed bubble index, offset, and length information when parsing bubbles
- log parseDrawState errors with full diagnostic context
- add tests covering malformed bubble packet errors

## Testing
- `xvfb-run go test ./...` *(fails: audio context is already created)*
- `xvfb-run go test -run ParseDrawStateBubbleErrors -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68906c8a63b0832a866988cf8cb12535