### PR TITLE
Correct bubble bounds after clamping to screen

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -88,6 +88,8 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, b
 	if top+height > sh {
 		top = sh - height
 	}
+	right = left + width
+	bottom = top + height
 
 	bgR, bgG, bgB, bgA := bgCol.RGBA()
 


### PR DESCRIPTION
## Summary
- recompute bubble edge coordinates after clamping to screen so the entire bubble moves with its mobile

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6892784f8900832a8d32670b06a125d4