### PR TITLE
Track bubbles relative to descriptor

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -600,16 +600,13 @@ func parseDrawState(data []byte) error {
 			}
 			stateMu.Unlock()
 			if showBubbles && txt != "" {
-				bx, by := h, v
-				if typ&kBubbleFar == 0 {
-					stateMu.Lock()
-					if m, ok := state.mobiles[idx]; ok {
-						bx, by = m.H, m.V
-					}
-					stateMu.Unlock()
+				b := bubble{Index: idx, Text: txt, Expire: time.Now().Add(4 * time.Second)}
+				if typ&kBubbleFar != 0 {
+					b.H, b.V = h, v
+					b.Far = true
 				}
 				stateMu.Lock()
-				state.bubbles = append(state.bubbles, debugBubble{H: bx, V: by, Text: txt, Expire: time.Now().Add(4 * time.Second)})
+				state.bubbles = append(state.bubbles, b)
 				stateMu.Unlock()
 			}
 			var msg string


### PR DESCRIPTION
## Summary
- introduce a bubble struct to store descriptor index, coordinates, far flag, text, and expiration
- populate bubbles during parsing and refresh their positions each frame
- render bubbles using updated coordinates so they move with their sources

## Testing
- `go build ./...`
- `go test ./...` *(fails: `The DISPLAY environment variable is missing`)*

------
https://chatgpt.com/codex/tasks/task_e_68907cb67940832a9af8992c667b5030