### PR TITLE
Restore message display after clmov precache

### DIFF
--- a/game.go
+++ b/game.go
@@ -829,6 +829,10 @@ func drawStatusBars(screen *ebiten.Image, snap drawSnapshot, alpha float64) {
 
 // drawMessages prints chat messages on the HUD.
 func drawMessages(screen *ebiten.Image, msgs []string) {
+	if blockRender {
+		return
+	}
+
 	y := (gameAreaSizeY - 50) * scale
 	maxWidth := float64(gameAreaSizeX*scale - 8*scale)
 	for i := len(msgs) - 1; i >= 0; i-- {

--- a/messages.go
+++ b/messages.go
@@ -21,10 +21,6 @@ var (
 )
 
 func addMessage(msg string) {
-	if blockRender {
-		return
-	}
-
 	if msg == "" {
 		return
 	}


### PR DESCRIPTION
## Summary
- Capture messages even when rendering is blocked during clmov frame caching
- Skip HUD message rendering only while rendering is blocked

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689297c68a30832a8221080f81a58873