### PR TITLE
Handle anomalous inventory commands

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -257,10 +257,24 @@ func parseInventory(data []byte) ([]byte, bool) {
 	}
 
 	for i := 0; i < cmdCount; i++ {
+		if cmd == kInvCmdFull|kInvCmdIndex || cmd == kInvCmdNone|kInvCmdIndex {
+			if cmd == kInvCmdFull|kInvCmdIndex {
+				logError("inventory: got kInvCmdFull + index")
+			} else {
+				logError("inventory: got kInvCmdNone + index")
+			}
+			if len(data) == 0 {
+				return nil, false
+			}
+			cmd = int(data[0])
+			data = data[1:]
+			continue
+		}
+
 		base := cmd &^ kInvCmdIndex
 		switch base {
 		case kInvCmdFull:
-			if cmd&kInvCmdIndex != 0 || len(data) < 1 {
+			if len(data) < 1 {
 				return nil, false
 			}
 			itemCount := int(data[0])
@@ -328,7 +342,9 @@ func parseInventory(data []byte) ([]byte, bool) {
 		cmd = int(data[0])
 		data = data[1:]
 	}
-	if cmd != kInvCmdNone {
+	if cmd == kInvCmdNone|kInvCmdIndex {
+		logError("inventory: got kInvCmdNone + index")
+	} else if cmd != kInvCmdNone {
 		return nil, false
 	}
 	for len(data) > 0 && data[0] == 0 {

--- a/draw_test.go
+++ b/draw_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+// Test that parseInventory skips kInvCmdFull|kInvCmdIndex and continues.
+func TestParseInventoryIgnoresFullWithIndex(t *testing.T) {
+	data := []byte{
+		kInvCmdMultiple,
+		2,
+		kInvCmdFull | kInvCmdIndex,
+		kInvCmdFull,
+		0,
+		kInvCmdNone,
+	}
+	rest, ok := parseInventory(data)
+	if !ok {
+		t.Fatalf("parseInventory failed for kInvCmdFull|kInvCmdIndex")
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected leftover bytes: %d", len(rest))
+	}
+}
+
+// Test that parseInventory skips kInvCmdNone|kInvCmdIndex and continues.
+func TestParseInventoryIgnoresNoneWithIndex(t *testing.T) {
+	data := []byte{
+		kInvCmdMultiple,
+		2,
+		kInvCmdNone | kInvCmdIndex,
+		kInvCmdFull,
+		0,
+		kInvCmdNone,
+	}
+	rest, ok := parseInventory(data)
+	if !ok {
+		t.Fatalf("parseInventory failed for kInvCmdNone|kInvCmdIndex")
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected leftover bytes: %d", len(rest))
+	}
+}


### PR DESCRIPTION
## Summary
- log unexpected inventory commands with index flag instead of aborting parsing
- add coverage for full/none commands mistakenly carrying an index

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_6891dcd412e8832aa28017d18cf84c0f