### PR TITLE
Use named buffer command constants

### DIFF
--- a/clsnd/clsnd.go
+++ b/clsnd/clsnd.go
@@ -30,7 +30,9 @@ type CLSounds struct {
 }
 
 const (
-	typeSound = 0x736e6420 // 'snd '
+	typeSound      = 0x736e6420 // 'snd '
+	bufferCmd      = 0x51
+	dataOffsetFlag = 0x8000
 )
 
 // Load parses the CL_Sounds keyfile located at path.
@@ -140,7 +142,7 @@ func soundHeaderOffset(data []byte) (int, bool) {
 		}
 		cmd := binary.BigEndian.Uint16(data[p : p+2])
 		off := int(binary.BigEndian.Uint32(data[p+4 : p+8]))
-		if cmd == 0x8000 { // bufferCmd | dataOffsetFlag
+		if (cmd&dataOffsetFlag) != 0 && (cmd&0x7FFF) == bufferCmd {
 			return off, true
 		}
 		p += 8

--- a/clsnd/clsnd_test.go
+++ b/clsnd/clsnd_test.go
@@ -5,14 +5,16 @@ import "testing"
 // Test that soundHeaderOffset ignores commands other than bufferCmd when the
 // dataOffsetFlag is set.
 func TestSoundHeaderOffsetSkipsNonBufferCommands(t *testing.T) {
+	cmd1 := dataOffsetFlag | 0x10 // not bufferCmd, high bit set
+	cmd2 := dataOffsetFlag | bufferCmd
 	data := []byte{
 		0x00, 0x01, // format 1
 		0x00, 0x00, // nMods
 		0x00, 0x02, // nCmds
-		0x80, 0x10, // cmd1: not bufferCmd, high bit set
+		byte(cmd1 >> 8), byte(cmd1), // cmd1
 		0x00, 0x00, // param1
 		0x00, 0x00, 0x00, 0x00, // param2 (ignored)
-		0x80, 0x00, // cmd2: bufferCmd | dataOffsetFlag
+		byte(cmd2 >> 8), byte(cmd2), // cmd2: bufferCmd | dataOffsetFlag
 		0x00, 0x00, // param1
 		0x00, 0x00, 0x00, 0x20, // param2 -> header offset 32
 	}


### PR DESCRIPTION
## Summary
- define buffer command and data offset flag constants
- check buffer command with bitwise flags
- update sound header test to use constants

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68956e7ff1c4832a80bb903c1615b453