### PR TITLE
Add night level flag for testing night effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The Go client accepts the following flags:
 - `-onion` – cross-fade sprite animations
 - `-noFastAnimation` – draw a mobile's previous animation frame when available
 - `-linear` – use linear filtering instead of nearest-neighbor rendering
+- `-night` – force night level (0-100)
 
 ## Data and Logging
 

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	fastSound   bool
 	fastBars    bool
 	maxSounds   int
+	nightLevel  int
 
 	loginRequest = make(chan struct{})
 )
@@ -72,8 +73,22 @@ func main() {
 	flag.BoolVar(&fastSound, "fast-sound", false, "use 22050Hz audio with linear resampling")
 	flag.BoolVar(&fastBars, "fastBars", true, "do not interpolate bar decreases")
 	flag.IntVar(&maxSounds, "maxSounds", 32, "maximum number of simultaneous sounds")
+	flag.IntVar(&nightLevel, "night", 0, "force night level (0-100)")
 
 	flag.Parse()
+	if nightLevel != 0 {
+		if nightLevel < 0 {
+			nightLevel = 0
+		} else if nightLevel > 100 {
+			nightLevel = 100
+		}
+		nightMode = true
+		gNight.mu.Lock()
+		gNight.BaseLevel = nightLevel
+		gNight.Level = nightLevel
+		gNight.calcCurLevel()
+		gNight.mu.Unlock()
+	}
 	fastAnimation = !noFastAnimation
 	initSoundContext()
 


### PR DESCRIPTION
## Summary
- add `-night` command-line flag to force a night level
- document the new night flag in README

## Testing
- `go build ./...`
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: The GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_689178c616cc832aba1bb18f7d0b27e5