### PR TITLE
Block bubble events while seeking in clMov player

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -734,84 +734,86 @@ func parseDrawState(data []byte) error {
 				}
 			}
 			stateMu.Unlock()
-			if showBubbles && txt != "" {
-				b := bubble{Index: idx, Text: txt, Type: typ, Expire: time.Now().Add(4 * time.Second)}
-				if typ&kBubbleFar != 0 {
-					b.H, b.V = h, v
-					b.Far = true
+			if !blockBubbles {
+				if showBubbles && txt != "" {
+					b := bubble{Index: idx, Text: txt, Type: typ, Expire: time.Now().Add(4 * time.Second)}
+					if typ&kBubbleFar != 0 {
+						b.H, b.V = h, v
+						b.Far = true
+					}
+					stateMu.Lock()
+					state.bubbles = append(state.bubbles, b)
+					stateMu.Unlock()
 				}
-				stateMu.Lock()
-				state.bubbles = append(state.bubbles, b)
-				stateMu.Unlock()
-			}
-			var msg string
-			switch {
-			case typ&kBubbleTypeMask == kBubbleNarrate:
-				if name != "" {
-					msg = fmt.Sprintf("(%v): %v", name, txt)
-				} else {
+				var msg string
+				switch {
+				case typ&kBubbleTypeMask == kBubbleNarrate:
+					if name != "" {
+						msg = fmt.Sprintf("(%v): %v", name, txt)
+					} else {
+						msg = txt
+					}
+				case verb == bubbleVerbVerbatim:
 					msg = txt
-				}
-			case verb == bubbleVerbVerbatim:
-				msg = txt
-			case verb == bubbleVerbParentheses:
-				msg = fmt.Sprintf("(%v)", txt)
-			default:
-				if name != "" {
-					if verb == "thinks" {
-						switch target {
-						case thinkToYou:
-							msg = fmt.Sprintf("%v thinks to you, %v", name, txt)
-						case thinkToClan:
-							msg = fmt.Sprintf("%v thinks to your clan, %v", name, txt)
-						case thinkToGroup:
-							msg = fmt.Sprintf("%v thinks to a group, %v", name, txt)
-						default:
-							msg = fmt.Sprintf("%v thinks, %v", name, txt)
-						}
-					} else if typ&kBubbleNotCommon != 0 {
-						langWord := lang
-						lw := strings.ToLower(langWord)
-						if langWord == "" || strings.HasPrefix(lw, "unknown") {
-							langWord = "an unknown language"
-						}
-						if code == kBubbleCodeKnown {
-							msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
-						} else if typ&kBubbleTypeMask == kBubbleYell {
-							switch code {
-							case kBubbleUnknownShort:
-								msg = fmt.Sprintf("%v %v, %v", name, verb, txt)
-							case kBubbleUnknownMedium:
-								msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
-							case kBubbleUnknownLong:
-								msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
+				case verb == bubbleVerbParentheses:
+					msg = fmt.Sprintf("(%v)", txt)
+				default:
+					if name != "" {
+						if verb == "thinks" {
+							switch target {
+							case thinkToYou:
+								msg = fmt.Sprintf("%v thinks to you, %v", name, txt)
+							case thinkToClan:
+								msg = fmt.Sprintf("%v thinks to your clan, %v", name, txt)
+							case thinkToGroup:
+								msg = fmt.Sprintf("%v thinks to a group, %v", name, txt)
 							default:
+								msg = fmt.Sprintf("%v thinks, %v", name, txt)
+							}
+						} else if typ&kBubbleNotCommon != 0 {
+							langWord := lang
+							lw := strings.ToLower(langWord)
+							if langWord == "" || strings.HasPrefix(lw, "unknown") {
+								langWord = "an unknown language"
+							}
+							if code == kBubbleCodeKnown {
 								msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
+							} else if typ&kBubbleTypeMask == kBubbleYell {
+								switch code {
+								case kBubbleUnknownShort:
+									msg = fmt.Sprintf("%v %v, %v", name, verb, txt)
+								case kBubbleUnknownMedium:
+									msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
+								case kBubbleUnknownLong:
+									msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
+								default:
+									msg = fmt.Sprintf("%v %v in %v, %v", name, verb, langWord, txt)
+								}
+							} else {
+								var unknown string
+								switch code {
+								case kBubbleUnknownShort:
+									unknown = "something short"
+								case kBubbleUnknownMedium:
+									unknown = "something medium"
+								case kBubbleUnknownLong:
+									unknown = "something long"
+								default:
+									unknown = "something"
+								}
+								msg = fmt.Sprintf("%v %v %v in %v", name, verb, unknown, langWord)
 							}
 						} else {
-							var unknown string
-							switch code {
-							case kBubbleUnknownShort:
-								unknown = "something short"
-							case kBubbleUnknownMedium:
-								unknown = "something medium"
-							case kBubbleUnknownLong:
-								unknown = "something long"
-							default:
-								unknown = "something"
-							}
-							msg = fmt.Sprintf("%v %v %v in %v", name, verb, unknown, langWord)
+							msg = fmt.Sprintf("%v %v, %v", name, verb, txt)
 						}
 					} else {
-						msg = fmt.Sprintf("%v %v, %v", name, verb, txt)
-					}
-				} else {
-					if txt != "" {
-						msg = "* " + txt
+						if txt != "" {
+							msg = "* " + txt
+						}
 					}
 				}
+				addMessage(msg)
 			}
-			addMessage(msg)
 		}
 		stateData = stateData[p+end+1:]
 	}

--- a/main.go
+++ b/main.go
@@ -26,21 +26,22 @@ var (
 	denoise  bool
 	dataDir  string
 
-	host        string
-	name        string
-	account     string
-	accountPass string
-	pass        string
-	demo        bool
-	clmov       string
-	noSplash    bool
-	baseDir     string
-	soundTest   bool
-	fastSound   bool
-	fastBars    bool
-	maxSounds   int
-	nightLevel  int
-	blockSound  bool
+	host         string
+	name         string
+	account      string
+	accountPass  string
+	pass         string
+	demo         bool
+	clmov        string
+	noSplash     bool
+	baseDir      string
+	soundTest    bool
+	fastSound    bool
+	fastBars     bool
+	maxSounds    int
+	nightLevel   int
+	blockSound   bool
+	blockBubbles bool
 
 	loginRequest = make(chan struct{})
 )

--- a/movie_player.go
+++ b/movie_player.go
@@ -169,9 +169,12 @@ func (p *moviePlayer) skipBack() { p.seek(p.cur - 5*p.fps) }
 func (p *moviePlayer) skipForward() { p.seek(p.cur + 5*p.fps) }
 
 func (p *moviePlayer) seek(idx int) {
-
 	blockSound = true
-	defer func() { blockSound = false }()
+	blockBubbles = true
+	defer func() {
+		blockSound = false
+		blockBubbles = false
+	}()
 
 	if idx < 0 {
 		idx = 0


### PR DESCRIPTION
## Summary
- prevent bubbles from rendering or logging during clMov seeking
- add global flag to gate bubble handling

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891d3922bb8832a8598e5f6d4d6bc6d