### PR TITLE
Apply high-pass filter to reduce 8-bit audio DC offset

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -202,6 +202,23 @@ func lowpassIIR16(x []int16, alpha float64) {
 	}
 }
 
+// highpassIIR16 removes DC offset using a simple one-pole high-pass filter.
+// alpha should be close to 1.0 (e.g. 0.995) to only filter very low
+// frequencies while leaving the audible band intact.
+func highpassIIR16(x []int16, alpha float64) {
+	if len(x) == 0 {
+		return
+	}
+	var prevIn, prevOut float64
+	for i := range x {
+		in := float64(x[i])
+		out := alpha * (prevOut + in - prevIn)
+		x[i] = int16(math.Round(out))
+		prevIn = in
+		prevOut = out
+	}
+}
+
 // loadSound retrieves a sound by ID, resamples it to match the audio context's
 // sample rate, and caches the resulting PCM bytes. The CL_Sounds archive is
 // opened on first use and individual sounds are parsed lazily.
@@ -249,6 +266,7 @@ func loadSound(id uint16) []byte {
 		if !gs.FastSound {
 			samples = u8ToS16TPDF(s.Data, 0xC0FFEE)
 			lowpassIIR16(samples, 0.5)
+			highpassIIR16(samples, 0.995)
 		} else {
 			samples = make([]int16, len(s.Data))
 			for i, b := range s.Data {


### PR DESCRIPTION
## Summary
- add one-pole high-pass filter to remove DC offset from converted 8-bit audio
- run the filter after dithering and low-pass smoothing for cleaner playback

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_689508ce3310832a81efcabd9b9197f5