### PR TITLE
Fix mobile name background alpha and set default opacity

### DIFF
--- a/game.go
+++ b/game.go
@@ -592,9 +592,11 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 			screen.DrawImage(img, op)
 		}
 		if d, ok := descMap[m.Index]; ok {
+			alpha := uint8(gs.NameBgOpacity * 255)
 			if d.Name != "" {
 				textClr, bgClr, frameClr := mobileNameColors(m.Colors)
-				bgClr.A = uint8(gs.NameBgOpacity * 255)
+				bgClr.A = alpha
+				frameClr.A = alpha
 				w, h := text.Measure(d.Name, mainFont, 0)
 				iw := int(math.Ceil(w))
 				ih := int(math.Ceil(h))
@@ -613,7 +615,7 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 						back = 0
 					}
 					barClr := nameBackColors[back]
-					barClr.A = uint8(gs.NameBgOpacity * 255)
+					barClr.A = alpha
 					top := y + size*gs.Scale/2 + 2*gs.Scale
 					left := x - 6*gs.Scale
 					ebitenutil.DrawRect(screen, float64(left), float64(top), float64(12*gs.Scale), float64(2*gs.Scale), barClr)

--- a/settings.go
+++ b/settings.go
@@ -17,7 +17,7 @@ var gs settings = settings{
 	MainFontSize:   8,
 	BubbleFontSize: 6,
 	BubbleOpacity:  160.0 / 255.0,
-	NameBgOpacity:  1.0,
+	NameBgOpacity:  0.66,
 
 	NightEffect:      true,
 	SpeechBubbles:    true,


### PR DESCRIPTION
## Summary
- ensure mobile name frames and bars respect `NameBgOpacity`
- default name background opacity to 0.66

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895965bf1e0832a895f6ce99c86d43c