### PR TITLE
Add option to precache sounds and sprites

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"log"
+	"path/filepath"
+
 	"github.com/hajimehoshi/ebiten/v2"
+
+	"go_client/clsnd"
 )
 
 func clearCaches() {
@@ -29,4 +34,29 @@ func clearCaches() {
 	poolMu.Lock()
 	imgPool = make(map[int][]*ebiten.Image)
 	poolMu.Unlock()
+}
+
+func precacheAssets() {
+	if clImages != nil {
+		for _, id := range clImages.IDs() {
+			loadSheet(uint16(id), nil, false)
+		}
+	}
+
+	soundMu.Lock()
+	if clSounds == nil {
+		snds, err := clsnd.Load(filepath.Join(dataDir, "CL_Sounds"))
+		if err != nil {
+			log.Printf("load CL_Sounds: %v", err)
+		} else {
+			clSounds = snds
+		}
+	}
+	soundMu.Unlock()
+
+	if clSounds != nil {
+		for _, id := range clSounds.IDs() {
+			loadSound(uint16(id))
+		}
+	}
 }

--- a/climg/climg.go
+++ b/climg/climg.go
@@ -537,3 +537,12 @@ func (c *CLImages) Plane(id uint32) int {
 	}
 	return 0
 }
+
+// IDs returns all image identifiers present in the archive.
+func (c *CLImages) IDs() []uint32 {
+	ids := make([]uint32, 0, len(c.idrefs))
+	for id := range c.idrefs {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/clsnd/clsnd.go
+++ b/clsnd/clsnd.go
@@ -109,6 +109,15 @@ func (c *CLSounds) ClearCache() {
 	c.mu.Unlock()
 }
 
+// IDs returns all sound identifiers present in the archive.
+func (c *CLSounds) IDs() []uint32 {
+	ids := make([]uint32, 0, len(c.index))
+	for id := range c.index {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 // soundHeaderOffset locates the SoundHeader inside a 'snd ' resource.
 func soundHeaderOffset(data []byte) (int, bool) {
 	if len(data) < 6 {

--- a/main.go
+++ b/main.go
@@ -108,6 +108,10 @@ func main() {
 		return
 	}
 
+	if gs.PrecacheAssets {
+		go precacheAssets()
+	}
+
 	<-ctx.Done()
 }
 

--- a/settings.go
+++ b/settings.go
@@ -27,6 +27,7 @@ var gs settings = settings{
 	BlendPicts:      true,
 	BlendAmount:     1.0,
 	DenoiseImages:   true,
+	PrecacheAssets:  true,
 	Scale:           2,
 
 	vsync: true,
@@ -50,6 +51,7 @@ type settings struct {
 	BlendPicts       bool
 	BlendAmount      float64
 	DenoiseImages    bool
+	PrecacheAssets   bool
 	TextureFiltering bool
 	FastSound        bool
 	Scale            int

--- a/ui.go
+++ b/ui.go
@@ -578,6 +578,15 @@ func openSettingsWindow() {
 	}
 	mainFlow.AddItem(fastSound)
 
+	precacheCB, precacheEvents := eui.NewCheckbox(&eui.ItemData{Text: "Precache Sounds and Sprites", Size: eui.Point{X: width, Y: 24}, Checked: gs.PrecacheAssets})
+	precacheEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.PrecacheAssets = ev.Checked
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(precacheCB)
+
 	blendSlider, blendEvents := eui.NewSlider(&eui.ItemData{Label: "Blend Amount", MinValue: 0.3, MaxValue: 1.0, Value: float32(gs.BlendAmount), Size: eui.Point{X: width - 10, Y: 24}})
 	blendEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {


### PR DESCRIPTION
## Summary
- add PrecacheAssets setting and default to load all sound and sprite resources
- expose "Precache Sounds and Sprites" toggle in settings UI and implement logic to cache assets

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68951f0555bc832aa22a67cbdaf695da