### PR TITLE
Avoid ReadPixels panic during PGO movie playback

### DIFF
--- a/game.go
+++ b/game.go
@@ -44,6 +44,7 @@ var debugWin *eui.WindowData
 var gameCtx context.Context
 var drawFilter = ebiten.FilterNearest
 var frameCounter int
+var gameStarted = make(chan struct{})
 
 var (
 	frameCh       = make(chan struct{}, 1)
@@ -865,6 +866,8 @@ func runGame(ctx context.Context) {
 	ebiten.SetVsyncEnabled(gs.vsync)
 	ebiten.SetTPS(ebiten.SyncWithFPS)
 	ebiten.SetCursorShape(ebiten.CursorShapeDefault)
+
+	close(gameStarted)
 
 	if err := ebiten.RunGame(&Game{}); err != nil {
 		log.Printf("ebiten: %v", err)

--- a/movie_player.go
+++ b/movie_player.go
@@ -177,6 +177,7 @@ func (p *moviePlayer) initUI() {
 }
 
 func (p *moviePlayer) run(ctx context.Context) {
+	<-gameStarted
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary
- ensure the game loop signals when it has started
- wait for that signal before processing movie frames

## Testing
- `go build -v ./...`

------
https://chatgpt.com/codex/tasks/task_e_689522741644832a97cb8d99dbf4f76d