### PR TITLE
Add blend rate slider to settings window

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -103,6 +103,18 @@ func initUI() {
 	}
 	mainFlow.AddItem(motion)
 
+	blendFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL}
+	blendLabel, _ := eui.NewText(&eui.ItemData{Text: "Blend Rate", Size: eui.Point{X: 100, Y: 24}})
+	blendFlow.AddItem(blendLabel)
+	blendSlider, blendEvents := eui.NewSlider(&eui.ItemData{MinValue: 0.1, MaxValue: 1.0, Value: float32(blendRate), Size: eui.Point{X: width - 100, Y: 24}})
+	blendEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			blendRate = float64(ev.Value)
+		}
+	}
+	blendFlow.AddItem(blendSlider)
+	mainFlow.AddItem(blendFlow)
+
 	anim, animEvents := eui.NewCheckbox(&eui.ItemData{Text: "Character Frame Blending", Size: eui.Point{X: width, Y: 24}, Checked: onion})
 	animEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {


### PR DESCRIPTION
## Summary
- Add blend rate slider to settings for runtime tuning of interpolation amount.

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689311fcdd0c832a9097fec1b8a1f0cb