### PR TITLE
Add basic inventory UI

### DIFF
--- a/draw_test.go
+++ b/draw_test.go
@@ -305,6 +305,7 @@ func TestParseDrawStateBubbleErrors(t *testing.T) {
 }
 
 func TestParseInventory(t *testing.T) {
+	resetInventory()
 	data := []byte{byte(kInvCmdAdd), 0x00, 0x01}
 	data = append(data, []byte("foo")...)
 	data = append(data, 0) // name terminator
@@ -312,6 +313,10 @@ func TestParseInventory(t *testing.T) {
 	rest, ok := parseInventory(data)
 	if !ok || len(rest) != 0 {
 		t.Fatalf("ok=%v rest=%v", ok, rest)
+	}
+	inv := getInventory()
+	if len(inv) != 1 || inv[0].ID != 1 || inv[0].Name != "foo" {
+		t.Fatalf("inventory=%v", inv)
 	}
 }
 

--- a/inventory.go
+++ b/inventory.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+type inventoryItem struct {
+	ID       uint16
+	Name     string
+	Equipped bool
+}
+
+var (
+	inventoryMu    sync.RWMutex
+	inventoryItems []inventoryItem
+)
+
+func resetInventory() {
+	inventoryMu.Lock()
+	inventoryItems = inventoryItems[:0]
+	inventoryMu.Unlock()
+}
+
+func addInventoryItem(id uint16, name string, equip bool) {
+	inventoryMu.Lock()
+	inventoryItems = append(inventoryItems, inventoryItem{ID: id, Name: name, Equipped: equip})
+	inventoryMu.Unlock()
+}
+
+func removeInventoryItem(id uint16) {
+	inventoryMu.Lock()
+	for i, it := range inventoryItems {
+		if it.ID == id {
+			inventoryItems = append(inventoryItems[:i], inventoryItems[i+1:]...)
+			break
+		}
+	}
+	inventoryMu.Unlock()
+}
+
+func equipInventoryItem(id uint16, equip bool) {
+	inventoryMu.Lock()
+	for i := range inventoryItems {
+		if inventoryItems[i].ID == id {
+			inventoryItems[i].Equipped = equip
+			break
+		}
+	}
+	inventoryMu.Unlock()
+}
+
+func renameInventoryItem(id uint16, name string) {
+	inventoryMu.Lock()
+	for i := range inventoryItems {
+		if inventoryItems[i].ID == id {
+			inventoryItems[i].Name = name
+			break
+		}
+	}
+	inventoryMu.Unlock()
+}
+
+func getInventory() []inventoryItem {
+	inventoryMu.RLock()
+	defer inventoryMu.RUnlock()
+	out := make([]inventoryItem, len(inventoryItems))
+	copy(out, inventoryItems)
+	return out
+}
+
+func setFullInventory(ids []uint16, equipped []bool) {
+	items := make([]inventoryItem, 0, len(ids))
+	for i, id := range ids {
+		name := fmt.Sprintf("Item %d", id)
+		equip := false
+		if i < len(equipped) && equipped[i] {
+			equip = true
+		}
+		items = append(items, inventoryItem{ID: id, Name: name, Equipped: equip})
+	}
+	inventoryMu.Lock()
+	inventoryItems = items
+	inventoryMu.Unlock()
+}

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -1,0 +1,24 @@
+//go:build !test
+
+package main
+
+import "github.com/Distortions81/EUI/eui"
+
+var inventoryWin *eui.WindowData
+var inventoryList *eui.ItemData
+
+func updateInventoryWindow() {
+	if inventoryList == nil {
+		return
+	}
+	items := getInventory()
+	inventoryList.Contents = inventoryList.Contents[:0]
+	for _, it := range items {
+		text := it.Name
+		if it.Equipped {
+			text = "* " + text
+		}
+		t, _ := eui.NewText(&eui.ItemData{Text: text})
+		inventoryList.AddItem(t)
+	}
+}

--- a/ui.go
+++ b/ui.go
@@ -180,11 +180,34 @@ func initUI() {
 
 	settingsWin.Open = false
 
+	inventoryWin = eui.NewWindow(&eui.WindowData{
+		Title:     "Inventory",
+		Open:      false,
+		Closable:  false,
+		Resizable: false,
+		AutoSize:  true,
+		Movable:   true,
+	})
+	inventoryList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
+	inventoryWin.AddItem(inventoryList)
+	inventoryWin.AddWindow(false)
+
 	overlay := &eui.ItemData{
 		ItemType: eui.ITEM_FLOW,
 		FlowType: eui.FLOW_HORIZONTAL,
 		PinTo:    eui.PIN_BOTTOM_RIGHT,
 	}
+	invBtn, invEvents := eui.NewButton(&eui.ItemData{Text: "I", Size: eui.Point{X: 36, Y: 36}, FontSize: 27})
+	invEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			inventoryWin.Open = !inventoryWin.Open
+			if inventoryWin.Open {
+				updateInventoryWindow()
+			}
+		}
+	}
+	overlay.AddItem(invBtn)
+
 	btn, btnEvents := eui.NewButton(&eui.ItemData{Text: "...", Size: eui.Point{X: 36, Y: 36}, FontSize: 27})
 	btnEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {


### PR DESCRIPTION
## Summary
- track inventory items and equipped state
- hook inventory parsing to maintain list
- add bottom-right inventory button and window to show items

## Testing
- `xvfb-run go test -run TestParseInventory -v`
- `xvfb-run go test ./...` *(fails: TestParseDrawStateTruncatedBubble, TestPlaySoundResample, TestFastSoundContext)*


------
https://chatgpt.com/codex/tasks/task_e_68916908494c832abd7b9e8d000da88d