### PR TITLE
Smooth denoise blending with sharpness slider

### DIFF
--- a/climg/climg.go
+++ b/climg/climg.go
@@ -43,7 +43,7 @@ type CLImages struct {
 	cache            map[string]*ebiten.Image
 	mu               sync.Mutex
 	Denoise          bool
-	DenoiseThreshold int
+	DenoiseSharpness float64
 	DenoisePercent   float64
 }
 
@@ -475,7 +475,7 @@ func (c *CLImages) Get(id uint32, custom []byte, forceTransparent bool) *ebiten.
 	}
 
 	if c.Denoise {
-		denoiseImage(img, c.DenoiseThreshold, c.DenoisePercent)
+		denoiseImage(img, c.DenoiseSharpness, c.DenoisePercent)
 	}
 
 	eimg := ebiten.NewImageFromImage(img)

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 		logError("failed to load CL_Images: %v", err)
 	} else {
 		clImages.Denoise = gs.DenoiseImages
-		clImages.DenoiseThreshold = gs.DenoiseThreshold
+		clImages.DenoiseSharpness = gs.DenoiseSharpness
 		clImages.DenoisePercent = gs.DenoisePercent
 	}
 

--- a/settings.go
+++ b/settings.go
@@ -28,7 +28,7 @@ var gs settings = settings{
 	BlendPicts:       true,
 	BlendAmount:      1.0,
 	DenoiseImages:    false,
-	DenoiseThreshold: 10000,
+	DenoiseSharpness: 4.0,
 	DenoisePercent:   0.2,
 	PrecacheAssets:   false,
 	CacheWholeSheet:  true,
@@ -59,7 +59,7 @@ type settings struct {
 	BlendPicts       bool
 	BlendAmount      float64
 	DenoiseImages    bool
-	DenoiseThreshold int
+	DenoiseSharpness float64
 	DenoisePercent   float64
 	PrecacheAssets   bool
 	CacheWholeSheet  bool
@@ -97,7 +97,7 @@ func loadSettings() bool {
 func applySettings() {
 	if clImages != nil {
 		clImages.Denoise = gs.DenoiseImages
-		clImages.DenoiseThreshold = gs.DenoiseThreshold
+		clImages.DenoiseSharpness = gs.DenoiseSharpness
 		clImages.DenoisePercent = gs.DenoisePercent
 	}
 	if gs.TextureFiltering {

--- a/ui.go
+++ b/ui.go
@@ -149,7 +149,7 @@ func openDownloadsWindow(status dataFilesStatus) {
 				if imgs, err := climg.Load(filepath.Join(dataDir, "CL_Images")); err == nil {
 					clImages = imgs
 					clImages.Denoise = gs.DenoiseImages
-					clImages.DenoiseThreshold = gs.DenoiseThreshold
+					clImages.DenoiseSharpness = gs.DenoiseSharpness
 					clImages.DenoisePercent = gs.DenoisePercent
 					clearCaches()
 				} else {
@@ -555,18 +555,18 @@ func openSettingsWindow() {
 	}
 	mainFlow.AddItem(denoiseCB)
 
-	denoiseThSlider, denoiseThEvents := eui.NewSlider(&eui.ItemData{Label: "Denoise Threshold", MinValue: 0, MaxValue: 65000, Value: float32(gs.DenoiseThreshold), Size: eui.Point{X: width - 10, Y: 24}, IntOnly: true})
-	denoiseThEvents.Handle = func(ev eui.UIEvent) {
+	denoiseSharpSlider, denoiseSharpEvents := eui.NewSlider(&eui.ItemData{Label: "Denoise Sharpness", MinValue: 0.1, MaxValue: 8, Value: float32(gs.DenoiseSharpness), Size: eui.Point{X: width - 10, Y: 24}})
+	denoiseSharpEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
-			gs.DenoiseThreshold = int(ev.Value)
+			gs.DenoiseSharpness = float64(ev.Value)
 			if clImages != nil {
-				clImages.DenoiseThreshold = gs.DenoiseThreshold
+				clImages.DenoiseSharpness = gs.DenoiseSharpness
 			}
 			clearCaches()
 			settingsDirty = true
 		}
 	}
-	mainFlow.AddItem(denoiseThSlider)
+	mainFlow.AddItem(denoiseSharpSlider)
 
 	denoiseAmtSlider, denoiseAmtEvents := eui.NewSlider(&eui.ItemData{Label: "Denoise Softening", MinValue: 0, MaxValue: 1, Value: float32(gs.DenoisePercent), Size: eui.Point{X: width - 10, Y: 24}})
 	denoiseAmtEvents.Handle = func(ev eui.UIEvent) {


### PR DESCRIPTION
## Summary
- Replace hard-threshold denoising with distance-based blending that falls off with a configurable sharpness
- Expose new `DenoiseSharpness` setting and slider alongside existing softening control

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895904beb9c832a84c9aa6659503596