### PR TITLE
Respect image denoise setting on load

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,8 @@ func main() {
 	clImages, err = climg.Load(filepath.Join(baseDir + "/data/CL_Images"))
 	if err != nil {
 		logError("failed to load CL_Images: %v", err)
+	} else {
+		clImages.Denoise = gs.DenoiseImages
 	}
 
 	clSounds, err = clsnd.Load(filepath.Join(baseDir + "/data/CL_Sounds"))


### PR DESCRIPTION
## Summary
- ensure saved denoise preference is applied when CL_Images are loaded

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689580ceec08832a9af15f07700d4938