### PR TITLE
Add Hide Mobiles setting

### DIFF
--- a/game.go
+++ b/game.go
@@ -54,6 +54,7 @@ var frameCounter int
 var showPlanes bool
 var showBubbles bool
 var nightMode bool
+var hideMobiles bool
 
 var (
 	frameCh       = make(chan struct{}, 1)
@@ -404,33 +405,39 @@ func drawScene(screen *ebiten.Image, snap drawSnapshot, alpha float64, fade floa
 		drawPicture(screen, p, alpha, fade, snap.mobiles, snap.prevMobiles, snap.picShiftX, snap.picShiftY)
 	}
 
-	sort.Slice(dead, func(i, j int) bool { return dead[i].V < dead[j].V })
-	for _, m := range dead {
-		drawMobile(screen, m, descMap, snap.prevMobiles, snap.prevDescs, snap.picShiftX, snap.picShiftY, alpha, fade)
-	}
+	if hideMobiles {
+		for _, p := range zeroPics {
+			drawPicture(screen, p, alpha, fade, snap.mobiles, snap.prevMobiles, snap.picShiftX, snap.picShiftY)
+		}
+	} else {
+		sort.Slice(dead, func(i, j int) bool { return dead[i].V < dead[j].V })
+		for _, m := range dead {
+			drawMobile(screen, m, descMap, snap.prevMobiles, snap.prevDescs, snap.picShiftX, snap.picShiftY, alpha, fade)
+		}
 
-	sort.Slice(live, func(i, j int) bool { return live[i].V < live[j].V })
-	i, j := 0, 0
-	for i < len(live) || j < len(zeroPics) {
-		var mV, pV int
-		if i < len(live) {
-			mV = int(live[i].V)
-		} else {
-			mV = int(^uint(0) >> 1)
-		}
-		if j < len(zeroPics) {
-			pV = int(zeroPics[j].V)
-		} else {
-			pV = int(^uint(0) >> 1)
-		}
-		if mV < pV {
-			if live[i].State != poseDead {
-				drawMobile(screen, live[i], descMap, snap.prevMobiles, snap.prevDescs, snap.picShiftX, snap.picShiftY, alpha, fade)
+		sort.Slice(live, func(i, j int) bool { return live[i].V < live[j].V })
+		i, j := 0, 0
+		for i < len(live) || j < len(zeroPics) {
+			var mV, pV int
+			if i < len(live) {
+				mV = int(live[i].V)
+			} else {
+				mV = int(^uint(0) >> 1)
 			}
-			i++
-		} else {
-			drawPicture(screen, zeroPics[j], alpha, fade, snap.mobiles, snap.prevMobiles, snap.picShiftX, snap.picShiftY)
-			j++
+			if j < len(zeroPics) {
+				pV = int(zeroPics[j].V)
+			} else {
+				pV = int(^uint(0) >> 1)
+			}
+			if mV < pV {
+				if live[i].State != poseDead {
+					drawMobile(screen, live[i], descMap, snap.prevMobiles, snap.prevDescs, snap.picShiftX, snap.picShiftY, alpha, fade)
+				}
+				i++
+			} else {
+				drawPicture(screen, zeroPics[j], alpha, fade, snap.mobiles, snap.prevMobiles, snap.picShiftX, snap.picShiftY)
+				j++
+			}
 		}
 	}
 

--- a/ui.go
+++ b/ui.go
@@ -161,6 +161,14 @@ func initUI() {
 	}
 	mainFlow.AddItem(planesCB)
 
+	hideMobCB, hideMobEvents := eui.NewCheckbox(&eui.ItemData{Text: "Hide Mobiles", Size: eui.Point{X: width, Y: 24}, Checked: hideMobiles})
+	hideMobEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			hideMobiles = ev.Checked
+		}
+	}
+	mainFlow.AddItem(hideMobCB)
+
 	settingsWin.AddItem(mainFlow)
 	settingsWin.AddWindow(false)
 	settingsWin.Open = false


### PR DESCRIPTION
## Summary
- add global setting `hideMobiles`
- allow toggling hiding mobiles from the Settings window
- skip rendering mobile entities when hideMobiles is enabled

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689318c89c74832aad95bf2315a29ed0