### PR TITLE
Add players window with bottom-right button

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -56,6 +56,7 @@ func parseBackendInfo(data []byte) {
 	p.Class = class
 	p.Clan = clan
 	playersMu.Unlock()
+	updatePlayersWindow()
 }
 
 // parseBackendShare parses "be-sh" messages describing sharing relationships.
@@ -92,6 +93,7 @@ func parseBackendShare(data []byte) {
 		p.Sharing = true
 		playersMu.Unlock()
 	}
+	updatePlayersWindow()
 }
 
 // parseBackendWho parses "be-wh" messages listing players.
@@ -114,6 +116,7 @@ func parseBackendWho(data []byte) {
 		}
 		data = data[idx+1:]
 	}
+	updatePlayersWindow()
 }
 
 // parseNames extracts a slice of names from a sequence of "-pn name -pn" entries.

--- a/player.go
+++ b/player.go
@@ -50,3 +50,13 @@ func updatePlayerAppearance(name string, pictID uint16, colors []byte) {
 	}
 	playersMu.Unlock()
 }
+
+func getPlayers() []Player {
+	playersMu.RLock()
+	defer playersMu.RUnlock()
+	out := make([]Player, 0, len(players))
+	for _, p := range players {
+		out = append(out, *p)
+	}
+	return out
+}

--- a/players_ui.go
+++ b/players_ui.go
@@ -1,0 +1,25 @@
+//go:build !test
+
+package main
+
+import (
+	"sort"
+
+	"github.com/Distortions81/EUI/eui"
+)
+
+var playersWin *eui.WindowData
+var playersList *eui.ItemData
+
+func updatePlayersWindow() {
+	if playersList == nil {
+		return
+	}
+	ps := getPlayers()
+	sort.Slice(ps, func(i, j int) bool { return ps[i].Name < ps[j].Name })
+	playersList.Contents = playersList.Contents[:0]
+	for _, p := range ps {
+		t, _ := eui.NewText(&eui.ItemData{Text: p.Name})
+		playersList.AddItem(t)
+	}
+}

--- a/ui.go
+++ b/ui.go
@@ -195,11 +195,37 @@ func initUI() {
 	inventoryWin.Open = false
 	inventoryWin.AddWindow(false)
 
+	playersWin = eui.NewWindow(&eui.WindowData{
+		Title:     "Players",
+		Open:      false,
+		Closable:  false,
+		Resizable: false,
+		AutoSize:  true,
+		Movable:   true,
+	})
+	playersList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
+	pTitle, _ := eui.NewText(&eui.ItemData{Text: "Players", Size: eui.Point{X: 256, Y: 128}})
+	playersWin.AddItem(pTitle)
+	playersWin.AddItem(playersList)
+	playersWin.Open = false
+	playersWin.AddWindow(false)
+
 	overlay := &eui.ItemData{
 		ItemType: eui.ITEM_FLOW,
 		FlowType: eui.FLOW_HORIZONTAL,
 		PinTo:    eui.PIN_BOTTOM_RIGHT,
 	}
+	playersBtn, playersEvents := eui.NewButton(&eui.ItemData{Text: "P", Size: eui.Point{X: 36, Y: 36}, FontSize: 27})
+	playersEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			playersWin.Open = !playersWin.Open
+			if playersWin.Open {
+				updatePlayersWindow()
+			}
+		}
+	}
+	overlay.AddItem(playersBtn)
+
 	invBtn, invEvents := eui.NewButton(&eui.ItemData{Text: "I", Size: eui.Point{X: 36, Y: 36}, FontSize: 27})
 	invEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {


### PR DESCRIPTION
## Summary
- Add a bottom-right "P" button that toggles a players window
- Populate the window with a sorted list of current players and refresh it when backend messages update player info

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891cb70c1fc832a997e3eafae27da74