### PR TITLE
Add IMA4 decoder and log unsupported sound compressions

### DIFF
--- a/clsnd/clsnd_test.go
+++ b/clsnd/clsnd_test.go
@@ -1,22 +1,25 @@
 package clsnd
 
-import "testing"
+import (
+	"encoding/binary"
+	"testing"
+)
 
 // Test that soundHeaderOffset ignores commands other than bufferCmd when the
 // dataOffsetFlag is set.
 func TestSoundHeaderOffsetSkipsNonBufferCommands(t *testing.T) {
-        cmd := dataOffsetFlag | bufferCmd
-        data := []byte{
-                0x00, 0x01, // format 1
-                0x00, 0x00, // nMods
-                0x00, 0x02, // nCmds
-                0x80, 0x10, // cmd1: not bufferCmd, high bit set
-                0x00, 0x00, // param1
-                0x00, 0x00, 0x00, 0x00, // param2 (ignored)
-                byte(cmd>>8), byte(cmd), // cmd2: bufferCmd | dataOffsetFlag (0x8051)
-                0x00, 0x00, // param1
-                0x00, 0x00, 0x00, 0x20, // param2 -> header offset 32
-        }
+	cmd := dataOffsetFlag | bufferCmd
+	data := []byte{
+		0x00, 0x01, // format 1
+		0x00, 0x00, // nMods
+		0x00, 0x02, // nCmds
+		0x80, 0x10, // cmd1: not bufferCmd, high bit set
+		0x00, 0x00, // param1
+		0x00, 0x00, 0x00, 0x00, // param2 (ignored)
+		byte(cmd >> 8), byte(cmd), // cmd2: bufferCmd | dataOffsetFlag (0x8051)
+		0x00, 0x00, // param1
+		0x00, 0x00, 0x00, 0x20, // param2 -> header offset 32
+	}
 	// pad up to offset 32
 	if len(data) < 0x20 {
 		data = append(data, make([]byte, 0x20-len(data))...)
@@ -31,5 +34,38 @@ func TestSoundHeaderOffsetSkipsNonBufferCommands(t *testing.T) {
 	}
 	if off != 0x20 {
 		t.Fatalf("got offset %d want 32", off)
+	}
+}
+
+// Test decoding of a minimal IMA4 compressed sound.
+func TestDecodeHeaderIMA4(t *testing.T) {
+	// Build a CmpSoundHeader at offset 0.
+	hdr := make([]byte, 64)
+	hdr[20] = 0xfe                                             // encode = CmpSoundHeader
+	binary.BigEndian.PutUint32(hdr[4:8], 1)                    // channels
+	binary.BigEndian.PutUint32(hdr[8:12], 22050<<16)           // sample rate 22050
+	binary.BigEndian.PutUint32(hdr[22:26], 64)                 // frames
+	binary.BigEndian.PutUint32(hdr[40:44], 0x696d6134)         // 'ima4'
+	binary.BigEndian.PutUint16(hdr[56:58], uint16(^uint16(3))) // -4 as uint16
+	binary.BigEndian.PutUint16(hdr[62:64], 16)                 // bits
+
+	block := make([]byte, 36) // predictor=0, index=0, data=all zero -> silence
+
+	data := append(hdr, block...)
+
+	s, err := decodeHeader(data, 0, 1)
+	if err != nil {
+		t.Fatalf("decodeHeader returned error: %v", err)
+	}
+	if s.SampleRate != 22050 || s.Channels != 1 || s.Bits != 16 {
+		t.Fatalf("unexpected params: %+v", s)
+	}
+	if len(s.Data) != 128 { // 64 samples * 2 bytes
+		t.Fatalf("got %d bytes, want 128", len(s.Data))
+	}
+	for i, b := range s.Data {
+		if b != 0 {
+			t.Fatalf("data[%d]=%d, want 0", i, b)
+		}
 	}
 }

--- a/clsnd/ima4.go
+++ b/clsnd/ima4.go
@@ -1,0 +1,76 @@
+package clsnd
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+var imaIndexTable = [...]int{-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8}
+var imaStepTable = [...]int{7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60, 66, 73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190, 209, 230, 253, 279, 307, 337, 371, 408, 449, 494, 544, 598, 658, 724, 796, 876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767}
+
+func decodeIMA4(data []byte, chans int) ([]byte, error) {
+	if chans <= 0 {
+		return nil, fmt.Errorf("invalid channel count")
+	}
+	blockSize := 36 * chans
+	if len(data)%blockSize != 0 {
+		return nil, fmt.Errorf("truncated ima4 data")
+	}
+	blocks := len(data) / blockSize
+	out := make([]int16, blocks*64*chans)
+	for b := 0; b < blocks; b++ {
+		for ch := 0; ch < chans; ch++ {
+			block := data[b*blockSize+ch*36 : b*blockSize+(ch+1)*36]
+			pred := int16(binary.BigEndian.Uint16(block[0:2]))
+			index := int(block[2])
+			if index < 0 {
+				index = 0
+			} else if index > 88 {
+				index = 88
+			}
+			p := b*64*chans + ch
+			for i := 0; i < 64; i++ {
+				var nibble int
+				if i%2 == 0 {
+					nibble = int(block[4+i/2] >> 4)
+				} else {
+					nibble = int(block[4+i/2] & 0x0F)
+				}
+				step := imaStepTable[index]
+				diff := step >> 3
+				if nibble&1 != 0 {
+					diff += step >> 2
+				}
+				if nibble&2 != 0 {
+					diff += step >> 1
+				}
+				if nibble&4 != 0 {
+					diff += step
+				}
+				if nibble&8 != 0 {
+					pred -= int16(diff)
+				} else {
+					pred += int16(diff)
+				}
+				if pred < -32768 {
+					pred = -32768
+				} else if pred > 32767 {
+					pred = 32767
+				}
+				index += imaIndexTable[nibble]
+				if index < 0 {
+					index = 0
+				} else if index > 88 {
+					index = 88
+				}
+				out[p] = pred
+				p += chans
+			}
+		}
+	}
+	pcm := make([]byte, len(out)*2)
+	for i, s := range out {
+		binary.BigEndian.PutUint16(pcm[2*i:], uint16(s))
+	}
+	return pcm, nil
+}


### PR DESCRIPTION
## Summary
- decode CmpSoundHeader blocks compressed with IMA4 ADPCM
- log sound ID and format when encountering unsupported compression like MACE or other types
- add tests for IMA4 decoding and log unsupported header encodings

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68957459c290832ab679b0f333fed166