### PR TITLE
Apply selective denoising filter

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func clearCaches() {
+	imageMu.Lock()
+	imageCache = make(map[string]*ebiten.Image)
+	sheetCache = make(map[string]*ebiten.Image)
+	mobileCache = make(map[string]*ebiten.Image)
+	imageMu.Unlock()
+
+	pixelCountMu.Lock()
+	pixelCountCache = make(map[uint16]int)
+	pixelCountMu.Unlock()
+
+	soundMu.Lock()
+	pcmCache = make(map[uint16][]byte)
+	soundMu.Unlock()
+
+	if clImages != nil {
+		clImages.ClearCache()
+	}
+	if clSounds != nil {
+		clSounds.ClearCache()
+	}
+
+	poolMu.Lock()
+	imgPool = make(map[int][]*ebiten.Image)
+	poolMu.Unlock()
+}

--- a/climg/climg.go
+++ b/climg/climg.go
@@ -489,6 +489,13 @@ func (c *CLImages) NumFrames(id uint32) int {
 	return 1
 }
 
+// ClearCache removes all cached images so they will be reloaded on demand.
+func (c *CLImages) ClearCache() {
+	c.mu.Lock()
+	c.cache = make(map[string]*ebiten.Image)
+	c.mu.Unlock()
+}
+
 // FrameIndex returns the picture frame for the given global animation counter.
 // If no animation is defined for the image, it returns 0.
 func (c *CLImages) FrameIndex(id uint32, counter int) int {

--- a/climg/denoise.go
+++ b/climg/denoise.go
@@ -5,34 +5,62 @@ import (
 	"image/color"
 )
 
-// denoiseImage applies a simple 3x3 box blur to reduce dithering artifacts.
+// denoiseImage smooths pixels that have uniformly coloured neighbours.
+// Pixels surrounded by similar colours are averaged with a 3x3 box filter,
+// while edge pixels remain unchanged.
 func denoiseImage(img *image.RGBA) {
 	bounds := img.Bounds()
 	w, h := bounds.Dx(), bounds.Dy()
-	dst := image.NewRGBA(bounds)
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			var r, g, b, a, count int
-			for dy := -1; dy <= 1; dy++ {
-				ny := y + dy
-				if ny < 0 || ny >= h {
-					continue
-				}
+
+	// Work on a copy so neighbour checks aren't affected by in-place writes.
+	src := image.NewRGBA(bounds)
+	copy(src.Pix, img.Pix)
+
+	// Collect points that require filtering and apply the blur after the scan.
+	var toFilter []image.Point
+	for y := 1; y < h-1; y++ {
+		for x := 1; x < w-1; x++ {
+			center := src.RGBAAt(x, y)
+
+			// Ensure all neighbouring pixels are similar to the centre pixel.
+			similar := true
+			for dy := -1; dy <= 1 && similar; dy++ {
 				for dx := -1; dx <= 1; dx++ {
-					nx := x + dx
-					if nx < 0 || nx >= w {
+					if dx == 0 && dy == 0 {
 						continue
 					}
-					off := img.PixOffset(nx, ny)
-					r += int(img.Pix[off])
-					g += int(img.Pix[off+1])
-					b += int(img.Pix[off+2])
-					a += int(img.Pix[off+3])
-					count++
+					if colourDist(src.RGBAAt(x+dx, y+dy), center) > 64 {
+						similar = false
+						break
+					}
 				}
 			}
-			dst.SetRGBA(x, y, color.RGBA{uint8(r / count), uint8(g / count), uint8(b / count), uint8(a / count)})
+			if similar {
+				toFilter = append(toFilter, image.Point{X: x, Y: y})
+			}
 		}
 	}
-	copy(img.Pix, dst.Pix)
+
+	for _, p := range toFilter {
+		var r, g, b, a, count int
+		for dy := -1; dy <= 1; dy++ {
+			for dx := -1; dx <= 1; dx++ {
+				c := src.RGBAAt(p.X+dx, p.Y+dy)
+				r += int(c.R)
+				g += int(c.G)
+				b += int(c.B)
+				a += int(c.A)
+				count++
+			}
+		}
+		img.SetRGBA(p.X, p.Y, color.RGBA{uint8(r / count), uint8(g / count), uint8(b / count), uint8(a / count)})
+	}
+}
+
+// colourDist returns the squared Euclidean distance between two colours.
+func colourDist(a, b color.RGBA) int {
+	dr := int(a.R) - int(b.R)
+	dg := int(a.G) - int(b.G)
+	db := int(a.B) - int(b.B)
+	return dr*dr + dg*dg + db*db
 }

--- a/clsnd/clsnd.go
+++ b/clsnd/clsnd.go
@@ -102,6 +102,13 @@ func (c *CLSounds) Get(id uint32) *Sound {
 	return s
 }
 
+// ClearCache discards all decoded sound data.
+func (c *CLSounds) ClearCache() {
+	c.mu.Lock()
+	c.cache = make(map[uint32]*Sound)
+	c.mu.Unlock()
+}
+
 // soundHeaderOffset locates the SoundHeader inside a 'snd ' resource.
 func soundHeaderOffset(data []byte) (int, bool) {
 	if len(data) < 6 {

--- a/main.go
+++ b/main.go
@@ -77,11 +77,14 @@ func main() {
 	clImages, imgErr = climg.Load(filepath.Join(dataDir, "CL_Images"))
 	if imgErr != nil {
 		addMessage(fmt.Sprintf("load CL_Images: %v", imgErr))
+	} else if clImages != nil {
+		clImages.Denoise = gs.DenoiseImages
 	}
 	if imgErr != nil && clmovPath != "" {
 		alt := filepath.Join(filepath.Dir(clmovPath), "CL_Images")
 		if imgs, err := climg.Load(alt); err == nil {
 			clImages = imgs
+			clImages.Denoise = gs.DenoiseImages
 			imgErr = nil
 		} else {
 			addMessage(fmt.Sprintf("load CL_Images from %v: %v", alt, err))

--- a/settings.go
+++ b/settings.go
@@ -26,6 +26,7 @@ var gs settings = settings{
 	BlendMobiles:    false,
 	BlendPicts:      true,
 	BlendAmount:     1.0,
+	DenoiseImages:   true,
 	Scale:           2,
 
 	vsync: true,
@@ -48,6 +49,7 @@ type settings struct {
 	BlendMobiles     bool
 	BlendPicts       bool
 	BlendAmount      float64
+	DenoiseImages    bool
 	TextureFiltering bool
 	FastSound        bool
 	Scale            int
@@ -78,6 +80,9 @@ func loadSettings() bool {
 }
 
 func applySettings() {
+	if clImages != nil {
+		clImages.Denoise = gs.DenoiseImages
+	}
 	if gs.TextureFiltering {
 		drawFilter = ebiten.FilterLinear
 	} else {

--- a/ui.go
+++ b/ui.go
@@ -137,6 +137,8 @@ func openDownloadsWindow(status dataFilesStatus) {
 				}
 				if imgs, err := climg.Load(filepath.Join(dataDir, "CL_Images")); err == nil {
 					clImages = imgs
+					clImages.Denoise = gs.DenoiseImages
+					clearCaches()
 				} else {
 					logError("load CL_Images: %v", err)
 					openErrorWindow("Error: Load CL_Images: " + err.Error())
@@ -499,6 +501,19 @@ func openSettingsWindow() {
 		}
 	}
 	mainFlow.AddItem(filt)
+
+	denoiseCB, denoiseEvents := eui.NewCheckbox(&eui.ItemData{Text: "Image Denoise", Size: eui.Point{X: width, Y: 24}, Checked: gs.DenoiseImages})
+	denoiseEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.DenoiseImages = ev.Checked
+			if clImages != nil {
+				clImages.Denoise = ev.Checked
+			}
+			clearCaches()
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(denoiseCB)
 
 	motion, motionEvents := eui.NewCheckbox(&eui.ItemData{Text: "Smooth Motion", Size: eui.Point{X: width, Y: 24}, Checked: gs.MotionSmoothing})
 	motionEvents.Handle = func(ev eui.UIEvent) {


### PR DESCRIPTION
## Summary
- Add `DenoiseImages` setting and default to enable optional image denoising
- Provide UI checkbox that clears caches when toggled
- Centralize cache clearing across images and sounds with new helper methods

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689509046238832ab123cd2cf6128329