### PR TITLE
Add clMov video rendering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/hajimehoshi/ebiten/v2 v2.8.8
 
 require (
 	github.com/Distortions81/EUI v0.0.7
+	github.com/gen2brain/x264-go v0.3.1
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	golang.org/x/crypto v0.40.0
 )
@@ -16,6 +17,8 @@ require (
 	github.com/ebitengine/gomobile v0.0.0-20250329061421-6d0a8e981e4c // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
+	github.com/gen2brain/x264-go/x264c v0.0.0-20241022182000-732e1bdb7da2 // indirect
+	github.com/gen2brain/x264-go/yuv v0.0.0-20221204084822-82ee2951dea2 // indirect
 	github.com/go-text/typesetting v0.3.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	golang.org/x/image v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,3 @@
-github.com/Distortions81/EUI v0.0.3 h1:zHPQ0A257Cw7H8qDrvkBy1F3QQtklQtfPaeoBU+8QaY=
-github.com/Distortions81/EUI v0.0.3/go.mod h1:F0FHVUCQx+BIHYATuNO/ToGZfBtL+Kp7uHnFhc/2HEE=
-github.com/Distortions81/EUI v0.0.4 h1:mphMp8YMPZFz9Gp3ZAbLpt98Xypq1a+kKF+GcfERpQw=
-github.com/Distortions81/EUI v0.0.4/go.mod h1:F0FHVUCQx+BIHYATuNO/ToGZfBtL+Kp7uHnFhc/2HEE=
-github.com/Distortions81/EUI v0.0.6 h1:qMvZfGchCuWiiO7BscXYXp1ik48zjPIDq25pPw3ro0M=
-github.com/Distortions81/EUI v0.0.6/go.mod h1:F0FHVUCQx+BIHYATuNO/ToGZfBtL+Kp7uHnFhc/2HEE=
 github.com/Distortions81/EUI v0.0.7 h1:ByH68JTDbGUZxtMTI7fgb8aZZveVQDMog+w6vqDWxpk=
 github.com/Distortions81/EUI v0.0.7/go.mod h1:F0FHVUCQx+BIHYATuNO/ToGZfBtL+Kp7uHnFhc/2HEE=
 github.com/ebitengine/gomobile v0.0.0-20250329061421-6d0a8e981e4c h1:Ccgks2VROTr6bIm1FFxG2jT6P1DaCBMj8g/O9xbOQ08=
@@ -14,6 +8,12 @@ github.com/ebitengine/oto/v3 v3.3.3 h1:m6RV69OqoXYSWCDsHXN9rc07aDuDstGHtait7HXSM
 github.com/ebitengine/oto/v3 v3.3.3/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/gen2brain/x264-go v0.3.1 h1:XFi6y8HM5BCMrP4kR/o711iBU++XNfLOY3PG8Alz2kU=
+github.com/gen2brain/x264-go v0.3.1/go.mod h1:+Z4VKXQrUKzbfEv36GyiyjXfixmOp2c820ugsMthW18=
+github.com/gen2brain/x264-go/x264c v0.0.0-20241022182000-732e1bdb7da2 h1:aS40m/Q+6z0ID7EVegxnnw3lWHUceGbg0zucbo7335I=
+github.com/gen2brain/x264-go/x264c v0.0.0-20241022182000-732e1bdb7da2/go.mod h1:r2t0/BO5YgPRwWQpLYO5iB5FLSj1ArTQc/zmAoAV7sQ=
+github.com/gen2brain/x264-go/yuv v0.0.0-20221204084822-82ee2951dea2 h1:lihaRUKRj94EWVZRp1jTmEiIxmvjEiSb9fJl2xftrXY=
+github.com/gen2brain/x264-go/yuv v0.0.0-20221204084822-82ee2951dea2/go.mod h1:PzzJntdOaVt4Gc37fNaEXpqmhKkUgd/xqyPMUfx+FQc=
 github.com/go-text/typesetting v0.3.0 h1:OWCgYpp8njoxSRpwrdd1bQOxdjOXDj9Rqart9ML4iF4=
 github.com/go-text/typesetting v0.3.0/go.mod h1:qjZLkhRgOEYMhU9eHBr3AR4sfnGJvOXNLt8yRAySFuY=
 github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066 h1:qCuYC+94v2xrb1PoS4NIDe7DGYtLnU2wWiQe9a1B1c0=


### PR DESCRIPTION
## Summary
- Add Render button to clMov controls that exports playback to `movie.h264`.
- Implement `renderVideo` using x264-go to encode cached frames.
- Include x264-go dependency for H264 encoding.

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689299ae2820832aa0bfad7a625c83eb