### PR TITLE
Restore chat and bubbles during clmov playback

### DIFF
--- a/game.go
+++ b/game.go
@@ -238,6 +238,13 @@ func applyDrawSnapshot(snap drawSnapshot, fps int) {
 	}
 
 	state.bubbles = append([]bubble(nil), snap.bubbles...)
+	if clMovPlaying {
+		now := time.Now()
+		for i := range state.bubbles {
+			rem := snap.bubbles[i].Expire.Sub(snap.curTime)
+			state.bubbles[i].Expire = now.Add(rem)
+		}
+	}
 
 	state.hp = snap.hp
 	state.hpMax = snap.hpMax

--- a/messages.go
+++ b/messages.go
@@ -18,10 +18,19 @@ type message struct {
 var (
 	messageMu sync.Mutex
 	messages  []message
+
+	clmovCaching    bool
+	clmovCacheFrame int
+	clmovCacheMsgs  [][]string
 )
 
 func addMessage(msg string) {
 	if msg == "" {
+		return
+	}
+
+	if clmovCaching && clmovCacheFrame < len(clmovCacheMsgs) {
+		clmovCacheMsgs[clmovCacheFrame] = append(clmovCacheMsgs[clmovCacheFrame], msg)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- capture chat messages during clmov precache and replay them while the movie runs
- preserve bubble durations so speech balloons render properly in playback

## Testing
- `go build ./...`
- `EBITEN_RUN_HEADLESS=1 go test ./...` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68929a7d244c832aab1017efb1969b72