### PR TITLE
Add keyboard walk speed slider and debug settings window

### DIFF
--- a/game.go
+++ b/game.go
@@ -41,6 +41,7 @@ var inputBg *ebiten.Image
 var hudPixel *ebiten.Image
 
 var settingsWin *eui.WindowData
+var debugWin *eui.WindowData
 var gameCtx context.Context
 var scale int = 2
 var interp bool = true
@@ -58,6 +59,7 @@ var showBubbles bool
 var nightMode bool
 var vsync = true
 var hideMobiles bool
+var keyWalkSpeed float64 = 0.5
 
 var (
 	frameCh       = make(chan struct{}, 1)
@@ -294,13 +296,12 @@ func (g *Game) Update() error {
 		}
 		if dx != 0 || dy != 0 {
 			keyWalk = true
+			speed := keyWalkSpeed
 			if ebiten.IsKeyPressed(ebiten.KeyShift) {
-				keyX = int16(dx * fieldCenterX)
-				keyY = int16(dy * fieldCenterY)
-			} else {
-				keyX = int16(dx * (fieldCenterX / 2))
-				keyY = int16(dy * (fieldCenterX / 2))
+				speed = 1.0
 			}
+			keyX = int16(float64(dx) * float64(fieldCenterX) * speed)
+			keyY = int16(float64(dy) * float64(fieldCenterY) * speed)
 		} else {
 			keyWalk = false
 		}

--- a/settings.go
+++ b/settings.go
@@ -26,6 +26,7 @@ type Settings struct {
 	ShowPlanes     bool    `json:"showPlanes"`
 	HideMoving     bool    `json:"hideMoving"`
 	HideMobiles    bool    `json:"hideMobiles"`
+	KeyWalkSpeed   float64 `json:"keyWalkSpeed"`
 }
 
 var settingsDirty bool
@@ -56,6 +57,10 @@ func loadSettings() bool {
 	showPlanes = s.ShowPlanes
 	hideMoving = s.HideMoving
 	hideMobiles = s.HideMobiles
+	keyWalkSpeed = s.KeyWalkSpeed
+	if keyWalkSpeed == 0 {
+		keyWalkSpeed = 0.5
+	}
 	return true
 }
 
@@ -89,6 +94,7 @@ func saveSettings() {
 		ShowPlanes:     showPlanes,
 		HideMoving:     hideMoving,
 		HideMobiles:    hideMobiles,
+		KeyWalkSpeed:   keyWalkSpeed,
 	}
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {

--- a/ui.go
+++ b/ui.go
@@ -108,16 +108,6 @@ func initUI() {
 	}
 	mainFlow.AddItem(filt)
 
-	vsyncCB, vsyncEvents := eui.NewCheckbox(&eui.ItemData{Text: "Vsync", Size: eui.Point{X: width, Y: 24}, Checked: vsync})
-	vsyncEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventCheckboxChanged {
-			vsync = ev.Checked
-			ebiten.SetVsyncEnabled(vsync)
-			settingsDirty = true
-		}
-	}
-	mainFlow.AddItem(vsyncCB)
-
 	motion, motionEvents := eui.NewCheckbox(&eui.ItemData{Text: "Smooth Motion", Size: eui.Point{X: width, Y: 24}, Checked: interp})
 	motionEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
@@ -163,23 +153,14 @@ func initUI() {
 	}
 	mainFlow.AddItem(blendSlider)
 
-	nightCB, nightEvents := eui.NewCheckbox(&eui.ItemData{Text: "Night Effects", Size: eui.Point{X: width, Y: 24}, Checked: nightMode})
-	nightEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventCheckboxChanged {
-			nightMode = ev.Checked
+	keySpeedSlider, keySpeedEvents := eui.NewSlider(&eui.ItemData{Label: "Keyboard Walk Speed", MinValue: 0.1, MaxValue: 1.0, Value: float32(keyWalkSpeed), Size: eui.Point{X: width - 10, Y: 24}})
+	keySpeedEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			keyWalkSpeed = float64(ev.Value)
 			settingsDirty = true
 		}
 	}
