### PR TITLE
Sort pictures by position to avoid flicker

### DIFF
--- a/game.go
+++ b/game.go
@@ -367,10 +367,13 @@ func drawScene(screen *ebiten.Image, snap drawSnapshot, alpha float64, fade floa
 			pi = clImages.Plane(uint32(snap.pictures[i].PictID))
 			pj = clImages.Plane(uint32(snap.pictures[j].PictID))
 		}
-		if pi == pj {
-			return snap.pictures[i].V < snap.pictures[j].V
+		if pi != pj {
+			return pi < pj
 		}
-		return pi < pj
+		if snap.pictures[i].V == snap.pictures[j].V {
+			return snap.pictures[i].H < snap.pictures[j].H
+		}
+		return snap.pictures[i].V < snap.pictures[j].V
 	})
 
 	dead := make([]frameMobile, 0, len(snap.mobiles))


### PR DESCRIPTION
## Summary
- Sort drawn pictures by plane, vertical coordinate, then horizontal coordinate

## Testing
- `xvfb-run -a go test ./...` *(fails: ui: ReadPixels cannot be called before the game starts)*

------
https://chatgpt.com/codex/tasks/task_e_689318dd99b8832ab3a7f5277db119e8