### PR TITLE
chore: optimize build script

### DIFF
--- a/scripts/build_binaries.sh
+++ b/scripts/build_binaries.sh
@@ -29,9 +29,14 @@ for platform in "${platforms[@]}"; do
     CGO_ENABLED=0  # Disable cgo for unsupported cross-compilation targets
   fi
 
-  # Build binary
+  # Build binary with optimization flags to reduce size and speed up execution
   env GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED="$CGO_ENABLED" \
-    go build -o "${OUTPUT_DIR}/${BIN_NAME}" .
+    go build \
+      -trimpath \
+      -buildvcs=false \
+      -gcflags="all=-d=checkptr=0" \
+      -ldflags="-s -w -buildid=" \
+      -o "${OUTPUT_DIR}/${BIN_NAME}" .
 
   # Zip it
   echo "Zipping ${BIN_NAME}..."


### PR DESCRIPTION
## Summary
- add multiple optimization flags to go build to create faster binaries

## Testing
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -trimpath -buildvcs=false -gcflags "all=-d=checkptr=0" -ldflags "-s -w -buildid=" -o /tmp/thoomspeak .`


------
https://chatgpt.com/codex/tasks/task_e_6895204cc6e4832a8098b6fa69e2f5a8