### PR TITLE
Replace players window with dropdown list

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -56,7 +56,7 @@ func parseBackendInfo(data []byte) {
 	p.Class = class
 	p.Clan = clan
 	playersMu.Unlock()
-	updatePlayersWindow()
+	updatePlayersDropdown()
 }
 
 // parseBackendShare parses "be-sh" messages describing sharing relationships.
@@ -93,7 +93,7 @@ func parseBackendShare(data []byte) {
 		p.Sharing = true
 		playersMu.Unlock()
 	}
-	updatePlayersWindow()
+	updatePlayersDropdown()
 }
 
 // parseBackendWho parses "be-wh" messages listing players.
@@ -116,7 +116,7 @@ func parseBackendWho(data []byte) {
 		}
 		data = data[idx+1:]
 	}
-	updatePlayersWindow()
+	updatePlayersDropdown()
 }
 
 // parseNames extracts a slice of names from a sequence of "-pn name -pn" entries.

--- a/player.go
+++ b/player.go
@@ -49,6 +49,7 @@ func updatePlayerAppearance(name string, pictID uint16, colors []byte) {
 		p.Colors = append(p.Colors[:0], colors...)
 	}
 	playersMu.Unlock()
+	updatePlayersDropdown()
 }
 
 func getPlayers() []Player {

--- a/players_ui.go
+++ b/players_ui.go
@@ -9,26 +9,28 @@ import (
 	"github.com/Distortions81/EUI/eui"
 )
 
-var playersWin *eui.WindowData
-var playersList *eui.ItemData
+// playersDropdown holds the bottom-right dropdown listing nearby players.
+var playersDropdown *eui.ItemData
 
-func updatePlayersWindow() {
-	if playersList == nil {
+// updatePlayersDropdown refreshes the dropdown options with the current
+// player list. Each entry includes the player's profession when available.
+func updatePlayersDropdown() {
+	if playersDropdown == nil {
 		return
 	}
 	ps := getPlayers()
 	sort.Slice(ps, func(i, j int) bool { return ps[i].Name < ps[j].Name })
-	playersList.Contents = playersList.Contents[:0]
-
-	buf := fmt.Sprintf("Players Online: %v", len(ps))
-	t, _ := eui.NewText(&eui.ItemData{ItemType: eui.ITEM_TEXT, Text: buf, FontSize: 10, Size: eui.Point{X: 100, Y: 24}})
-	playersList.AddItem(t)
+	playersDropdown.Options = playersDropdown.Options[:0]
 	for _, p := range ps {
 		if p.Name == "" {
 			continue
 		}
-		t, _ := eui.NewText(&eui.ItemData{Text: p.Name, FontSize: 10, Size: eui.Point{X: 100, Y: 24}})
-		playersList.AddItem(t)
+		label := p.Name
+		if p.Class != "" {
+			label = fmt.Sprintf("%s (%s)", p.Name, p.Class)
+		}
+		playersDropdown.Options = append(playersDropdown.Options, label)
 	}
-	playersWin.Refresh()
+	playersDropdown.Selected = -1
+	playersDropdown.Text = fmt.Sprintf("Players (%d)", len(playersDropdown.Options))
 }

--- a/ui.go
+++ b/ui.go
@@ -294,22 +294,6 @@ func initUI() {
 	inventoryWin.Open = false
 	inventoryWin.AddWindow(false)
 
-	playersWin = eui.NewWindow(&eui.WindowData{
-		Title:     "Players",
-		Open:      false,
-		Closable:  false,
-		Resizable: false,
-		AutoSize:  false,
-		Movable:   true,
-		Size:      eui.Point{X: 128, Y: 384},
-	})
-	playersList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
-	playersWin.AddItem(playersList)
-	playersWin.Open = false
-	playersWin.AddWindow(false)
-	playersWin.Resizable = true
-	playersWin.AutoSize = true
-
 	helpWin = eui.NewWindow(&eui.WindowData{
 		Title:     "Help",
 		Open:      false,
@@ -340,16 +324,14 @@ func initUI() {
 		FlowType: eui.FLOW_HORIZONTAL,
 		PinTo:    eui.PIN_BOTTOM_RIGHT,
 	}
-	playersBtn, playersEvents := eui.NewButton(&eui.ItemData{Text: "Players", Size: eui.Point{X: 128, Y: 24}, FontSize: 18})
+	playersDropdown, playersEvents := eui.NewDropdown(&eui.ItemData{Text: "Players", Size: eui.Point{X: 128, Y: 24}, FontSize: 18})
 	playersEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			playersWin.Open = !playersWin.Open
-			if playersWin.Open {
-				updatePlayersWindow()
-			}
+		if ev.Type == eui.EventDropdownSelected {
+			// placeholder for future actions on selection
 		}
 	}
-	overlay.AddItem(playersBtn)
+	overlay.AddItem(playersDropdown)
+	updatePlayersDropdown()
 
 	invBtn, invEvents := eui.NewButton(&eui.ItemData{Text: "Inventory", Size: eui.Point{X: 128, Y: 24}, FontSize: 18})
 	invEvents.Handle = func(ev eui.UIEvent) {


### PR DESCRIPTION
## Summary
- replace standalone players window with a bottom-right dropdown menu listing players
- refresh player list when backend info, share, who or appearance updates arrive

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689364c71b10832abb742ab8afca465f