### PR TITLE
Include all bubbles in message log

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -676,9 +676,7 @@ func parseDrawState(data []byte) error {
 					}
 				}
 			}
-			if idx != playerIndex {
-				addMessage(msg)
-			}
+			addMessage(msg)
 		}
 		stateData = stateData[p+end+1:]
 	}


### PR DESCRIPTION
## Summary
- log every bubble message regardless of source so the hero's bubbles appear in the message window
- test that a bubble from the player is added to the message log

## Testing
- `go test ./... -run TestHandleDrawStatePlayerBubble -v` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_689081ae09f0832aae8bf52d42f2d7d9