### PR TITLE
Handle reused pictures in draw state

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -581,7 +581,9 @@ func parseDrawState(data []byte) error {
 	}
 	for i := range newPics {
 		moving := true
-		if i >= again {
+		if i < again {
+			moving = false
+		} else {
 			for _, pp := range prevPics {
 				if pp.PictID == newPics[i].PictID &&
 					int(pp.H)+state.picShiftX == int(newPics[i].H) &&

--- a/draw_test.go
+++ b/draw_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+func resetStateForTest() {
+	stateMu.Lock()
+	state = drawState{
+		descriptors: make(map[uint8]frameDescriptor),
+		mobiles:     make(map[uint8]frameMobile),
+		prevMobiles: make(map[uint8]frameMobile),
+		prevDescs:   make(map[uint8]frameDescriptor),
+	}
+	stateMu.Unlock()
+	interp = false
+	onion = false
+	fastAnimation = true
+}
+
+func TestPictAgainStationaryPicture(t *testing.T) {
+	resetStateForTest()
+	pixelCountMu.Lock()
+	pixelCountCache[1] = 1
+	pixelCountMu.Unlock()
+
+	frame1 := []byte{
+		0,          // ackCmd
+		0, 0, 0, 0, // ackFrame
+		0, 0, 0, 0, // resendFrame
+		0,                   // descriptor count
+		0, 0, 0, 0, 0, 0, 0, // stats
+		1,             // picture count
+		0, 4, 0, 0, 0, // picture bits for id=1,h=0,v=0
+		0,    // mobile count
+		0, 4, // state length
+		0, 0, 0, 0, // state data
+	}
+	if err := parseDrawState(frame1); err != nil {
+		t.Fatalf("frame1 parse failed: %v", err)
+	}
+
+	frame2 := []byte{
+		0,          // ackCmd
+		0, 0, 0, 0, // ackFrame
+		0, 0, 0, 0, // resendFrame
+		0,                   // descriptor count
+		0, 0, 0, 0, 0, 0, 0, // stats
+		255, 1, 0, // pictCount=255, pictAgain=1, pictCount=0
+		0,    // mobile count
+		0, 4, // state length
+		0, 0, 0, 0, // state data
+	}
+	if err := parseDrawState(frame2); err != nil {
+		t.Fatalf("frame2 parse failed: %v", err)
+	}
+
+	if len(state.pictures) != 1 {
+		t.Fatalf("expected 1 picture, got %d", len(state.pictures))
+	}
+	if state.pictures[0].Moving {
+		t.Fatalf("expected Moving=false for reused picture")
+	}
+}

--- a/inventory_ui_test.go
+++ b/inventory_ui_test.go
@@ -1,0 +1,5 @@
+//go:build test
+
+package main
+
+func updateInventoryWindow() {}


### PR DESCRIPTION
## Summary
- treat `pictAgain` entries as stationary in `parseDrawState`
- add regression test for reused picture remaining stationary

## Testing
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891a85245e4832ab69123f5d251036a