### PR TITLE
Add opacity sliders for bubbles and names

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -54,41 +54,41 @@ func adjustBubbleRect(x, y, width, height, tailHeight, sw, sh int, far bool) (le
 // bubbleColors selects the border, background, and text colors for a bubble
 // based on its type. Alpha values are premultiplied to match Ebiten's color
 // expectations.
-const bubbleAlpha = 160
 
 func bubbleColors(typ int) (border, bg, text color.Color) {
+	alpha := uint8(gs.BubbleOpacity * 255)
 	switch typ & kBubbleTypeMask {
 	case kBubbleWhisper:
 		border = color.NRGBA{0x80, 0x80, 0x80, 0xff}
-		bg = color.NRGBA{0x33, 0x33, 0x33, bubbleAlpha}
+		bg = color.NRGBA{0x33, 0x33, 0x33, alpha}
 		text = color.White
 	case kBubbleYell:
 		border = color.NRGBA{0xff, 0xff, 0x00, 0xff}
-		bg = color.White
+		bg = color.NRGBA{0xff, 0xff, 0xff, alpha}
 		text = color.Black
 	case kBubbleThought, kBubblePonder:
 		border = color.NRGBA{0x00, 0x00, 0x00, 0x00}
-		bg = color.NRGBA{0x80, 0x80, 0x80, bubbleAlpha}
+		bg = color.NRGBA{0x80, 0x80, 0x80, alpha}
 		text = color.Black
 	case kBubbleRealAction:
 		border = color.NRGBA{0x00, 0x00, 0x80, 0xff}
-		bg = color.NRGBA{0xff, 0xff, 0xff, bubbleAlpha}
+		bg = color.NRGBA{0xff, 0xff, 0xff, alpha}
 		text = color.Black
 	case kBubblePlayerAction:
 		border = color.NRGBA{0x80, 0x00, 0x00, 0xff}
-		bg = color.NRGBA{0xff, 0xff, 0xff, bubbleAlpha}
+		bg = color.NRGBA{0xff, 0xff, 0xff, alpha}
 		text = color.Black
 	case kBubbleNarrate:
 		border = color.NRGBA{0x00, 0x80, 0x00, 0xff}
-		bg = color.NRGBA{0xff, 0xff, 0xff, bubbleAlpha}
+		bg = color.NRGBA{0xff, 0xff, 0xff, alpha}
 		text = color.Black
 	case kBubbleMonster:
 		border = color.NRGBA{0xd6, 0xd6, 0xd6, 0xff}
-		bg = color.NRGBA{0x47, 0x47, 0x47, bubbleAlpha}
+		bg = color.NRGBA{0x47, 0x47, 0x47, alpha}
 		text = color.White
 	default:
 		border = color.White
-		bg = color.NRGBA{0xff, 0xff, 0xff, bubbleAlpha}
+		bg = color.NRGBA{0xff, 0xff, 0xff, alpha}
 		text = color.Black
 	}
 	return

--- a/game.go
+++ b/game.go
@@ -567,6 +567,7 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 		if d, ok := descMap[m.Index]; ok {
 			if d.Name != "" {
 				textClr, bgClr, frameClr := mobileNameColors(m.Colors)
+				bgClr.A = uint8(gs.NameBgOpacity * 255)
 				w, h := text.Measure(d.Name, mainFont, 0)
 				iw := int(math.Ceil(w))
 				ih := int(math.Ceil(h))
@@ -585,6 +586,7 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 						back = 0
 					}
 					barClr := nameBackColors[back]
+					barClr.A = uint8(gs.NameBgOpacity * 255)
 					top := y + size*gs.Scale/2 + 2*gs.Scale
 					left := x - 6*gs.Scale
 					ebitenutil.DrawRect(screen, float64(left), float64(top), float64(12*gs.Scale), float64(2*gs.Scale), barClr)

--- a/settings.go
+++ b/settings.go
@@ -17,6 +17,8 @@ var gs settings = settings{
 	KBWalkSpeed:    0.25,
 	MainFontSize:   8,
 	BubbleFontSize: 6,
+	BubbleOpacity:  160.0 / 255.0,
+	NameBgOpacity:  1.0,
 
 	NightEffect:      true,
 	SpeechBubbles:    true,
@@ -44,6 +46,8 @@ type settings struct {
 	KBWalkSpeed    float64
 	MainFontSize   float64
 	BubbleFontSize float64
+	BubbleOpacity  float64
+	NameBgOpacity  float64
 
 	NightEffect      bool
 	SpeechBubbles    bool

--- a/ui.go
+++ b/ui.go
@@ -490,6 +490,27 @@ func openSettingsWindow() {
 	}
 	mainFlow.AddItem(labelFontSlider)
 
+	label, _ = eui.NewText(&eui.ItemData{Text: "\nOpacity Settings:", FontSize: 15, Size: eui.Point{X: 150, Y: 50}})
+	mainFlow.AddItem(label)
+
+	bubbleOpSlider, bubbleOpEvents := eui.NewSlider(&eui.ItemData{Label: "Message Bubble", MinValue: 0, MaxValue: 1, Value: float32(gs.BubbleOpacity), Size: eui.Point{X: width - 10, Y: 24}})
+	bubbleOpEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.BubbleOpacity = float64(ev.Value)
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(bubbleOpSlider)
+
+	nameBgSlider, nameBgEvents := eui.NewSlider(&eui.ItemData{Label: "Name Background", MinValue: 0, MaxValue: 1, Value: float32(gs.NameBgOpacity), Size: eui.Point{X: width - 10, Y: 24}})
+	nameBgEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.NameBgOpacity = float64(ev.Value)
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(nameBgSlider)
+
 	label, _ = eui.NewText(&eui.ItemData{Text: "\nGraphics Settings:", FontSize: 15, Size: eui.Point{X: 150, Y: 50}})
 	mainFlow.AddItem(label)
 


### PR DESCRIPTION
## Summary
- allow configuring message bubble background opacity and mobile name background opacity
- expose new opacity sliders in Settings

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68956e6b24cc832ab1b93d7271c34c9b