### PR TITLE
Parse inventory data for item names

### DIFF
--- a/inventory.go
+++ b/inventory.go
@@ -72,7 +72,13 @@ func getInventory() []inventoryItem {
 func setFullInventory(ids []uint16, equipped []bool) {
 	items := make([]inventoryItem, 0, len(ids))
 	for i, id := range ids {
-		name := fmt.Sprintf("Item %d", id)
+		name := ""
+		if clImages != nil {
+			name = clImages.ItemName(uint32(id))
+		}
+		if name == "" {
+			name = fmt.Sprintf("Item %d", id)
+		}
 		equip := false
 		if i < len(equipped) && equipped[i] {
 			equip = true


### PR DESCRIPTION
## Summary
- read `ClientItem` records from the `CL_Images` archive and expose names via `ItemName`
- populate inventory entries with names from game data instead of placeholders

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891c99f2ff0832abe54befbb4c80b02