### PR TITLE
Show cache usage in debug menu

### DIFF
--- a/game.go
+++ b/game.go
@@ -227,6 +227,7 @@ type Game struct{}
 
 func (g *Game) Update() error {
 	eui.Update()
+	updateDebugStats()
 
 	if settingsDirty {
 		saveSettings()

--- a/images.go
+++ b/images.go
@@ -138,3 +138,33 @@ func loadMobileFrame(id uint16, state uint8, colors []byte) *ebiten.Image {
 	imageMu.Unlock()
 	return frame
 }
+
+// imageCacheStats returns the counts and approximate memory usage in bytes for
+// each of the image caches: sheetCache, imageCache, and mobileCache.
+func imageCacheStats() (sheetCount, sheetBytes, frameCount, frameBytes, mobileCount, mobileBytes int) {
+	imageMu.Lock()
+	defer imageMu.Unlock()
+
+	for _, img := range sheetCache {
+		if img != nil {
+			sheetCount++
+			b := img.Bounds()
+			sheetBytes += b.Dx() * b.Dy() * 4
+		}
+	}
+	for _, img := range imageCache {
+		if img != nil {
+			frameCount++
+			b := img.Bounds()
+			frameBytes += b.Dx() * b.Dy() * 4
+		}
+	}
+	for _, img := range mobileCache {
+		if img != nil {
+			mobileCount++
+			b := img.Bounds()
+			mobileBytes += b.Dx() * b.Dy() * 4
+		}
+	}
+	return
+}

--- a/sound.go
+++ b/sound.go
@@ -328,3 +328,16 @@ func loadSound(id uint16) []byte {
 	soundMu.Unlock()
 	return pcm
 }
+
+// soundCacheStats returns the number of cached sounds and total bytes used.
+func soundCacheStats() (count, bytes int) {
+	soundMu.Lock()
+	defer soundMu.Unlock()
+	for _, pcm := range pcmCache {
+		if pcm != nil {
+			count++
+			bytes += len(pcm)
+		}
+	}
+	return
+}

--- a/ui.go
+++ b/ui.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -21,6 +22,13 @@ var addCharPass string
 var addCharRemember bool
 var chatFontSize = 12
 var labelFontSize = 12
+
+var (
+	sheetCacheLabel  *eui.ItemData
+	frameCacheLabel  *eui.ItemData
+	mobileCacheLabel *eui.ItemData
+	soundCacheLabel  *eui.ItemData
+)
 
 func initUI() {
 	status, err := checkDataFiles(dataDir, clientVersion)
@@ -661,8 +669,48 @@ func openDebugWindow() {
 	}
 	debugFlow.AddItem(smoothinCB)
 
+	sheetCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	debugFlow.AddItem(sheetCacheLabel)
+
+	frameCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	debugFlow.AddItem(frameCacheLabel)
+
+	mobileCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	debugFlow.AddItem(mobileCacheLabel)
+
+	soundCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	debugFlow.AddItem(soundCacheLabel)
+
 	debugWin.AddItem(debugFlow)
 	debugWin.AddWindow(false)
+	updateDebugStats()
+}
+
+// updateDebugStats refreshes the cache statistics displayed in the debug window.
+func updateDebugStats() {
+	if debugWin == nil {
+		return
+	}
+
+	sheetCount, sheetBytes, frameCount, frameBytes, mobileCount, mobileBytes := imageCacheStats()
+	soundCount, soundBytes := soundCacheStats()
+
+	if sheetCacheLabel != nil {
+		sheetCacheLabel.Text = fmt.Sprintf("Sheets: %d (%d bytes)", sheetCount, sheetBytes)
+		sheetCacheLabel.Dirty = true
+	}
+	if frameCacheLabel != nil {
+		frameCacheLabel.Text = fmt.Sprintf("Frames: %d (%d bytes)", frameCount, frameBytes)
+		frameCacheLabel.Dirty = true
+	}
+	if mobileCacheLabel != nil {
+		mobileCacheLabel.Text = fmt.Sprintf("Mobiles: %d (%d bytes)", mobileCount, mobileBytes)
+		mobileCacheLabel.Dirty = true
+	}
+	if soundCacheLabel != nil {
+		soundCacheLabel.Text = fmt.Sprintf("Sounds: %d (%d bytes)", soundCount, soundBytes)
+		soundCacheLabel.Dirty = true
+	}
 }
 
 func openInventoryWindow() {


### PR DESCRIPTION
## Summary
- add cache statistics for images and sounds to debug window
- update cache stats each frame in game loop

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68950e4f1458832abaa2cf120f10ad5b