### PR TITLE
Clamp bubble tail to screen bounds

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -15,6 +15,42 @@ func init() {
 	whiteImage.Fill(color.White)
 }
 
+// adjustBubbleRect calculates the on-screen rectangle for a bubble and shifts
+// the tail tip (x, y) if clamping is required. It returns the clamped
+// rectangle along with the adjusted tail coordinates.
+func adjustBubbleRect(x, y, width, height, tailHeight, sw, sh int, far bool) (left, top, right, bottom, ax, ay int) {
+	bottom = y
+	if !far {
+		bottom = y - tailHeight
+	}
+	left = x - width/2
+	top = bottom - height
+
+	origLeft, origTop := left, top
+
+	if left < 0 {
+		left = 0
+	}
+	if left+width > sw {
+		left = sw - width
+	}
+	if top < 0 {
+		top = 0
+	}
+	if top+height > sh {
+		top = sh - height
+	}
+
+	dx := left - origLeft
+	dy := top - origTop
+	ax = x + dx
+	ay = y + dy
+
+	right = left + width
+	bottom = top + height
+	return
+}
+
 // Bubble dimensions and text widths derived from the original Macintosh client.
 // Sizes are in pixels at scale 1.
 const (
@@ -67,27 +103,7 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, b
 	width += 2 * pad
 	height := lineHeight*len(lines) + 2*pad
 
-	bottom := y
-	if !far {
-		bottom = y - tailHeight
-	}
-	left := x - width/2
-	top := bottom - height
-	right := left + width
-
-	// Ensure the bubble remains fully on screen.
-	if left < 0 {
-		left = 0
-	}
-	if left+width > sw {
-		left = sw - width
-	}
-	if top < 0 {
-		top = 0
-	}
-	if top+height > sh {
-		top = sh - height
-	}
+	left, top, right, bottom, x, y := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, far)
 
 	bgR, bgG, bgB, bgA := bgCol.RGBA()
 

--- a/bubble_test.go
+++ b/bubble_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+func TestAdjustBubbleRectClampLeft(t *testing.T) {
+	sw, sh := 200, 200
+	width, height := 100, 50
+	tailHeight := 10
+	x, y := 10, 100
+	left, _, right, bottom, ax, ay := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, false)
+
+	if left != 0 {
+		t.Fatalf("expected left to be clamped to 0, got %d", left)
+	}
+	if right-left != width {
+		t.Fatalf("expected width %d, got %d", width, right-left)
+	}
+	if ax != left+width/2 {
+		t.Fatalf("tail x not shifted correctly: %d != %d", ax, left+width/2)
+	}
+	if ay != bottom+tailHeight {
+		t.Fatalf("tail y not shifted correctly: %d != %d", ay, bottom+tailHeight)
+	}
+}
+
+func TestAdjustBubbleRectClampTop(t *testing.T) {
+	sw, sh := 200, 200
+	width, height := 100, 50
+	tailHeight := 10
+	x, y := 100, 20
+	left, top, _, bottom, ax, ay := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, false)
+
+	if top != 0 {
+		t.Fatalf("expected top to be clamped to 0, got %d", top)
+	}
+	if bottom-top != height {
+		t.Fatalf("expected height %d, got %d", height, bottom-top)
+	}
+	if ax != left+width/2 {
+		t.Fatalf("tail x not shifted correctly: %d != %d", ax, left+width/2)
+	}
+	if ay != bottom+tailHeight {
+		t.Fatalf("tail y not shifted correctly: %d != %d", ay, bottom+tailHeight)
+	}
+}


### PR DESCRIPTION
## Summary
- Recompute bubble rectangle when clamped to screen bounds and shift tail coordinates accordingly
- Cover bubble clamping logic with tests to ensure stable size and attached tail

## Testing
- `xvfb-run go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892b0dcf4ac832ab2e2cf1c5fadd180