### PR TITLE
Show equipped items first in inventory list

### DIFF
--- a/inventory.go
+++ b/inventory.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -91,6 +92,12 @@ func getInventory() []inventoryItem {
 	defer inventoryMu.RUnlock()
 	out := make([]inventoryItem, len(inventoryItems))
 	copy(out, inventoryItems)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Equipped != out[j].Equipped {
+			return out[i].Equipped && !out[j].Equipped
+		}
+		return out[i].Index < out[j].Index
+	})
 	return out
 }
 


### PR DESCRIPTION
## Summary
- sort inventory so equipped items appear before unequipped

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68954d84bfc4832a818fd118a619c7eb