### PR TITLE
Refactor window lifecycle to add/remove on toggle

### DIFF
--- a/input_ui.go
+++ b/input_ui.go
@@ -6,9 +6,6 @@ import "github.com/Distortions81/EUI/eui"
 func pointInUI(x, y int) bool {
 	fx, fy := float32(x), float32(y)
 	for _, win := range eui.Windows() {
-		if !win.Open {
-			continue
-		}
 		pos := win.GetPos()
 		size := win.GetSize()
 		if fx >= pos.X && fx < pos.X+size.X && fy >= pos.Y && fy < pos.Y+size.Y {


### PR DESCRIPTION
## Summary
- Switch UI window management to remove and recreate windows instead of flipping an `Open` flag
- Update hit testing to consider only active windows
- Add utility functions to open or close specific windows on demand

## Testing
- `go build ./...`
- `go test ./...` *(fails: "DISPLAY environment variable is missing")*

------
https://chatgpt.com/codex/tasks/task_e_68941255243c832a892c1490a2445bed