-	mainFlow.AddItem(nightCB)
-
-	bubbleCB, bubbleEvents := eui.NewCheckbox(&eui.ItemData{Text: "Show Message Bubbles", Size: eui.Point{X: width, Y: 24}, Checked: showBubbles})
-	bubbleEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventCheckboxChanged {
-			showBubbles = ev.Checked
-			settingsDirty = true
-		}
-	}
-	mainFlow.AddItem(bubbleCB)
+	mainFlow.AddItem(keySpeedSlider)
 
 	textSlider, textEvents := eui.NewSlider(&eui.ItemData{Label: "Text Size", MinValue: 3, MaxValue: 24, Value: float32(mainFontSize), Size: eui.Point{X: width - 10, Y: 24}, IntOnly: true})
 	textEvents.Handle = func(ev eui.UIEvent) {
@@ -202,6 +183,62 @@ func initUI() {
 	}
 	mainFlow.AddItem(bubbleTextSlider)
 
+	debugBtn, debugEvents := eui.NewButton(&eui.ItemData{Text: "Debug Settings", Size: eui.Point{X: width, Y: 24}})
+	debugEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			debugWin.Open = !debugWin.Open
+		}
+	}
+	mainFlow.AddItem(debugBtn)
+
+	settingsWin.AddItem(mainFlow)
+	settingsWin.AddWindow(false)
+	settingsWin.Open = false
+
+	debugWin = eui.NewWindow(&eui.WindowData{
+		Title:     "Debug Settings",
+		Size:      eui.Point{X: 256, Y: 256},
+		Position:  eui.Point{X: 272, Y: 8},
+		Open:      false,
+		Closable:  false,
+		Resizable: true,
+		AutoSize:  true,
+		Movable:   true,
+	})
+
+	debugFlow := &eui.ItemData{
+		ItemType: eui.ITEM_FLOW,
+		FlowType: eui.FLOW_VERTICAL,
+	}
+
+	vsyncCB, vsyncEvents := eui.NewCheckbox(&eui.ItemData{Text: "Vsync", Size: eui.Point{X: width, Y: 24}, Checked: vsync})
+	vsyncEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			vsync = ev.Checked
+			ebiten.SetVsyncEnabled(vsync)
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(vsyncCB)
+
+	nightCB, nightEvents := eui.NewCheckbox(&eui.ItemData{Text: "Night Effects", Size: eui.Point{X: width, Y: 24}, Checked: nightMode})
+	nightEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			nightMode = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(nightCB)
+
+	bubbleCB, bubbleEvents := eui.NewCheckbox(&eui.ItemData{Text: "Show Message Bubbles", Size: eui.Point{X: width, Y: 24}, Checked: showBubbles})
+	bubbleEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			showBubbles = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(bubbleCB)
+
 	planesCB, planesEvents := eui.NewCheckbox(&eui.ItemData{Text: "Show image plane numbers", Size: eui.Point{X: width, Y: 24}, Checked: showPlanes})
 	planesEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
@@ -209,7 +246,7 @@ func initUI() {
 			settingsDirty = true
 		}
 	}
-	mainFlow.AddItem(planesCB)
+	debugFlow.AddItem(planesCB)
 
 	hideMoveCB, hideMoveEvents := eui.NewCheckbox(&eui.ItemData{Text: "Hide Moving", Size: eui.Point{X: width, Y: 24}, Checked: hideMoving})
 	hideMoveEvents.Handle = func(ev eui.UIEvent) {
@@ -218,7 +255,8 @@ func initUI() {
 			settingsDirty = true
 		}
 	}
-	mainFlow.AddItem(hideMoveCB)
+	debugFlow.AddItem(hideMoveCB)
+
 	hideMobCB, hideMobEvents := eui.NewCheckbox(&eui.ItemData{Text: "Hide Mobiles", Size: eui.Point{X: width, Y: 24}, Checked: hideMobiles})
 	hideMobEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
@@ -226,11 +264,11 @@ func initUI() {
 			settingsDirty = true
 		}
 	}
-	mainFlow.AddItem(hideMobCB)
+	debugFlow.AddItem(hideMobCB)
 
-	settingsWin.AddItem(mainFlow)
-	settingsWin.AddWindow(false)
-	settingsWin.Open = false
+	debugWin.AddItem(debugFlow)
+	debugWin.AddWindow(false)
+	debugWin.Open = false
 
 	inventoryWin = eui.NewWindow(&eui.WindowData{
 		Title:     "Inventory",


### PR DESCRIPTION
## Summary
- add configurable keyboard walk speed slider
- move advanced options to new Debug Settings window

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68935c4bf318832a8f57ebd1b568da03