### PR TITLE
Interpolate picture motion

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -546,6 +546,11 @@ func parseDrawState(data []byte) error {
 
 	// retain previously drawn pictures when the packet specifies pictAgain
 	prevPics := state.pictures
+	if interp {
+		state.prevPictures = append([]framePicture(nil), prevPics...)
+	} else {
+		state.prevPictures = nil
+	}
 	again := pictAgain
 	if again > len(prevPics) {
 		again = len(prevPics)


### PR DESCRIPTION
## Summary
- track previous picture frames and expose them in draw snapshots
- smooth non-background picture movement when within max interpolation distance

## Testing
- `go test ./...` *(fails: GLFW library initialization error)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68918ca6af68832abac3f9b580b2f29d