### PR TITLE
Fix speech bubble tail positioning

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -91,6 +91,12 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, b
 	right = left + width
 	bottom = top + height
 
+	if !far {
+		// Reposition the tail tip so it remains a fixed distance below the bubble
+		// after clamping the bubble to the screen bounds.
+		y = bottom + tailHeight
+	}
+
 	bgR, bgG, bgB, bgA := bgCol.RGBA()
 
 	radius := float32(4 * scale)


### PR DESCRIPTION
## Summary
- adjust tail tip coordinates after clamping bubble to screen to avoid stray vertices

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689281ae773c832a9ef288075fcee3ef