### PR TITLE
Fix bubble clamping with scaled coordinates

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -124,12 +124,12 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, b
 		return
 	}
 
-	sw, sh := gameAreaSizeX, gameAreaSizeY
+	sw, sh := gameAreaSizeX*scale, gameAreaSizeY*scale
 	pad := (4 + 2) * scale
 	tailHeight := 10 * scale
 	tailHalf := 6 * scale
 
-	maxLineWidth := sw/4*scale - 2*pad
+	maxLineWidth := sw/4 - 2*pad
 	width, lines := wrapText(txt, bubbleFont, float64(maxLineWidth))
 	metrics := bubbleFont.Metrics()
 	lineHeight := int(math.Ceil(metrics.HAscent) + math.Ceil(metrics.HDescent) + math.Ceil(metrics.HLineGap))

--- a/bubble_test.go
+++ b/bubble_test.go
@@ -43,3 +43,55 @@ func TestAdjustBubbleRectClampTop(t *testing.T) {
 		t.Fatalf("tail y not shifted correctly: %d != %d", ay, bottom+tailHeight)
 	}
 }
+
+func TestAdjustBubbleRectClampRightScaled(t *testing.T) {
+	scale := 2
+	sw, sh := 200*scale, 200*scale
+	width, height := 100*scale, 50*scale
+	tailHeight := 10 * scale
+	// place tail tip off-screen to the right
+	x, y := sw+10*scale, 100*scale
+	left, top, right, bottom, ax, ay := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, false)
+
+	if right != sw {
+		t.Fatalf("expected right to be clamped to %d, got %d", sw, right)
+	}
+	if left != sw-width {
+		t.Fatalf("expected left to be %d, got %d", sw-width, left)
+	}
+	if ax != left+width/2 {
+		t.Fatalf("tail x not shifted correctly: %d != %d", ax, left+width/2)
+	}
+	if ay != bottom+tailHeight {
+		t.Fatalf("tail y not shifted correctly: %d != %d", ay, bottom+tailHeight)
+	}
+	if top != bottom-height {
+		t.Fatalf("expected height %d, got %d", height, bottom-top)
+	}
+}
+
+func TestAdjustBubbleRectClampBottomScaled(t *testing.T) {
+	scale := 2
+	sw, sh := 200*scale, 200*scale
+	width, height := 100*scale, 50*scale
+	tailHeight := 10 * scale
+	// place tail tip off-screen at the bottom
+	x, y := 100*scale, sh+10*scale
+	left, top, right, bottom, ax, ay := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, false)
+
+	if bottom != sh {
+		t.Fatalf("expected bottom to be clamped to %d, got %d", sh, bottom)
+	}
+	if top != sh-height {
+		t.Fatalf("expected top to be %d, got %d", sh-height, top)
+	}
+	if ax != left+width/2 {
+		t.Fatalf("tail x not shifted correctly: %d != %d", ax, left+width/2)
+	}
+	if ay != bottom+tailHeight {
+		t.Fatalf("tail y not shifted correctly: %d != %d", ay, bottom+tailHeight)
+	}
+	if right-left != width {
+		t.Fatalf("expected width %d, got %d", width, right-left)
+	}
+}


### PR DESCRIPTION
## Summary
- Scale the screen dimensions used when drawing speech bubbles
- Simplify max line width calculation for scaled bubbles
- Add tests covering bubble clamping at right and bottom edges with scaling

## Testing
- `go test` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_6892b5d5cbd8832a8e1c7cabbec2ff8a