### PR TITLE
Log panics to dedicated file in logs directory

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sync"
 	"time"
 )
@@ -94,4 +95,21 @@ func setDebugLogging(enabled bool) {
 	} else {
 		debugLogger = nil
 	}
+}
+
+func logPanic(r interface{}) {
+	logDir := filepath.Join(baseDir, "logs")
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		fmt.Printf("could not create log directory: %v\n", err)
+		return
+	}
+	ts := time.Now().Format("20060102-150405")
+	panicLogPath := filepath.Join(logDir, fmt.Sprintf("panic-%s.log", ts))
+	if f, err := os.Create(panicLogPath); err == nil {
+		defer f.Close()
+		fmt.Fprintf(f, "panic: %v\n%s", r, debug.Stack())
+	} else {
+		fmt.Printf("could not create panic log: %v\n", err)
+	}
+	logError("panic: %v\n%s", r, debug.Stack())
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"runtime/debug"
 	"runtime/pprof"
 	"syscall"
 	"time"
@@ -66,7 +65,7 @@ func main() {
 	setupLogging(debug)
 	defer func() {
 		if r := recover(); r != nil {
-			logError("panic: %v\n%s", r, debug.Stack())
+			logPanic(r)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- add `logPanic` utility to store panic stack traces in `logs/panic-<timestamp>.log`
- use `logPanic` in main to capture unexpected crashes

## Testing
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689543c0a4a8832a98040fd5ec473d39