### PR TITLE
Account for latency in late input updates

### DIFF
--- a/game.go
+++ b/game.go
@@ -939,7 +939,11 @@ func sendInputLoop(ctx context.Context, conn net.Conn) {
 			latencyMu.Lock()
 			lat := netLatency
 			latencyMu.Unlock()
-			delay = (interval*3)/4 - lat
+			// Send the input early enough for the server to receive it
+			// before the next update, adding a 15% safety margin to the
+			// measured latency.
+			adjusted := (lat * 115) / 100
+			delay = interval - adjusted
 			if delay < 0 {
 				delay = 0
 			}


### PR DESCRIPTION
## Summary
- Adjust late input update timing to subtract measured latency with a 15% safety margin so inputs reach the server before the next frame.

## Testing
- `go mod download`
- `go build ./...` *(fails: debug already declared; fmt imported and not used)*

------
https://chatgpt.com/codex/tasks/task_e_689549a0f8e0832aa9e4a50b12e6c4da