### PR TITLE
Add option to hide speech bubble arrow

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -125,11 +125,12 @@ func bubbleColors(typ int) (border, bg, text color.Color) {
 
 // drawBubble renders a text bubble anchored so that (x, y) corresponds to the
 // bottom-center of the balloon tail. If far is true the tail is omitted and
-// (x, y) represents the bottom-center of the bubble itself. The typ parameter
+// (x, y) represents the bottom-center of the bubble itself. The tail can also
+// be skipped explicitly via noArrow. The typ parameter
 // is currently unused but retained for future compatibility with the original
 // bubble images. The colors of the border, background, and text can be
 // customized via borderCol, bgCol, and textCol respectively.
-func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, borderCol, bgCol, textCol color.Color) {
+func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, noArrow bool, borderCol, bgCol, textCol color.Color) {
 	if txt == "" {
 		return
 	}
@@ -166,7 +167,7 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, b
 	body.Close()
 
 	var tail vector.Path
-	if !far {
+	if !far && !noArrow {
 		tail.MoveTo(float32(x-tailHalf), float32(bottom))
 		tail.LineTo(float32(x), float32(y))
 		tail.LineTo(float32(x+tailHalf), float32(bottom))
@@ -185,7 +186,7 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, b
 	op := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha}
 	screen.DrawTriangles(vs, is, whiteImage, op)
 
-	if !far {
+	if !far && !noArrow {
 		vs, is = tail.AppendVerticesAndIndicesForFilling(vs[:0], is[:0])
 		for i := range vs {
 			vs[i].SrcX = 0
@@ -205,7 +206,7 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, b
 	outline.Arc(float32(right)-radius, float32(top)+radius, radius, -math.Pi/2, 0, vector.Clockwise)
 	outline.LineTo(float32(right), float32(bottom)-radius)
 	outline.Arc(float32(right)-radius, float32(bottom)-radius, radius, 0, math.Pi/2, vector.Clockwise)
-	if !far {
+	if !far && !noArrow {
 		outline.LineTo(float32(x+tailHalf), float32(bottom))
 		outline.LineTo(float32(x), float32(y))
 		outline.LineTo(float32(x-tailHalf), float32(bottom))

--- a/bubble_test.go
+++ b/bubble_test.go
@@ -65,7 +65,7 @@ func TestDrawBubbleWideNoArtifacts(t *testing.T) {
 
 	screen := ebiten.NewImage(gameAreaSizeX, gameAreaSizeY)
 	borderCol, bgCol, textCol := bubbleColors(kBubbleNormal)
-	drawBubble(screen, txt, gameAreaSizeX/2, gameAreaSizeY/2, kBubbleNormal, false, borderCol, bgCol, textCol)
+	drawBubble(screen, txt, gameAreaSizeX/2, gameAreaSizeY/2, kBubbleNormal, false, false, borderCol, bgCol, textCol)
 
 	width, lines := wrapText(txt, bubbleFont, float64(maxLineWidth))
 	if len(lines) != 1 {

--- a/draw.go
+++ b/draw.go
@@ -754,6 +754,10 @@ func parseDrawState(data []byte) error {
 			stateMu.Unlock()
 			if showBubbles && txt != "" && !blockBubbles {
 				b := bubble{Index: idx, Text: txt, Type: typ, Expire: time.Now().Add(4 * time.Second)}
+				switch typ & kBubbleTypeMask {
+				case kBubbleRealAction, kBubblePlayerAction, kBubbleNarrate:
+					b.NoArrow = true
+				}
 				if typ&kBubbleFar != 0 {
 					b.H, b.V = h, v
 					b.Far = true

--- a/game.go
+++ b/game.go
@@ -98,12 +98,13 @@ var (
 
 // bubble stores temporary bubble debug information.
 type bubble struct {
-	Index  uint8
-	H, V   int16
-	Far    bool
-	Text   string
-	Type   int
-	Expire time.Time
+	Index   uint8
+	H, V    int16
+	Far     bool
+	NoArrow bool
+	Text    string
+	Type    int
+	Expire  time.Time
 }
 
 // drawSnapshot is a read-only copy of the current draw state.
@@ -464,7 +465,7 @@ func drawScene(screen *ebiten.Image, snap drawSnapshot, alpha float64, fade floa
 			x := (int(math.Round(hpos)) + fieldCenterX) * scale
 			y := (int(math.Round(vpos)) + fieldCenterY) * scale
 			borderCol, bgCol, textCol := bubbleColors(b.Type)
-			drawBubble(screen, b.Text, x, y, b.Type, b.Far, borderCol, bgCol, textCol)
+			drawBubble(screen, b.Text, x, y, b.Type, b.Far, b.NoArrow, borderCol, bgCol, textCol)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- allow bubbles to skip drawing their arrow via a new `NoArrow` flag
- hide the arrow for realAction, playerAction, and narrate message types
- update drawing logic to respect the new flag

## Testing
- `go test ./...` *(fails: night.go:205:6: no new variables on left side of :=)*

------
https://chatgpt.com/codex/tasks/task_e_6892c72908c8832aae3b65f3cf9f67e5