### PR TITLE
Maintain base night level and recalc on parse

### DIFF
--- a/night.go
+++ b/night.go
@@ -75,6 +75,7 @@ func parseNightCommand(s string) bool {
 		cloudy := m[3] != "0"
 		gNight.mu.Lock()
 		gNight.BaseLevel = lvl
+		gNight.Level = lvl
 		gNight.Azimuth = sa
 		gNight.Cloudy = cloudy
 		gNight.calcCurLevel()
@@ -89,20 +90,18 @@ func parseNightCommand(s string) bool {
 	var nightLevel, shadowLevel, sunAngle, declination int
 	if n, err := fmt.Sscanf(rest, "%d %d %d %d", &nightLevel, &shadowLevel, &sunAngle, &declination); err == nil && n >= 3 {
 		gNight.mu.Lock()
+		gNight.BaseLevel = nightLevel
 		gNight.Level = nightLevel
-		gNight.Shadows = shadowLevel
 		gNight.Azimuth = sunAngle
+		gNight.calcCurLevel()
 		gNight.mu.Unlock()
 		return true
 	}
 	if n, err := fmt.Sscanf(rest, "%d", &nightLevel); err == nil && n == 1 {
-		shadowLevel = 50 - nightLevel
-		if shadowLevel < 0 {
-			shadowLevel = 0
-		}
 		gNight.mu.Lock()
+		gNight.BaseLevel = nightLevel
 		gNight.Level = nightLevel
-		gNight.Shadows = shadowLevel
+		gNight.calcCurLevel()
 		gNight.mu.Unlock()
 		return true
 	}

--- a/night_test.go
+++ b/night_test.go
@@ -21,8 +21,8 @@ func TestParseNightCommandV100(t *testing.T) {
 	}
 	gNight.mu.Lock()
 	defer gNight.mu.Unlock()
-	if gNight.Level != 30 || gNight.Shadows != 15 || gNight.Azimuth != 250 {
-		t.Fatalf("unexpected night info: level=%d shadows=%d az=%d", gNight.Level, gNight.Shadows, gNight.Azimuth)
+	if gNight.BaseLevel != 30 || gNight.Level != 30 || gNight.Shadows != 20 || gNight.Azimuth != 250 {
+		t.Fatalf("unexpected night info: base=%d level=%d shadows=%d az=%d", gNight.BaseLevel, gNight.Level, gNight.Shadows, gNight.Azimuth)
 	}
 }
 
@@ -33,8 +33,8 @@ func TestParseNightCommandLegacy(t *testing.T) {
 	}
 	gNight.mu.Lock()
 	defer gNight.mu.Unlock()
-	if gNight.Level != 20 || gNight.Shadows != 30 {
-		t.Fatalf("unexpected night info: level=%d shadows=%d", gNight.Level, gNight.Shadows)
+	if gNight.BaseLevel != 20 || gNight.Level != 20 || gNight.Shadows != 30 {
+		t.Fatalf("unexpected night info: base=%d level=%d shadows=%d", gNight.BaseLevel, gNight.Level, gNight.Shadows)
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure parseNightCommand sets BaseLevel and Level in both v100 and legacy formats
- recompute night levels after parsing so flag-based modifiers apply
- verify BaseLevel in night command tests

## Testing
- `go build ./...`
- `go test ./...` *(fails: GLFW requires X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_689167e440fc832abddc60d3a28bd20f