### PR TITLE
Add semi-transparent background to message area

### DIFF
--- a/game.go
+++ b/game.go
@@ -671,8 +671,14 @@ func drawStatusBars(screen *ebiten.Image, snap drawSnapshot, alpha float64) {
 func drawMessages(screen *ebiten.Image, msgs []string) {
 	startY := gameAreaSizeY*scale - 200
 	for i, msg := range msgs {
+		y := startY + (12*i)*scale
+		w, _ := text.Measure(msg, nameFace, 0)
+		iw := int(math.Ceil(w)) + 8*scale
+		ih := 12 * scale
+		ebitenutil.DrawRect(screen, 0, float64(y), float64(iw), float64(ih), color.RGBA{0, 0, 0, 128})
+
 		op := &text.DrawOptions{}
-		op.GeoM.Translate(float64(4*scale), float64(startY+(12*i)*scale))
+		op.GeoM.Translate(float64(4*scale), float64(y))
 		op.ColorScale.ScaleWithColor(color.White)
 		text.Draw(screen, msg, nameFace, op)
 	}


### PR DESCRIPTION
## Summary
- draw chat messages on top of a semi-transparent, dynamically sized background

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689079b92450832aab46853c2067dd94