### PR TITLE
Enable playback during clMov caching

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,10 +204,7 @@ func main() {
 		mp := newMoviePlayer(frames, clMovFPS, cancel)
 		mp.initUI()
 		go mp.run(ctx)
-		go func() {
-			mp.cacheFrames()
-			mp.play()
-		}()
+		go mp.cacheFrames()
 
 		<-ctx.Done()
 		return


### PR DESCRIPTION
## Summary
- Allow movie playback while frames are still being cached
- Grow slider range and total time as frames finish caching
- Run caching asynchronously without blocking rendering

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw DISPLAY env variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68929168d1c4832ab48c70ebbaf05a96