### PR TITLE
Revamp login UI with character selection and connecting window

### DIFF
--- a/login.go
+++ b/login.go
@@ -156,13 +156,18 @@ func login(ctx context.Context, clientVersion int) {
 				}
 			}
 		}
-		if pass == "" && !demo {
+		if pass == "" && passHash == "" && !demo {
 			fmt.Print("enter character password: ")
 			fmt.Scanln(&pass)
 		}
 		playerName = name
 
-		answer, err := answerChallenge(pass, challenge)
+		var answer []byte
+		if pass != "" {
+			answer, err = answerChallenge(pass, challenge)
+		} else {
+			answer, err = answerChallengeHash(passHash, challenge)
+		}
 		if err != nil {
 			log.Fatalf("hash: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -20,22 +20,24 @@ var (
 	denoise  bool
 	dataDir  string
 
-	host         string
-	name         string
-	account      string
-	accountPass  string
-	pass         string
-	demo         bool
-	clmov        string
-	baseDir      string
-	soundTest    bool
-	fastSound    bool
-	fastBars     bool
-	maxSounds    int
-	nightLevel   int
-	blendRate    float64
-	blockSound   bool
-	blockBubbles bool
+	host          string
+	name          string
+	account       string
+	accountPass   string
+	pass          string
+	passHash      string
+	demo          bool
+	clmov         string
+	baseDir       string
+	soundTest     bool
+	fastSound     bool
+	fastBars      bool
+	maxSounds     int
+	nightLevel    int
+	blendRate     float64
+	blockSound    bool
+	blockBubbles  bool
+	clientVersion int
 )
 
 func main() {
@@ -47,6 +49,7 @@ func main() {
 	flag.IntVar(&debugPacketDumpLen, "debug-packet-bytes", 256, "max bytes of packet payload to log (0=all)")
 	flag.IntVar(&maxSounds, "maxSounds", 32, "maximum number of simultaneous sounds")
 	flag.Parse()
+	clientVersion = *clientVer
 
 	baseDir = os.Getenv("PWD")
 	if baseDir == "" {


### PR DESCRIPTION
## Summary
- Replace manual credential fields with a character list using radio buttons and a connect button
- Add an “Add Character” dialog and a cancelable “Connecting…” window
- Support logging in using stored password hashes

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68940d97e6bc832aa1ef03db5d8e195c