### PR TITLE
Return actual width from wrapText

### DIFF
--- a/game.go
+++ b/game.go
@@ -763,9 +763,8 @@ func drawMessages(screen *ebiten.Image, msgs []string) {
 	maxWidth := float64(gameAreaSizeX*scale - 8*scale)
 	for i := len(msgs) - 1; i >= 0; i-- {
 		msg := msgs[i]
-		_, lines := wrapText(msg, mainFont, maxWidth)
-		w, _ := text.Measure(msg, mainFont, 0)
-		iw := int(math.Ceil(w)) + 8*scale + 4
+		width, lines := wrapText(msg, mainFont, maxWidth)
+		iw := width + 8*scale + 4
 		ih := 14 * scale
 		for j := len(lines) - 1; j >= 0; j-- {
 			y -= 15 * scale


### PR DESCRIPTION
## Summary
- Track the widest line in wrapText and return its actual width instead of the maximum allowed width.
- Use the width from wrapText to size chat message overlays accurately.

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689267f1e894832a9e7cbd6598c6127b