### PR TITLE
Fix mobile name background alpha and set default opacity

### DIFF
--- a/game.go
+++ b/game.go
@@ -602,12 +602,20 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 				ih := int(math.Ceil(h))
 				top := y + (20 * gs.Scale)
 				left := x - iw/2
-				ebitenutil.DrawRect(screen, float64(left), float64(top), float64(iw+5), float64(ih), bgClr)
+				if hudPixel == nil {
+					hudPixel = ebiten.NewImage(1, 1)
+					hudPixel.Fill(color.White)
+				}
+				op := &ebiten.DrawImageOptions{}
+				op.GeoM.Scale(float64(iw+5), float64(ih))
+				op.GeoM.Translate(float64(left), float64(top))
+				op.ColorM.Scale(float64(bgClr.R)/255, float64(bgClr.G)/255, float64(bgClr.B)/255, float64(bgClr.A)/255)
+				screen.DrawImage(hudPixel, op)
 				vector.StrokeRect(screen, float32(left), float32(top), float32(iw+5), float32(ih), 1, frameClr, false)
-				op := &text.DrawOptions{}
-				op.GeoM.Translate(float64(left+2), float64(top+2))
-				op.ColorScale.ScaleWithColor(textClr)
-				text.Draw(screen, d.Name, mainFont, op)
+				opTxt := &text.DrawOptions{}
+				opTxt.GeoM.Translate(float64(left+2), float64(top+2))
+				opTxt.ColorScale.ScaleWithColor(textClr)
+				text.Draw(screen, d.Name, mainFont, opTxt)
 			} else {
 				back := int((m.Colors >> 4) & 0x0f)
 				if back != kColorCodeBackWhite && back != kColorCodeBackBlue && !(back == kColorCodeBackBlack && d.Type == kDescMonster) {
@@ -618,7 +626,15 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 					barClr.A = alpha
 					top := y + size*gs.Scale/2 + 2*gs.Scale
 					left := x - 6*gs.Scale
-					ebitenutil.DrawRect(screen, float64(left), float64(top), float64(12*gs.Scale), float64(2*gs.Scale), barClr)
+					if hudPixel == nil {
+						hudPixel = ebiten.NewImage(1, 1)
+						hudPixel.Fill(color.White)
+					}
+					op := &ebiten.DrawImageOptions{}
+					op.GeoM.Scale(float64(12*gs.Scale), float64(2*gs.Scale))
+					op.GeoM.Translate(float64(left), float64(top))
+					op.ColorM.Scale(float64(barClr.R)/255, float64(barClr.G)/255, float64(barClr.B)/255, float64(barClr.A)/255)
+					screen.DrawImage(hudPixel, op)
 				}
 			}
 		}

--- a/game.go
+++ b/game.go
@@ -592,9 +592,11 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 			screen.DrawImage(img, op)
 		}
 		if d, ok := descMap[m.Index]; ok {
+			alpha := uint8(gs.NameBgOpacity * 255)
 			if d.Name != "" {
 				textClr, bgClr, frameClr := mobileNameColors(m.Colors)
-				bgClr.A = uint8(gs.NameBgOpacity * 255)
+				bgClr.A = alpha
+				frameClr.A = alpha
 				w, h := text.Measure(d.Name, mainFont, 0)
 				iw := int(math.Ceil(w))
 				ih := int(math.Ceil(h))
@@ -613,7 +615,7 @@ func drawMobile(screen *ebiten.Image, m frameMobile, descMap map[uint8]frameDesc
 						back = 0
 					}
 					barClr := nameBackColors[back]
-					barClr.A = uint8(gs.NameBgOpacity * 255)
+					barClr.A = alpha
 					top := y + size*gs.Scale/2 + 2*gs.Scale
 					left := x - 6*gs.Scale
 					ebitenutil.DrawRect(screen, float64(left), float64(top), float64(12*gs.Scale), float64(2*gs.Scale), barClr)

--- a/settings.go
+++ b/settings.go
@@ -17,7 +17,7 @@ var gs settings = settings{
 	MainFontSize:   8,
 	BubbleFontSize: 6,
 	BubbleOpacity:  160.0 / 255.0,
-	NameBgOpacity:  1.0,
+	NameBgOpacity:  0.66,
 
 	NightEffect:      true,
 	SpeechBubbles:    true,


### PR DESCRIPTION
## Summary
- ensure mobile name frames and bars respect `NameBgOpacity`
- default name background opacity to 0.66

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895965bf1e0832a895f6ce99c86d43c