### PR TITLE
Adjust bubble position when no target

### DIFF
--- a/game.go
+++ b/game.go
@@ -174,7 +174,13 @@ func captureDrawSnapshot() drawSnapshot {
 				if !b.Far {
 					if m, ok := state.mobiles[b.Index]; ok {
 						b.H, b.V = m.H, m.V
+					} else {
+						b.H -= int16(state.picShiftX)
+						b.V -= int16(state.picShiftY)
 					}
+				} else {
+					b.H -= int16(state.picShiftX)
+					b.V -= int16(state.picShiftY)
 				}
 				kept = append(kept, b)
 			}


### PR DESCRIPTION
## Summary
- move speech bubbles without a mobile target by the current picture shift so they stay aligned with the scene

## Testing
- `go test` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894e6e9fe6c832a9f2e54b501864b55