### PR TITLE
Block rendering and sounds during clMov caching

### DIFF
--- a/game.go
+++ b/game.go
@@ -384,6 +384,9 @@ func (g *Game) Update() error {
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {
+	if blockRender {
+		return
+	}
 	//screen.Fill(color.White)
 	if clmov == "" && tcpConn == nil && !noSplash {
 		drawSplash(screen)

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ var (
 	nightLevel   int
 	blockSound   bool
 	blockBubbles bool
+	blockRender  bool
 
 	loginRequest = make(chan struct{})
 )

--- a/movie_player.go
+++ b/movie_player.go
@@ -171,6 +171,16 @@ func (p *moviePlayer) initUI() {
 // cacheFrames simulates all frames and stores draw state snapshots.
 func (p *moviePlayer) cacheFrames() {
 	addMessage("caching clMov frames...")
+
+	prevSound := blockSound
+	prevRender := blockRender
+	blockSound = true
+	blockRender = true
+	defer func() {
+		blockSound = prevSound
+		blockRender = prevRender
+	}()
+
 	p.states = make([]drawSnapshot, 0, len(p.frames)+1)
 	p.states = append(p.states, captureDrawSnapshot())
 	for _, m := range p.frames {


### PR DESCRIPTION
## Summary
- add global flag to block rendering
- suppress sound and rendering while caching clMov frames

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892817bc858832a9d66af40efa2b9cf