### PR TITLE
Use human-readable cache sizes in debug window

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/hajimehoshi/ebiten/v2 v2.8.8
 
 require (
 	github.com/Distortions81/EUI v0.0.7
+	github.com/dustin/go-humanize v1.0.1
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	golang.org/x/crypto v0.40.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Distortions81/EUI v0.0.7 h1:ByH68JTDbGUZxtMTI7fgb8aZZveVQDMog+w6vqDWxpk=
 github.com/Distortions81/EUI v0.0.7/go.mod h1:F0FHVUCQx+BIHYATuNO/ToGZfBtL+Kp7uHnFhc/2HEE=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/gomobile v0.0.0-20250329061421-6d0a8e981e4c h1:Ccgks2VROTr6bIm1FFxG2jT6P1DaCBMj8g/O9xbOQ08=
 github.com/ebitengine/gomobile v0.0.0-20250329061421-6d0a8e981e4c/go.mod h1:M6DDA2RbegvWBVv4Dq482lwyFTtMczT1A7UNm1qOYzY=
 github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=

--- a/ui.go
+++ b/ui.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/Distortions81/EUI/eui"
+	"github.com/dustin/go-humanize"
 	"github.com/hajimehoshi/ebiten/v2"
 
 	"go_client/climg"
@@ -696,19 +697,19 @@ func updateDebugStats() {
 	soundCount, soundBytes := soundCacheStats()
 
 	if sheetCacheLabel != nil {
-		sheetCacheLabel.Text = fmt.Sprintf("Sheets: %d (%d bytes)", sheetCount, sheetBytes)
+		sheetCacheLabel.Text = fmt.Sprintf("Sheets: %d (%s)", sheetCount, humanize.Bytes(uint64(sheetBytes)))
 		sheetCacheLabel.Dirty = true
 	}
 	if frameCacheLabel != nil {
-		frameCacheLabel.Text = fmt.Sprintf("Frames: %d (%d bytes)", frameCount, frameBytes)
+		frameCacheLabel.Text = fmt.Sprintf("Frames: %d (%s)", frameCount, humanize.Bytes(uint64(frameBytes)))
 		frameCacheLabel.Dirty = true
 	}
 	if mobileCacheLabel != nil {
-		mobileCacheLabel.Text = fmt.Sprintf("Mobiles: %d (%d bytes)", mobileCount, mobileBytes)
+		mobileCacheLabel.Text = fmt.Sprintf("Mobiles: %d (%s)", mobileCount, humanize.Bytes(uint64(mobileBytes)))
 		mobileCacheLabel.Dirty = true
 	}
 	if soundCacheLabel != nil {
-		soundCacheLabel.Text = fmt.Sprintf("Sounds: %d (%d bytes)", soundCount, soundBytes)
+		soundCacheLabel.Text = fmt.Sprintf("Sounds: %d (%s)", soundCount, humanize.Bytes(uint64(soundBytes)))
 		soundCacheLabel.Dirty = true
 	}
 }


### PR DESCRIPTION
## Summary
- Format debug cache byte counts with humanize to display human-friendly sizes
- Add go-humanize dependency

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_689512b8dab4832abea78eb10b00ed68