### PR TITLE
Return to login screen on disconnect

### DIFF
--- a/game.go
+++ b/game.go
@@ -995,6 +995,7 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 				}
 			}
 			logError("udp read error: %v", err)
+			handleDisconnect()
 			return
 		}
 		latencyMu.Lock()
@@ -1040,6 +1041,7 @@ loop:
 				}
 			}
 			logError("read error: %v", err)
+			handleDisconnect()
 			break
 		}
 		tag := binary.BigEndian.Uint16(m[:2])

--- a/ui.go
+++ b/ui.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
@@ -380,7 +381,11 @@ func openLoginWindow() {
 			loginWin.RemoveWindow()
 			loginWin = nil
 			go func() {
-				if err := login(gameCtx, clientVersion); err != nil {
+				ctx, cancel := context.WithCancel(gameCtx)
+				loginMu.Lock()
+				loginCancel = cancel
+				loginMu.Unlock()
+				if err := login(ctx, clientVersion); err != nil {
 					logError("login: %v", err)
 					openErrorWindow("Error: Login: " + err.Error())
 					openLoginWindow()


### PR DESCRIPTION
## Summary
- handle server disconnections by cancelling login context and reopening the login UI
- propagate disconnect events from TCP/UDP loops
- use a cancelable context when logging in

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689557316d24832abc6d2002e79e3f4c