### PR TITLE
Avoid interpolating mobiles after large shifts

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -35,6 +35,7 @@ type frameMobile struct {
 
 const poseDead = 32
 const maxInterpPixels = 128
+const maxMobileInterpPixels = 64
 
 // sanity limits for parsed counts to avoid excessive allocations or
 // obviously corrupt packets.


### PR DESCRIPTION
## Summary
- Limit mobile interpolation to 64 pixels relative to picture shift
- Adjust interpolation checks for mobiles, bubbles, and picture-aligned sprites

## Testing
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891ae3afc54832a92473518aea09e2c