### PR TITLE
Render messages bottom-up with expiration

### DIFF
--- a/game.go
+++ b/game.go
@@ -701,21 +701,21 @@ func drawStatusBars(screen *ebiten.Image, snap drawSnapshot, alpha float64) {
 
 // drawMessages prints chat messages on the HUD.
 func drawMessages(screen *ebiten.Image, msgs []string) {
-	startY := gameAreaSizeY*scale - 210
-	y := startY
+	y := gameAreaSizeY * scale
 	maxWidth := float64(gameAreaSizeX*scale - 8*scale)
-	for _, msg := range msgs {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		msg := msgs[i]
 		lines := wrapText(msg, nameFace, maxWidth)
-		for _, line := range lines {
-			w, _ := text.Measure(msg, nameFace, 0)
-			iw := int(math.Ceil(w)) + 8*scale + 4
-			ih := 12*scale + 4
+		w, _ := text.Measure(msg, nameFace, 0)
+		iw := int(math.Ceil(w)) + 8*scale + 4
+		ih := 12*scale + 4
+		for j := len(lines) - 1; j >= 0; j-- {
+			y -= 14 * scale
 			ebitenutil.DrawRect(screen, 0, float64(y), float64(iw), float64(ih), color.RGBA{0, 0, 0, 128})
 			op := &text.DrawOptions{}
 			op.GeoM.Translate(float64(4*scale), float64(y))
 			op.ColorScale.ScaleWithColor(color.White)
-			text.Draw(screen, line, nameFace, op)
-			y += 14 * scale
+			text.Draw(screen, lines[j], nameFace, op)
 		}
 	}
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExpiredMessagesRemoved(t *testing.T) {
+	messages = nil
+	addMessage("hi")
+	if len(getMessages()) != 1 {
+		t.Fatalf("message not added")
+	}
+	messageMu.Lock()
+	messages[0].expire = time.Now().Add(-time.Second)
+	messageMu.Unlock()
+	if len(getMessages()) != 0 {
+		t.Fatalf("expired message not removed")
+	}
+}


### PR DESCRIPTION
## Summary
- Draw chat messages from the bottom of the HUD upward so newest text sticks to the bottom
- Add per-message expiration and prune entries after 15 seconds
- Test that expired messages are removed from the message list

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68908622be98832aa48980141f16ac2a