### PR TITLE
Remember last character selection

### DIFF
--- a/characters.go
+++ b/characters.go
@@ -50,11 +50,15 @@ func rememberCharacter(name, pass string) {
 		if characters[i].Name == name {
 			characters[i].PassHash = hash
 			saveCharacters()
+			lastCharacter = name
+			saveSettings()
 			return
 		}
 	}
 	characters = append(characters, Character{Name: name, PassHash: hash})
 	saveCharacters()
+	lastCharacter = name
+	saveSettings()
 }
 
 // removeCharacter deletes a stored character by name.
@@ -63,6 +67,10 @@ func removeCharacter(name string) {
 		if c.Name == name {
 			characters = append(characters[:i], characters[i+1:]...)
 			saveCharacters()
+			if lastCharacter == name {
+				lastCharacter = ""
+				saveSettings()
+			}
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	accountPass   string
 	pass          string
 	passHash      string
+	lastCharacter string
 	demo          bool
 	clmov         string
 	baseDir       string

--- a/settings.go
+++ b/settings.go
@@ -27,6 +27,7 @@ type Settings struct {
 	HideMoving     bool    `json:"hideMoving"`
 	HideMobiles    bool    `json:"hideMobiles"`
 	KeyWalkSpeed   float64 `json:"keyWalkSpeed"`
+	LastCharacter  string  `json:"lastCharacter"`
 }
 
 var settingsDirty bool
@@ -61,6 +62,7 @@ func loadSettings() bool {
 	if keyWalkSpeed == 0 {
 		keyWalkSpeed = 0.5
 	}
+	lastCharacter = s.LastCharacter
 	return true
 }
 
@@ -95,6 +97,7 @@ func saveSettings() {
 		HideMoving:     hideMoving,
 		HideMobiles:    hideMobiles,
 		KeyWalkSpeed:   keyWalkSpeed,
+		LastCharacter:  lastCharacter,
 	}
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {

--- a/ui.go
+++ b/ui.go
@@ -87,6 +87,21 @@ func updateCharacterButtons() {
 	if charactersList == nil {
 		return
 	}
+	if name == "" {
+		if lastCharacter != "" {
+			for _, c := range characters {
+				if c.Name == lastCharacter {
+					name = c.Name
+					passHash = c.PassHash
+					break
+				}
+			}
+		}
+		if name == "" && len(characters) == 1 {
+			name = characters[0].Name
+			passHash = characters[0].PassHash
+		}
+	}
 	charactersList.Contents = charactersList.Contents[:0]
 	if len(characters) == 0 {
 		empty, _ := eui.NewText(&eui.ItemData{Text: "empty", Size: eui.Point{X: 160, Y: 24}})
@@ -111,6 +126,8 @@ func updateCharacterButtons() {
 				if ev.Type == eui.EventRadioSelected {
 					name = nameCopy
 					passHash = hashCopy
+					lastCharacter = nameCopy
+					saveSettings()
 				}
 			}
 			row.AddItem(radio)
@@ -185,6 +202,8 @@ func openAddCharacterWindow() {
 			}
 			name = addCharName
 			passHash = hash
+			lastCharacter = addCharName
+			saveSettings()
 			updateCharacterButtons()
 			if loginWin != nil {
 				loginWin.Refresh()
@@ -289,6 +308,8 @@ func openLoginWindow() {
 			if name == "" {
 				return
 			}
+			lastCharacter = name
+			saveSettings()
 			loginWin.RemoveWindow()
 			loginWin = nil
 			openConnectingWindow()


### PR DESCRIPTION
## Summary
- Persist and load the last used character in settings
- Default to last used or single character in login UI
- Save last selection when adding or selecting characters

## Testing
- `go test ./...` *(fails: glfw DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894183e67b4832a881cf6beec1d362b