### PR TITLE
Clamp truncated sound data

### DIFF
--- a/clsnd/clsnd_test.go
+++ b/clsnd/clsnd_test.go
@@ -87,6 +87,43 @@ func createExtTestFile(t *testing.T, dir string) string {
 	return path
 }
 
+// helper to create CL_Sounds file with truncated sample data
+func createTruncTestFile(t *testing.T, dir string) string {
+	snd := []byte{
+		0x00, 0x01, // format
+		0x00, 0x00, // numModifiers
+		0x00, 0x01, // numCommands
+		0x80, 0x51, // cmd = bufferCmd | dataOffsetFlag
+		0x00, 0x00, // param1
+		0x00, 0x00, 0x00, 0x0e, // param2 -> offset to SoundHeader (14)
+		// SoundHeader at offset 14
+		0x00, 0x00, 0x00, 0x00, // samplePtr
+		0x00, 0x00, 0x00, 0x02, // length claims 2 bytes
+		0x56, 0x22, 0x00, 0x00, // sampleRate 22050<<16
+		0x00, 0x00, 0x00, 0x00, // loopStart
+		0x00, 0x00, 0x00, 0x02, // loopEnd
+		0x00, // encode stdSH
+		0x3c, // baseFrequency
+		0x80, // only 1 byte of sample data
+	}
+	header := make([]byte, 12)
+	binary.BigEndian.PutUint16(header[0:2], 0xffff)
+	binary.BigEndian.PutUint32(header[2:6], 1) // one entry
+	table := make([]byte, 16)
+	offset := uint32(len(header) + len(table))
+	binary.BigEndian.PutUint32(table[0:4], offset)
+	binary.BigEndian.PutUint32(table[4:8], uint32(len(snd)))
+	binary.BigEndian.PutUint32(table[8:12], typeSound)
+	binary.BigEndian.PutUint32(table[12:16], 1)
+	data := append(header, table...)
+	data = append(data, snd...)
+	path := filepath.Join(dir, "CL_Sounds")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	return path
+}
+
 func TestLoadAndGet(t *testing.T) {
 	dir := t.TempDir()
 	path := createTestFile(t, dir)
@@ -128,6 +165,22 @@ func TestLoadAndGetExt(t *testing.T) {
 	}
 	want := []byte{0x01, 0x02, 0x03, 0x04}
 	if !bytes.Equal(s.Data, want) {
+		t.Fatalf("data %#v", s.Data)
+	}
+}
+
+func TestTruncatedSound(t *testing.T) {
+	dir := t.TempDir()
+	path := createTruncTestFile(t, dir)
+	cs, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	s := cs.Get(1)
+	if s == nil {
+		t.Fatalf("Get returned nil")
+	}
+	if len(s.Data) != 1 || s.Data[0] != 0x80 {
 		t.Fatalf("data %#v", s.Data)
 	}
 }


### PR DESCRIPTION
## Summary
- Clamp decoded sound length to available bytes and log truncation warnings including the sound ID
- Test that truncated sound resources return remaining data without error

## Testing
- `go test ./clsnd`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890873073bc832aa4a5e7a573977673