### PR TITLE
Add speech bubble rendering

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"image/color"
+	"math"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+// Bubble dimensions and text widths derived from the original Macintosh client.
+// Sizes are in pixels at scale 1.
+const (
+	bubbleTextSmallWidth  = 56
+	bubbleTextMediumWidth = 90
+	bubbleTextLargeWidth  = 136
+
+	bubbleSmallWidth   = 84
+	bubbleSmallHeight  = 33
+	bubbleMediumWidth  = 116
+	bubbleMediumHeight = 43
+	bubbleLargeWidth   = 164
+	bubbleLargeHeight  = 53
+)
+
+// gBubbleMap replicates the Clan Lord mapping from bubble type to column index
+// in the bubble sprite sheet.
+var gBubbleMap = []int{
+	0, // kBubbleNormal
+	1, // kBubbleWhisper
+	2, // kBubbleYell
+	3, // kBubbleThought
+	4, // kBubbleRealAction
+	5, // kBubbleMonster
+	4, // kBubblePlayerAction - same graphic as real action
+	3, // kBubblePonder - same graphic as thought
+	4, // kBubbleNarrate - same graphic as real action
+}
+
+// drawBubble renders a text bubble anchored so that (x, y) corresponds to the
+// bottom-center of the balloon tail. The typ parameter is the bubble type value
+// from the server draw state.
+func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int) {
+	if txt == "" {
+		return
+	}
+
+	// Determine bubble size by wrapping the text with a small width.
+	lines := wrapText(txt, nameFace, bubbleTextSmallWidth*float64(scale))
+	id := uint16(1)
+	bw, bh := bubbleSmallWidth, bubbleSmallHeight
+	tw := bubbleTextSmallWidth
+	if len(lines) > 2 {
+		lines = wrapText(txt, nameFace, bubbleTextMediumWidth*float64(scale))
+		id = 2
+		bw, bh = bubbleMediumWidth, bubbleMediumHeight
+		tw = bubbleTextMediumWidth
+		if len(lines) > 3 {
+			lines = wrapText(txt, nameFace, bubbleTextLargeWidth*float64(scale))
+			id = 3
+			bw, bh = bubbleLargeWidth, bubbleLargeHeight
+			tw = bubbleTextLargeWidth
+		}
+	}
+
+	col := 0
+	if t := typ & kBubbleTypeMask; t >= 0 && t < len(gBubbleMap) {
+		col = gBubbleMap[t]
+	}
+
+	img := loadBubbleImage(id, col)
+	if img != nil {
+		op := &ebiten.DrawImageOptions{}
+		op.Filter = drawFilter
+		op.GeoM.Scale(float64(scale), float64(scale))
+		op.GeoM.Translate(float64(x-bw*scale/2), float64(y-bh*scale))
+		screen.DrawImage(img, op)
+	}
+
+	metrics := nameFace.Metrics()
+	lineHeight := int(math.Ceil(metrics.HAscent + metrics.HDescent + metrics.HLineGap))
+	baseline := y - bh*scale + 4*scale + int(math.Ceil(metrics.HAscent))
+	left := x - tw*scale/2
+
+	for i, line := range lines {
+		op := &text.DrawOptions{}
+		op.GeoM.Translate(float64(left), float64(baseline+i*lineHeight))
+		op.ColorScale.ScaleWithColor(color.Black)
+		text.Draw(screen, line, nameFace, op)
+	}
+}

--- a/draw.go
+++ b/draw.go
@@ -600,7 +600,7 @@ func parseDrawState(data []byte) error {
 			}
 			stateMu.Unlock()
 			if showBubbles && txt != "" {
-				b := bubble{Index: idx, Text: txt, Expire: time.Now().Add(4 * time.Second)}
+				b := bubble{Index: idx, Text: txt, Type: typ, Expire: time.Now().Add(4 * time.Second)}
 				if typ&kBubbleFar != 0 {
 					b.H, b.V = h, v
 					b.Far = true

--- a/game.go
+++ b/game.go
@@ -98,6 +98,7 @@ type bubble struct {
 	H, V   int16
 	Far    bool
 	Text   string
+	Type   int
 	Expire time.Time
 }
 
@@ -445,16 +446,7 @@ func drawScene(screen *ebiten.Image, snap drawSnapshot, alpha float64, fade floa
 			}
 			x := (int(math.Round(hpos)) + fieldCenterX) * scale
 			y := (int(math.Round(vpos)) + fieldCenterY) * scale
-			w, h := text.Measure(b.Text, nameFace, 0)
-			iw := int(math.Ceil(w))
-			ih := int(math.Ceil(h))
-			left := x - iw/2 - 2
-			top := y - ih - 4*scale
-			vector.StrokeRect(screen, float32(left), float32(top), float32(iw+4), float32(ih+4), 1, color.RGBA{255, 0, 0, 255}, false)
-			op := &text.DrawOptions{}
-			op.GeoM.Translate(float64(left+2), float64(top+2))
-			op.ColorScale.ScaleWithColor(color.Black)
-			text.Draw(screen, b.Text, nameFace, op)
+			drawBubble(screen, b.Text, x, y, b.Type)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- load and cache bubble sprites for picture IDs 1-3
- define bubble size constants and render speech bubbles with wrapped text
- draw parsed bubbles in-game instead of debug rectangles

## Testing
- `xvfb-run go test ./...` *(fails: parseDrawState returned error, audio context already created)*


------
https://chatgpt.com/codex/tasks/task_e_689084b728c8832a8f2d22809ce2c0fe