### PR TITLE
Fix bubble text alignment and padding

### DIFF
--- a/game.go
+++ b/game.go
@@ -463,7 +463,7 @@ func drawScene(screen *ebiten.Image, snap drawSnapshot, alpha float64, fade floa
 			}
 			x := (int(math.Round(hpos)) + fieldCenterX) * scale
 			y := (int(math.Round(vpos)) + fieldCenterY) * scale
-			drawBubble(screen, b.Text, x, y, b.Type, b.Far)
+			drawBubble(screen, b.Text, x, y, b.Type, b.Far, color.White, color.NRGBA{R: 255, G: 255, B: 255, A: 128}, color.Black)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- ensure speech bubbles include additional 2*scale padding and adjust their width accordingly
- render bubble text from a top-left origin so it stays inside the bubble
- draw bubble borders and allow border, background, and text colors to be customized

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689273cf33b0832a8e8efff9d5cb0aca