### PR TITLE
Relax inventory parser to tolerate missing trailing command

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -334,7 +334,7 @@ func parseInventory(data []byte) ([]byte, bool) {
 			}
 			id := binary.BigEndian.Uint16(data[:2])
 			data = data[2:]
-			idx := -1
+			idx := 0
 			if cmd&kInvCmdIndex != 0 {
 				if len(data) < 1 {
 					return nil, false
@@ -368,16 +368,17 @@ func parseInventory(data []byte) ([]byte, bool) {
 		default:
 			return nil, false
 		}
-		if len(data) == 0 {
-			return nil, false
+		if len(data) > 0 {
+			cmd = int(data[0])
+			data = data[1:]
+		} else {
+			cmd = kInvCmdNone
 		}
-		cmd = int(data[0])
-		data = data[1:]
 	}
 	if cmd == kInvCmdNone|kInvCmdIndex {
 		logError("inventory: got kInvCmdNone + index")
 	} else if cmd != kInvCmdNone {
-		return nil, false
+		logError("inventory: unexpected trailing cmd %d", cmd)
 	}
 	for len(data) > 0 && data[0] == 0 {
 		data = data[1:]


### PR DESCRIPTION
## Summary
- Match old Mac client's inventory offsets and indexing
- Allow parseInventory to handle missing terminator and pad bytes

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68963674370c832a897cb1600cef328e