### PR TITLE
Add option to log bubble text to message area

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -338,7 +338,9 @@ func handleInfoText(data []byte) {
 		}
 		if _, txt, _, _, _, _ := decodeBubble(line); txt != "" {
 			//fmt.Println(txt)
-			addMessage(txt)
+			if gs.bubbleMessages {
+				addMessage(txt)
+			}
 			continue
 		}
 		s := strings.TrimSpace(decodeMacRoman(stripBEPPTags(line)))

--- a/draw.go
+++ b/draw.go
@@ -880,7 +880,9 @@ func parseDrawState(data []byte) error {
 					}
 				}
 			}
-			addMessage(msg)
+			if gs.bubbleMessages {
+				addMessage(msg)
+			}
 		}
 		stateData = stateData[p+end+1:]
 	}

--- a/settings.go
+++ b/settings.go
@@ -37,6 +37,7 @@ var gs settings = settings{
 	smoothMoving:     true,
 	fastBars:         true,
 	speechBubbles:    true,
+	bubbleMessages:   false,
 }
 
 type settings struct {
@@ -76,6 +77,7 @@ type settings struct {
 	smoothMoving     bool
 	fastBars         bool
 	speechBubbles    bool
+	bubbleMessages   bool
 }
 
 var settingsDirty bool

--- a/ui.go
+++ b/ui.go
@@ -732,6 +732,15 @@ func openDebugWindow() {
 	}
 	debugFlow.AddItem(bubbleCB)
 
+	bubbleMsgCB, bubbleMsgEvents := eui.NewCheckbox(&eui.ItemData{Text: "Bubble Text in Messages", Size: eui.Point{X: width, Y: 24}, Checked: gs.bubbleMessages})
+	bubbleMsgEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.bubbleMessages = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(bubbleMsgCB)
+
 	hideMoveCB, hideMoveEvents := eui.NewCheckbox(&eui.ItemData{Text: "Hide Moving", Size: eui.Point{X: width, Y: 24}, Checked: gs.hideMoving})
 	hideMoveEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {


### PR DESCRIPTION
## Summary
- add `Bubble Text in Messages` debug option
- gate bubble text logging behind new setting

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895ad4d2918832a8735ed7876ef6993