### PR TITLE
Implement word wrapping for text console

### DIFF
--- a/game.go
+++ b/game.go
@@ -670,11 +670,17 @@ func drawStatusBars(screen *ebiten.Image, snap drawSnapshot, alpha float64) {
 // drawMessages prints chat messages on the HUD.
 func drawMessages(screen *ebiten.Image, msgs []string) {
 	startY := gameAreaSizeY*scale - 200
-	for i, msg := range msgs {
-		op := &text.DrawOptions{}
-		op.GeoM.Translate(float64(4*scale), float64(startY+(12*i)*scale))
-		op.ColorScale.ScaleWithColor(color.White)
-		text.Draw(screen, msg, nameFace, op)
+	y := startY
+	maxWidth := float64(gameAreaSizeX*scale - 8*scale)
+	for _, msg := range msgs {
+		lines := wrapText(msg, nameFace, maxWidth)
+		for _, line := range lines {
+			op := &text.DrawOptions{}
+			op.GeoM.Translate(float64(4*scale), float64(y))
+			op.ColorScale.ScaleWithColor(color.White)
+			text.Draw(screen, line, nameFace, op)
+			y += 12 * scale
+		}
 	}
 }
 

--- a/textwrap.go
+++ b/textwrap.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+	"strings"
+)
+
+// wrapText splits s into lines that do not exceed maxWidth when rendered
+// with the provided face. Words are kept intact when possible; if a single
+// word exceeds maxWidth it will be broken across lines.
+func wrapText(s string, face text.Face, maxWidth float64) []string {
+	var lines []string
+	for _, para := range strings.Split(s, "\n") {
+		words := strings.Fields(para)
+		if len(words) == 0 {
+			lines = append(lines, "")
+			continue
+		}
+		cur := words[0]
+		for _, w := range words[1:] {
+			cand := cur + " " + w
+			width, _ := text.Measure(cand, face, 0)
+			if width <= maxWidth {
+				cur = cand
+				continue
+			}
+			lines = append(lines, cur)
+			// if the single word is too wide, break it into pieces
+			if ww, _ := text.Measure(w, face, 0); ww > maxWidth {
+				var runes []rune
+				for _, r := range w {
+					runes = append(runes, r)
+					if wpart, _ := text.Measure(string(runes), face, 0); wpart > maxWidth && len(runes) > 1 {
+						lines = append(lines, string(runes[:len(runes)-1]))
+						runes = runes[len(runes)-1:]
+					}
+				}
+				cur = string(runes)
+			} else {
+				cur = w
+			}
+		}
+		lines = append(lines, cur)
+	}
+	return lines
+}

--- a/textwrap_test.go
+++ b/textwrap_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+	"testing"
+)
+
+func TestWrapText(t *testing.T) {
+	initFont()
+	w1, _ := text.Measure("hello", nameFace, 0)
+	w2, _ := text.Measure("hello world", nameFace, 0)
+	maxWidth := (w1 + w2) / 2
+	lines := wrapText("hello world", nameFace, maxWidth)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	if lines[0] != "hello" || lines[1] != "world" {
+		t.Fatalf("got lines %#v", lines)
+	}
+}


### PR DESCRIPTION
## Summary
- add generic wrapText helper to split text by rendered width
- use wrapText when drawing messages so long lines wrap within HUD width
- cover wrapText with a unit test

## Testing
- `go build ./...`
- `xvfb-run -a go test -run TestWrapText -v`


------
https://chatgpt.com/codex/tasks/task_e_6890799cb828832ab40d3eb2f16af96d