### PR TITLE
Interpolate small picture movements

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -20,10 +20,11 @@ type frameDescriptor struct {
 }
 
 type framePicture struct {
-	PictID     uint16
-	H, V       int16
-	Moving     bool
-	Background bool
+	PictID       uint16
+	H, V         int16
+	PrevH, PrevV int16
+	Moving       bool
+	Background   bool
 }
 
 type frameMobile struct {
@@ -570,6 +571,8 @@ func parseDrawState(data []byte) error {
 		state.descriptors[d.Index] = d
 	}
 	for i := range newPics {
+		newPics[i].PrevH = int16(int(newPics[i].H) - state.picShiftX)
+		newPics[i].PrevV = int16(int(newPics[i].V) - state.picShiftY)
 		moving := true
 		if i < again {
 			moving = false
@@ -581,6 +584,27 @@ func parseDrawState(data []byte) error {
 					moving = false
 					break
 				}
+			}
+		}
+		if moving {
+			bestDist := maxInterpPixels*maxInterpPixels + 1
+			var best *framePicture
+			for j := range prevPics {
+				pp := &prevPics[j]
+				if pp.PictID != newPics[i].PictID {
+					continue
+				}
+				dh := int(newPics[i].H) - int(pp.H) - state.picShiftX
+				dv := int(newPics[i].V) - int(pp.V) - state.picShiftY
+				dist := dh*dh + dv*dv
+				if dist < bestDist {
+					bestDist = dist
+					best = pp
+				}
+			}
+			if best != nil && bestDist <= maxInterpPixels*maxInterpPixels {
+				newPics[i].PrevH = best.H
+				newPics[i].PrevV = best.V
 			}
 		}
 		newPics[i].Moving = moving

--- a/game.go
+++ b/game.go
@@ -387,7 +387,7 @@ func drawScene(screen *ebiten.Image, snap drawSnapshot, alpha float64, fade floa
 	}
 
 	for _, p := range negPics {
-		drawPicture(screen, p, snap.picShiftX, snap.picShiftY, alpha, fade, snap.mobiles, snap.prevMobiles)
+		drawPicture(screen, p, alpha, fade, snap.mobiles, snap.prevMobiles)
 	}
 
 	sort.Slice(dead, func(i, j int) bool { return dead[i].V < dead[j].V })
@@ -415,13 +415,13 @@ func drawScene(screen *ebiten.Image, snap drawSnapshot, alpha float64, fade floa
 			}
 			i++
 		} else {
-			drawPicture(screen, zeroPics[j], snap.picShiftX, snap.picShiftY, alpha, fade, snap.mobiles, snap.prevMobiles)
+			drawPicture(screen, zeroPics[j], alpha, fade, snap.mobiles, snap.prevMobiles)
 			j++
 		}
 	}
 
 	for _, p := range posPics {
-		drawPicture(screen, p, snap.picShiftX, snap.picShiftY, alpha, fade, snap.mobiles, snap.prevMobiles)
+		drawPicture(screen, p, alpha, fade, snap.mobiles, snap.prevMobiles)
 	}
 
 	if showBubbles {
@@ -576,9 +576,9 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 }
 
 // drawPicture renders a single picture sprite.
-func drawPicture(screen *ebiten.Image, p framePicture, shiftX, shiftY int, alpha float64, fade float32, mobiles []frameMobile, prevMobiles map[uint8]frameMobile) {
-	offX := -float64(shiftX) * (1 - alpha)
-	offY := -float64(shiftY) * (1 - alpha)
+func drawPicture(screen *ebiten.Image, p framePicture, alpha float64, fade float32, mobiles []frameMobile, prevMobiles map[uint8]frameMobile) {
+	offX := float64(int(p.PrevH)-int(p.H)) * (1 - alpha)
+	offY := float64(int(p.PrevV)-int(p.V)) * (1 - alpha)
 
 	frame := 0
 	plane := 0


### PR DESCRIPTION
## Summary
- Track previous coordinates for pictures and infer per-picture shifts
- Interpolate moving pictures when displacement is within `maxInterpPixels`
- Draw pictures using stored previous positions for smoother motion

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ae1497a8832a907dd6100847a1c7