### PR TITLE
Add night mode flag and setting

### DIFF
--- a/game.go
+++ b/game.go
@@ -53,6 +53,7 @@ var drawFilter = ebiten.FilterNearest
 var frameCounter int
 var showPlanes bool
 var showBubbles bool
+var nightMode bool
 
 var (
 	frameCh       = make(chan struct{}, 1)
@@ -324,7 +325,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	alpha, fade := computeInterpolation(snap.prevTime, snap.curTime)
 	//logDebug("Draw alpha=%.2f shift=(%d,%d) pics=%d", alpha, snap.picShiftX, snap.picShiftY, len(snap.pictures))
 	drawScene(screen, snap, alpha, fade)
-	//drawNightOverlay(screen)
+	if nightMode {
+		drawNightOverlay(screen)
+	}
 	drawMessages(screen, getMessages())
 
 	eui.Draw(screen)

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func main() {
 	flag.BoolVar(&smoothDebug, "smoothDebug", false, "highlight moving pictures during smoothing")
 	flag.BoolVar(&blendPicts, "blendPicts", false, "frame blending for picture animations")
 	flag.BoolVar(&denoise, "denoise", false, "apply image denoising filter")
+	flag.BoolVar(&nightMode, "nightMode", false, "enable night-time visual effects")
 	flag.BoolVar(&showPlanes, "planes", false, "draw plane and type for each sprite")
 	flag.BoolVar(&showBubbles, "bubble", false, "draw bubble debug boxes")
 	clientVer := flag.Int("client-version", 1440, "client version number (for testing)")

--- a/ui.go
+++ b/ui.go
@@ -96,7 +96,6 @@ func initUI() {
 	}
 	mainFlow.AddItem(anim)
 
-
 	fastAnim, fastAnimEvents := eui.NewCheckbox(&eui.ItemData{Text: "Fast Animation", Size: eui.Point{X: 150, Y: 24}, Checked: fastAnimation})
 	fastAnimEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
@@ -112,6 +111,14 @@ func initUI() {
 		}
 	}
 	mainFlow.AddItem(pictBlend)
+
+	nightCB, nightEvents := eui.NewCheckbox(&eui.ItemData{Text: "Night Mode", Size: eui.Point{X: 150, Y: 24}, Checked: nightMode})
+	nightEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			nightMode = ev.Checked
+		}
+	}
+	mainFlow.AddItem(nightCB)
 
 	toggle, toggleEvents := eui.NewCheckbox(&eui.ItemData{Text: "Click-to-Toggle Walk", Size: eui.Point{X: 150, Y: 24}, Checked: clickToToggle})
 	toggleEvents.Handle = func(ev eui.UIEvent) {


### PR DESCRIPTION
## Summary
- add `-nightMode` command-line flag to enable night effects
- allow toggling night overlay via settings UI
- render night overlay when night mode is active

## Testing
- `go test ./...` *(fails: undefined: op; GLFW display missing)*
- `go build ./...` *(fails: undefined: op)*

------
https://chatgpt.com/codex/tasks/task_e_6890e33de90c832a8793802073d99a1a