### PR TITLE
Read numFrames from extended sound headers

### DIFF
--- a/clsnd/clsnd.go
+++ b/clsnd/clsnd.go
@@ -163,7 +163,7 @@ func decodeHeader(data []byte, hdr int, id uint32) (*Sound, error) {
 		if hdr+44 > len(data) {
 			return nil, fmt.Errorf("short ext header")
 		}
-		frames := int(binary.BigEndian.Uint32(data[hdr+4 : hdr+8]))
+		frames := int(binary.BigEndian.Uint32(data[hdr+32 : hdr+36]))
 		rate := binary.BigEndian.Uint32(data[hdr+8:hdr+12]) >> 16
 		chans := binary.BigEndian.Uint32(data[hdr+24 : hdr+28])
 		bits := binary.BigEndian.Uint16(data[hdr+28 : hdr+30])
@@ -173,7 +173,7 @@ func decodeHeader(data []byte, hdr int, id uint32) (*Sound, error) {
 		if start > len(data) {
 			return nil, fmt.Errorf("data out of range")
 		}
-		if end := start + length; end > len(data) {
+		if length > len(data)-start {
 			fmt.Printf("truncated sound data")
 			if id != 0 {
 				fmt.Printf(" for id %d", id)

--- a/clsnd/clsnd_test.go
+++ b/clsnd/clsnd_test.go
@@ -59,7 +59,7 @@ func createExtTestFile(t *testing.T, dir string) string {
 	binary.BigEndian.PutUint32(snd[10:14], 14)    // param2 -> offset to SoundHeader
 	hdr := 14
 	binary.BigEndian.PutUint32(snd[hdr+0:hdr+4], 0)           // samplePtr
-	binary.BigEndian.PutUint32(snd[hdr+4:hdr+8], 1)           // frames
+	binary.BigEndian.PutUint32(snd[hdr+4:hdr+8], 0)           // reserved
 	binary.BigEndian.PutUint32(snd[hdr+8:hdr+12], 0x56220000) // sampleRate 22050<<16
 	binary.BigEndian.PutUint32(snd[hdr+12:hdr+16], 0)         // loopStart
 	binary.BigEndian.PutUint32(snd[hdr+16:hdr+20], 1)         // loopEnd
@@ -67,6 +67,7 @@ func createExtTestFile(t *testing.T, dir string) string {
 	snd[hdr+21] = 0x3c                                        // baseFrequency
 	binary.BigEndian.PutUint32(snd[hdr+24:hdr+28], 2)         // channels
 	binary.BigEndian.PutUint16(snd[hdr+28:hdr+30], 16)        // bits
+	binary.BigEndian.PutUint32(snd[hdr+32:hdr+36], 1)         // numFrames
 	copy(snd[hdr+44:], sample)                                // sample data
 
 	header := make([]byte, 12)
@@ -106,6 +107,47 @@ func createTruncTestFile(t *testing.T, dir string) string {
 		0x3c, // baseFrequency
 		0x80, // only 1 byte of sample data
 	}
+	header := make([]byte, 12)
+	binary.BigEndian.PutUint16(header[0:2], 0xffff)
+	binary.BigEndian.PutUint32(header[2:6], 1) // one entry
+	table := make([]byte, 16)
+	offset := uint32(len(header) + len(table))
+	binary.BigEndian.PutUint32(table[0:4], offset)
+	binary.BigEndian.PutUint32(table[4:8], uint32(len(snd)))
+	binary.BigEndian.PutUint32(table[8:12], typeSound)
+	binary.BigEndian.PutUint32(table[12:16], 1)
+	data := append(header, table...)
+	data = append(data, snd...)
+	path := filepath.Join(dir, "CL_Sounds")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	return path
+}
+
+// helper to create CL_Sounds file with truncated ExtSoundHeader sample data
+func createTruncExtTestFile(t *testing.T, dir string) string {
+	sample := []byte{0x01, 0x02, 0x03, 0x04}
+	snd := make([]byte, 14+44+len(sample))
+	binary.BigEndian.PutUint16(snd[0:2], 0x0001)  // format
+	binary.BigEndian.PutUint16(snd[2:4], 0x0000)  // numModifiers
+	binary.BigEndian.PutUint16(snd[4:6], 0x0001)  // numCommands
+	binary.BigEndian.PutUint16(snd[6:8], 0x8051)  // cmd = bufferCmd | dataOffsetFlag
+	binary.BigEndian.PutUint16(snd[8:10], 0x0000) // param1
+	binary.BigEndian.PutUint32(snd[10:14], 14)    // param2 -> offset to SoundHeader
+	hdr := 14
+	binary.BigEndian.PutUint32(snd[hdr+0:hdr+4], 0)           // samplePtr
+	binary.BigEndian.PutUint32(snd[hdr+4:hdr+8], 0)           // reserved
+	binary.BigEndian.PutUint32(snd[hdr+8:hdr+12], 0x56220000) // sampleRate 22050<<16
+	binary.BigEndian.PutUint32(snd[hdr+12:hdr+16], 0)         // loopStart
+	binary.BigEndian.PutUint32(snd[hdr+16:hdr+20], 1)         // loopEnd
+	snd[hdr+20] = 0xff                                        // encode ExtSoundHeader
+	snd[hdr+21] = 0x3c                                        // baseFrequency
+	binary.BigEndian.PutUint32(snd[hdr+24:hdr+28], 2)         // channels
+	binary.BigEndian.PutUint16(snd[hdr+28:hdr+30], 16)        // bits
+	binary.BigEndian.PutUint32(snd[hdr+32:hdr+36], 2)         // numFrames claims 2 frames
+	copy(snd[hdr+44:], sample)                                // only 1 frame of data
+
 	header := make([]byte, 12)
 	binary.BigEndian.PutUint16(header[0:2], 0xffff)
 	binary.BigEndian.PutUint32(header[2:6], 1) // one entry
@@ -181,6 +223,23 @@ func TestTruncatedSound(t *testing.T) {
 		t.Fatalf("Get returned nil")
 	}
 	if len(s.Data) != 1 || s.Data[0] != 0x80 {
+		t.Fatalf("data %#v", s.Data)
+	}
+}
+
+func TestTruncatedExtSound(t *testing.T) {
+	dir := t.TempDir()
+	path := createTruncExtTestFile(t, dir)
+	cs, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	s := cs.Get(1)
+	if s == nil {
+		t.Fatalf("Get returned nil")
+	}
+	want := []byte{0x01, 0x02, 0x03, 0x04}
+	if !bytes.Equal(s.Data, want) {
 		t.Fatalf("data %#v", s.Data)
 	}
 }


### PR DESCRIPTION
## Summary
- parse `ExtSoundHeader` using the `numFrames` field and clamp decoded length to available data
- populate `numFrames` in test fixtures and test truncated extended headers

## Testing
- `go test ./...` *(fails: DISPLAY environment variable is missing)*
- `go test ./clsnd -run . -v`


------
https://chatgpt.com/codex/tasks/task_e_6890899a6948832a93ec4df4e53de56f