### PR TITLE
Fix sound header parsing for CL_Sounds

### DIFF
--- a/clsnd/clsnd.go
+++ b/clsnd/clsnd.go
@@ -140,7 +140,7 @@ func soundHeaderOffset(data []byte) (int, bool) {
 		}
 		cmd := binary.BigEndian.Uint16(data[p : p+2])
 		off := int(binary.BigEndian.Uint32(data[p+4 : p+8]))
-		if cmd&0x8000 != 0 { // high bit indicates offset form
+		if cmd == 0x8000 { // bufferCmd | dataOffsetFlag
 			return off, true
 		}
 		p += 8

--- a/clsnd/clsnd_test.go
+++ b/clsnd/clsnd_test.go
@@ -1,0 +1,34 @@
+package clsnd
+
+import "testing"
+
+// Test that soundHeaderOffset ignores commands other than bufferCmd when the
+// dataOffsetFlag is set.
+func TestSoundHeaderOffsetSkipsNonBufferCommands(t *testing.T) {
+	data := []byte{
+		0x00, 0x01, // format 1
+		0x00, 0x00, // nMods
+		0x00, 0x02, // nCmds
+		0x80, 0x10, // cmd1: not bufferCmd, high bit set
+		0x00, 0x00, // param1
+		0x00, 0x00, 0x00, 0x00, // param2 (ignored)
+		0x80, 0x00, // cmd2: bufferCmd | dataOffsetFlag
+		0x00, 0x00, // param1
+		0x00, 0x00, 0x00, 0x20, // param2 -> header offset 32
+	}
+	// pad up to offset 32
+	if len(data) < 0x20 {
+		data = append(data, make([]byte, 0x20-len(data))...)
+	}
+	// minimal header at offset 32
+	header := make([]byte, 22)
+	data = append(data, header...)
+
+	off, ok := soundHeaderOffset(data)
+	if !ok {
+		t.Fatalf("soundHeaderOffset returned !ok")
+	}
+	if off != 0x20 {
+		t.Fatalf("got offset %d want 32", off)
+	}
+}


### PR DESCRIPTION
## Summary
- Only treat bufferCmd with dataOffsetFlag as the sound header reference
- Add regression test for soundHeaderOffset when other high-bit commands are present

## Testing
- `go test ./clsnd`
- `go test ./...` (no tests in other packages)


------
https://chatgpt.com/codex/tasks/task_e_68956060de4c832a8d26799deea49a7e