### PR TITLE
Limit bubbles to one per mobile and add bubble tails

### DIFF
--- a/game.go
+++ b/game.go
@@ -172,7 +172,17 @@ func captureDrawSnapshot() drawSnapshot {
 				kept = append(kept, b)
 			}
 		}
-		state.bubbles = kept
+		last := make(map[uint8]int)
+		for i, b := range kept {
+			last[b.Index] = i
+		}
+		dedup := kept[:0]
+		for i, b := range kept {
+			if last[b.Index] == i {
+				dedup = append(dedup, b)
+			}
+		}
+		state.bubbles = dedup
 		snap.bubbles = append([]bubble(nil), state.bubbles...)
 	}
 	if interp || onion || !fastAnimation {
@@ -453,7 +463,7 @@ func drawScene(screen *ebiten.Image, snap drawSnapshot, alpha float64, fade floa
 			}
 			x := (int(math.Round(hpos)) + fieldCenterX) * scale
 			y := (int(math.Round(vpos)) + fieldCenterY) * scale
-			drawBubble(screen, b.Text, x, y, b.Type)
+			drawBubble(screen, b.Text, x, y, b.Type, b.Far)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- ensure only the newest bubble is retained per mobile when capturing draw snapshots
- render bubbles with rounded corners and a triangular tail pointing to on-screen mobiles

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68926de851f4832a864eb5690eecef63