### PR TITLE
Add sentinel name for unknown thinker

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -14,6 +14,9 @@ const (
 	thinkToGroup
 )
 
+// ThinkUnknownName is used when the sender's name can't be parsed.
+const ThinkUnknownName = "someone"
+
 const (
 	bubbleVerbVerbatim    = "\x01"
 	bubbleVerbParentheses = "\x02"
@@ -153,6 +156,7 @@ func parseThinkText(raw []byte, text string) (name string, target thinkTarget, m
 		name = strings.TrimSpace(text[:idx])
 		msg = strings.TrimSpace(text[idx+1:])
 	} else {
+		name = ThinkUnknownName
 		msg = strings.TrimSpace(text)
 	}
 
@@ -167,7 +171,7 @@ func parseThinkText(raw []byte, text string) (name string, target thinkTarget, m
 		}
 	}
 
-	if target == thinkNone && name != "" {
+	if target == thinkNone && name != "" && name != ThinkUnknownName {
 		switch {
 		case strings.HasSuffix(name, " to you"):
 			target = thinkToYou


### PR DESCRIPTION
## Summary
- add exported `ThinkUnknownName` to represent missing thinker name
- use the sentinel when a think message lacks a colon and skip suffix parsing

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689556216758832abcb8c7ffe181bcb2