### PR TITLE
Specify dimensions and font for inventory text

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -20,7 +20,7 @@ func updateInventoryWindow() {
 		if it.Equipped {
 			text = "* " + text
 		}
-		t, _ := eui.NewText(&eui.ItemData{Text: text})
+		t, _ := eui.NewText(&eui.ItemData{Text: text, Size: eui.Point{X: 256, Y: 24}, FontSize: 10})
 		inventoryList.AddItem(t)
 		logDebug("Ivn Name: %v, ID: %v", it.Name, it.ID)
 	}


### PR DESCRIPTION
## Summary
- Provide size and font size when creating inventory item text so items display correctly

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895802eb340832aa6593c18f6822193