### PR TITLE
feat: configurable image denoiser

### DIFF
--- a/climg/climg.go
+++ b/climg/climg.go
@@ -36,13 +36,15 @@ type dataLocation struct {
 }
 
 type CLImages struct {
-	data    []byte
-	idrefs  map[uint32]*dataLocation
-	colors  map[uint32]*dataLocation
-	images  map[uint32]*dataLocation
-	cache   map[string]*ebiten.Image
-	mu      sync.Mutex
-	Denoise bool
+	data             []byte
+	idrefs           map[uint32]*dataLocation
+	colors           map[uint32]*dataLocation
+	images           map[uint32]*dataLocation
+	cache            map[string]*ebiten.Image
+	mu               sync.Mutex
+	Denoise          bool
+	DenoiseThreshold int
+	DenoisePercent   float64
 }
 
 const (
@@ -470,7 +472,7 @@ func (c *CLImages) Get(id uint32, custom []byte, forceTransparent bool) *ebiten.
 	}
 
 	if c.Denoise {
-		denoiseImage(img)
+		denoiseImage(img, c.DenoiseThreshold, c.DenoisePercent)
 	}
 
 	eimg := ebiten.NewImageFromImage(img)

--- a/main.go
+++ b/main.go
@@ -110,6 +110,8 @@ func main() {
 		logError("failed to load CL_Images: %v", err)
 	} else {
 		clImages.Denoise = gs.DenoiseImages
+		clImages.DenoiseThreshold = gs.DenoiseThreshold
+		clImages.DenoisePercent = gs.DenoisePercent
 	}
 
 	clSounds, err = clsnd.Load(filepath.Join(baseDir + "/data/CL_Sounds"))

--- a/settings.go
+++ b/settings.go
@@ -28,6 +28,8 @@ var gs settings = settings{
 	BlendPicts:       true,
 	BlendAmount:      1.0,
 	DenoiseImages:    false,
+	DenoiseThreshold: 3000,
+	DenoisePercent:   0.5,
 	PrecacheAssets:   false,
 	CacheWholeSheet:  true,
 	ShowFPS:          true,
@@ -57,6 +59,8 @@ type settings struct {
 	BlendPicts       bool
 	BlendAmount      float64
 	DenoiseImages    bool
+	DenoiseThreshold int
+	DenoisePercent   float64
 	PrecacheAssets   bool
 	CacheWholeSheet  bool
 	ShowFPS          bool
@@ -93,6 +97,8 @@ func loadSettings() bool {
 func applySettings() {
 	if clImages != nil {
 		clImages.Denoise = gs.DenoiseImages
+		clImages.DenoiseThreshold = gs.DenoiseThreshold
+		clImages.DenoisePercent = gs.DenoisePercent
 	}
 	if gs.TextureFiltering {
 		drawFilter = ebiten.FilterLinear

--- a/ui.go
+++ b/ui.go
@@ -149,6 +149,8 @@ func openDownloadsWindow(status dataFilesStatus) {
 				if imgs, err := climg.Load(filepath.Join(dataDir, "CL_Images")); err == nil {
 					clImages = imgs
 					clImages.Denoise = gs.DenoiseImages
+					clImages.DenoiseThreshold = gs.DenoiseThreshold
+					clImages.DenoisePercent = gs.DenoisePercent
 					clearCaches()
 				} else {
 					logError("load CL_Images: %v", err)
@@ -552,6 +554,32 @@ func openSettingsWindow() {
 		}
 	}
 	mainFlow.AddItem(denoiseCB)
+
+	denoiseThSlider, denoiseThEvents := eui.NewSlider(&eui.ItemData{Label: "Denoise Threshold", MinValue: 0, MaxValue: 10000, Value: float32(gs.DenoiseThreshold), Size: eui.Point{X: width - 10, Y: 24}, IntOnly: true})
+	denoiseThEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.DenoiseThreshold = int(ev.Value)
+			if clImages != nil {
+				clImages.DenoiseThreshold = gs.DenoiseThreshold
+			}
+			clearCaches()
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(denoiseThSlider)
+
+	denoiseAmtSlider, denoiseAmtEvents := eui.NewSlider(&eui.ItemData{Label: "Denoise Softening", MinValue: 0, MaxValue: 1, Value: float32(gs.DenoisePercent), Size: eui.Point{X: width - 10, Y: 24}})
+	denoiseAmtEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.DenoisePercent = float64(ev.Value)
+			if clImages != nil {
+				clImages.DenoisePercent = gs.DenoisePercent
+			}
+			clearCaches()
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(denoiseAmtSlider)
 
 	motion, motionEvents := eui.NewCheckbox(&eui.ItemData{Text: "Smooth Motion", Size: eui.Point{X: width, Y: 24}, Checked: gs.MotionSmoothing})
 	motionEvents.Handle = func(ev eui.UIEvent) {


### PR DESCRIPTION
## Summary
- soften only adjacent pixels when denoising and blend based on threshold
- add configurable denoise threshold and softening sliders in settings
- plumb threshold and softening values through settings and CLImages

## Testing
- `go build -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_689588656de0832ab0acbcc7e3c0c18e