### PR TITLE
Add cross-platform build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ go_client
 *.log
 *.exe
 data/night.png
+binaries/*
+!binaries/.gitkeep

--- a/scripts/build_binaries.sh
+++ b/scripts/build_binaries.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="binaries"
+mkdir -p "$OUTPUT_DIR"
+
+platforms=(
+  "linux:amd64"
+  "darwin:amd64"
+  "windows:amd64"
+)
+
+for platform in "${platforms[@]}"; do
+  IFS=":" read -r GOOS GOARCH <<<"$platform"
+  BIN_NAME="thoomspeak-${GOOS}-${GOARCH}"
+  if [ "$GOOS" = "windows" ]; then
+    BIN_NAME+=".exe"
+  fi
+  echo "Building ${GOOS}/${GOARCH}..."
+  env GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=1 \
+    go build -o "${OUTPUT_DIR}/${BIN_NAME}" .
+done
+
+echo "Binaries are located in ${OUTPUT_DIR}/"


### PR DESCRIPTION
## Summary
- add `scripts/build_binaries.sh` to build Linux, macOS, and Windows versions of the client into `binaries/`
- ensure generated binaries stay out of version control by updating `.gitignore` and adding a placeholder in `binaries/`

## Testing
- `./scripts/build_binaries.sh` *(fails: cgo: C compiler "clang" not found: exec: "clang": executable file not found in $PATH)*
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_6892e6424e2c832a8ab8e98778abbabf