### PR TITLE
Add low memory mode to disable asset caching

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -37,6 +37,9 @@ func clearCaches() {
 }
 
 func precacheAssets() {
+	if gs.LowMemory {
+		return
+	}
 	if clImages != nil {
 		for _, id := range clImages.IDs() {
 			loadSheet(uint16(id), nil, false)
@@ -49,6 +52,7 @@ func precacheAssets() {
 		if err != nil {
 			log.Printf("load CL_Sounds: %v", err)
 		} else {
+			snds.NoCache = gs.LowMemory
 			clSounds = snds
 		}
 	}

--- a/imgpool.go
+++ b/imgpool.go
@@ -29,6 +29,9 @@ func nextPow2(n int) int {
 // The image is cleared before being returned.
 func getTempImage(size int) *ebiten.Image {
 	s := nextPow2(size)
+	if gs.LowMemory {
+		return ebiten.NewImage(s, s)
+	}
 	poolMu.Lock()
 	defer poolMu.Unlock()
 	pool := imgPool[s]
@@ -46,6 +49,9 @@ func getTempImage(size int) *ebiten.Image {
 // recycleTempImage returns an image to the pool for reuse.
 func recycleTempImage(img *ebiten.Image) {
 	if img == nil {
+		return
+	}
+	if gs.LowMemory {
 		return
 	}
 	s := img.Bounds().Dx()

--- a/main.go
+++ b/main.go
@@ -104,19 +104,21 @@ func main() {
 		addMessage(fmt.Sprintf("load CL_Images: %v", imgErr))
 	} else if clImages != nil {
 		clImages.Denoise = gs.DenoiseImages
+		clImages.NoCache = gs.LowMemory
 	}
 	if imgErr != nil && clmovPath != "" {
 		alt := filepath.Join(filepath.Dir(clmovPath), "CL_Images")
 		if imgs, err := climg.Load(alt); err == nil {
 			clImages = imgs
 			clImages.Denoise = gs.DenoiseImages
+			clImages.NoCache = gs.LowMemory
 			imgErr = nil
 		} else {
 			addMessage(fmt.Sprintf("load CL_Images from %v: %v", alt, err))
 		}
 	}
 
-	if gs.PrecacheAssets {
+	if gs.PrecacheAssets && !gs.LowMemory {
 		go precacheAssets()
 	}
 

--- a/settings.go
+++ b/settings.go
@@ -28,6 +28,7 @@ var gs settings = settings{
 	BlendAmount:     1.0,
 	DenoiseImages:   true,
 	PrecacheAssets:  true,
+	LowMemory:       false,
 	Scale:           2,
 
 	vsync: true,
@@ -54,6 +55,7 @@ type settings struct {
 	PrecacheAssets   bool
 	TextureFiltering bool
 	FastSound        bool
+	LowMemory        bool
 	Scale            int
 
 	imgPlanesDebug bool
@@ -84,6 +86,13 @@ func loadSettings() bool {
 func applySettings() {
 	if clImages != nil {
 		clImages.Denoise = gs.DenoiseImages
+		clImages.NoCache = gs.LowMemory
+	}
+	if clSounds != nil {
+		clSounds.NoCache = gs.LowMemory
+	}
+	if gs.LowMemory {
+		gs.PrecacheAssets = false
 	}
 	if gs.TextureFiltering {
 		drawFilter = ebiten.FilterLinear


### PR DESCRIPTION
## Summary
- add a Low Memory setting that disables asset precaching and caches
- avoid storing images, sounds, and temporary images when Low Memory is enabled

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895230b95c0832a863929c82078b8b9