### PR TITLE
Use constants for sound header command

### DIFF
--- a/clsnd/clsnd.go
+++ b/clsnd/clsnd.go
@@ -30,7 +30,9 @@ type CLSounds struct {
 }
 
 const (
-	typeSound = 0x736e6420 // 'snd '
+        typeSound     = 0x736e6420 // 'snd '
+        bufferCmd     = 0x51
+        dataOffsetFlag = 0x8000
 )
 
 // Load parses the CL_Sounds keyfile located at path.
@@ -139,10 +141,10 @@ func soundHeaderOffset(data []byte) (int, bool) {
 			return 0, false
 		}
 		cmd := binary.BigEndian.Uint16(data[p : p+2])
-		off := int(binary.BigEndian.Uint32(data[p+4 : p+8]))
-		if cmd == 0x8000 { // bufferCmd | dataOffsetFlag
-			return off, true
-		}
+                off := int(binary.BigEndian.Uint32(data[p+4 : p+8]))
+                if cmd == dataOffsetFlag|bufferCmd {
+                        return off, true
+                }
 		p += 8
 	}
 	return 0, false

--- a/clsnd/clsnd_test.go
+++ b/clsnd/clsnd_test.go
@@ -5,17 +5,18 @@ import "testing"
 // Test that soundHeaderOffset ignores commands other than bufferCmd when the
 // dataOffsetFlag is set.
 func TestSoundHeaderOffsetSkipsNonBufferCommands(t *testing.T) {
-	data := []byte{
-		0x00, 0x01, // format 1
-		0x00, 0x00, // nMods
-		0x00, 0x02, // nCmds
-		0x80, 0x10, // cmd1: not bufferCmd, high bit set
-		0x00, 0x00, // param1
-		0x00, 0x00, 0x00, 0x00, // param2 (ignored)
-		0x80, 0x00, // cmd2: bufferCmd | dataOffsetFlag
-		0x00, 0x00, // param1
-		0x00, 0x00, 0x00, 0x20, // param2 -> header offset 32
-	}
+        cmd := dataOffsetFlag | bufferCmd
+        data := []byte{
+                0x00, 0x01, // format 1
+                0x00, 0x00, // nMods
+                0x00, 0x02, // nCmds
+                0x80, 0x10, // cmd1: not bufferCmd, high bit set
+                0x00, 0x00, // param1
+                0x00, 0x00, 0x00, 0x00, // param2 (ignored)
+                byte(cmd>>8), byte(cmd), // cmd2: bufferCmd | dataOffsetFlag (0x8051)
+                0x00, 0x00, // param1
+                0x00, 0x00, 0x00, 0x20, // param2 -> header offset 32
+        }
 	// pad up to offset 32
 	if len(data) < 0x20 {
 		data = append(data, make([]byte, 0x20-len(data))...)


### PR DESCRIPTION
## Summary
- define `bufferCmd` and `dataOffsetFlag` constants and use their combination when finding sound headers
- update tests to build command bytes from these constants (0x8051)

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68956e88ab0c832abee6b779b51a451f