### PR TITLE
Use playback speed for clMov interpolation

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -652,7 +652,9 @@ func parseDrawState(data []byte) error {
 	if needAnimUpdate {
 		const defaultInterval = time.Second / 5
 		interval := defaultInterval
-		if !state.prevTime.IsZero() && !state.curTime.IsZero() {
+		if clMovPlaying && clMovFPS > 0 {
+			interval = time.Second / time.Duration(clMovFPS)
+		} else if !state.prevTime.IsZero() && !state.curTime.IsZero() {
 			if d := state.curTime.Sub(state.prevTime); d > 0 {
 				interval = d
 			}

--- a/main.go
+++ b/main.go
@@ -22,9 +22,10 @@ import (
 )
 
 var (
-	clMovFPS int
-	denoise  bool
-	dataDir  string
+	clMovFPS     int
+	clMovPlaying bool
+	denoise      bool
+	dataDir      string
 
 	host         string
 	name         string
@@ -190,6 +191,7 @@ func main() {
 	*/
 
 	if clmovPath != "" {
+		clMovPlaying = true
 		drawStateEncrypted = false
 		frames, err := parseMovie(clmovPath, *clientVer)
 		if err != nil {

--- a/movie_player.go
+++ b/movie_player.go
@@ -231,7 +231,9 @@ func (p *moviePlayer) setFPS(fps int) {
 		fps = 1
 	}
 	p.fps = fps
+	clMovFPS = fps
 	p.ticker.Reset(time.Second / time.Duration(p.fps))
+	resetInterpolation()
 	p.updateUI()
 }
 


### PR DESCRIPTION
## Summary
- Add clMovPlaying flag to track movie playback mode
- Base interpolation interval on current clMov playback speed
- Sync global playback speed when changing UPS and reset interpolation

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_6892743b2edc832aa4916642d3c83a16