### PR TITLE
Add FPS toggle and display during movie playback

### DIFF
--- a/game.go
+++ b/game.go
@@ -351,7 +351,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		drawInputOverlay(screen, string(inputText))
 	}
 	drawStatusBars(screen, snap, alpha)
-	drawServerFPS(screen, serverFPS)
+	if gs.ShowFPS {
+		drawServerFPS(screen, serverFPS)
+	}
 }
 
 // drawScene renders all world objects for the current frame.

--- a/movie_player.go
+++ b/movie_player.go
@@ -29,6 +29,7 @@ type moviePlayer struct {
 
 func newMoviePlayer(frames [][]byte, fps int, cancel context.CancelFunc) *moviePlayer {
 	setInterpFPS(fps)
+	serverFPS = float64(fps)
 	return &moviePlayer{
 		frames:  frames,
 		fps:     fps,
@@ -242,6 +243,7 @@ func (p *moviePlayer) setFPS(fps int) {
 	p.fps = fps
 	p.ticker.Reset(time.Second / time.Duration(p.fps))
 	setInterpFPS(p.fps)
+	serverFPS = float64(p.fps)
 	p.updateUI()
 }
 

--- a/settings.go
+++ b/settings.go
@@ -28,6 +28,7 @@ var gs settings = settings{
 	BlendAmount:     1.0,
 	DenoiseImages:   true,
 	PrecacheAssets:  true,
+	ShowFPS:         true,
 	Scale:           2,
 
 	vsync: true,
@@ -52,6 +53,7 @@ type settings struct {
 	BlendAmount      float64
 	DenoiseImages    bool
 	PrecacheAssets   bool
+	ShowFPS          bool
 	TextureFiltering bool
 	FastSound        bool
 	Scale            int

--- a/ui.go
+++ b/ui.go
@@ -587,6 +587,15 @@ func openSettingsWindow() {
 	}
 	mainFlow.AddItem(precacheCB)
 
+	showFPSCB, showFPSEvents := eui.NewCheckbox(&eui.ItemData{Text: "Show FPS", Size: eui.Point{X: width, Y: 24}, Checked: gs.ShowFPS})
+	showFPSEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.ShowFPS = ev.Checked
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(showFPSCB)
+
 	blendSlider, blendEvents := eui.NewSlider(&eui.ItemData{Label: "Blend Amount", MinValue: 0.3, MaxValue: 1.0, Value: float32(gs.BlendAmount), Size: eui.Point{X: width - 10, Y: 24}})
 	blendEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {


### PR DESCRIPTION
## Summary
- allow turning FPS display on/off via new Show FPS setting
- show FPS/UPS overlay when playing clMov movies

## Testing
- `apt-get update`
- `apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev libasound2-dev`
- `go build ./... && echo build-success`

------
https://chatgpt.com/codex/tasks/task_e_6895241cf824832a8824a7933acc37da