### PR TITLE
Add scale slider

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -68,8 +68,18 @@ func initUI() {
 		ItemType: eui.ITEM_FLOW,
 		FlowType: eui.FLOW_VERTICAL,
 	}
-
 	var width float32 = 250
+
+	scaleSlider, scaleEvents := eui.NewSlider(&eui.ItemData{Label: "Scale", MinValue: 2, MaxValue: 5, Value: float32(scale), Size: eui.Point{X: width, Y: 24}, IntOnly: true})
+	scaleEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			scale = int(ev.Value)
+			initFont()
+			inputBg = nil
+			ebiten.SetWindowSize(gameAreaSizeX*scale, gameAreaSizeY*scale)
+		}
+	}
+	mainFlow.AddItem(scaleSlider)
 
 	toggle, toggleEvents := eui.NewCheckbox(&eui.ItemData{Text: "Click-to-Toggle Walk", Size: eui.Point{X: width, Y: 24}, Checked: clickToToggle})
 	toggleEvents.Handle = func(ev eui.UIEvent) {

--- a/ui.go
+++ b/ui.go
@@ -70,7 +70,7 @@ func initUI() {
 	}
 	var width float32 = 250
 
-	scaleSlider, scaleEvents := eui.NewSlider(&eui.ItemData{Label: "Scale", MinValue: 2, MaxValue: 5, Value: float32(scale), Size: eui.Point{X: width, Y: 24}, IntOnly: true})
+	scaleSlider, scaleEvents := eui.NewSlider(&eui.ItemData{Label: "Scaling", MinValue: 2, MaxValue: 5, Value: float32(scale), Size: eui.Point{X: width, Y: 24}, IntOnly: true})
 	scaleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			scale = int(ev.Value)


### PR DESCRIPTION
## Summary
- allow adjusting in-game scale with an integer slider (range 2-5)
- resize window and reload fonts when scale changes

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689313679d78832a87051c37dcacc13c