### PR TITLE
Add text size adjustments to settings window

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -153,6 +153,25 @@ func initUI() {
 	}
 	mainFlow.AddItem(bubbleCB)
 
+	textSlider, textEvents := eui.NewSlider(&eui.ItemData{Label: "Text Size", MinValue: 6, MaxValue: 18, Value: float32(mainFontSize), Size: eui.Point{X: width - 10, Y: 24}, IntOnly: true})
+	textEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			mainFontSize = float64(ev.Value)
+			initFont()
+			inputBg = nil
+		}
+	}
+	mainFlow.AddItem(textSlider)
+
+	bubbleTextSlider, bubbleTextEvents := eui.NewSlider(&eui.ItemData{Label: "Bubble Text Size", MinValue: 6, MaxValue: 18, Value: float32(bubbleFontSize), Size: eui.Point{X: width - 10, Y: 24}, IntOnly: true})
+	bubbleTextEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			bubbleFontSize = float64(ev.Value)
+			initFont()
+		}
+	}
+	mainFlow.AddItem(bubbleTextSlider)
+
 	planesCB, planesEvents := eui.NewCheckbox(&eui.ItemData{Text: "Show image plane numbers", Size: eui.Point{X: width, Y: 24}, Checked: showPlanes})
 	planesEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {


### PR DESCRIPTION
## Summary
- Add sliders for global text size and bubble text size to the Settings window

## Testing
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6893194791ec832aab69ac306a639d00