### PR TITLE
Cache clMov frames for faster playback and seeking

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,6 +203,10 @@ func main() {
 		mp := newMoviePlayer(frames, clMovFPS, cancel)
 		mp.initUI()
 		go mp.run(ctx)
+		go func() {
+			mp.cacheFrames()
+			mp.play()
+		}()
 
 		<-ctx.Done()
 		return


### PR DESCRIPTION
## Summary
- Cache movie state snapshots on load and play back using precomputed frames for smoother seeking
- Add draw state restoration helper to apply cached snapshots
- Start clmov playback paused, display caching progress, then auto-play when caching completes

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw DISPLAY environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68927943a8cc832aa50b2af586412344