### PR TITLE
Constrain game viewport and handle window resizing

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -149,6 +149,8 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	for i := range vs {
 		vs[i].SrcX = 0
 		vs[i].SrcY = 0
+		vs[i].DstX *= float32(viewScale)
+		vs[i].DstY *= float32(viewScale)
 		vs[i].ColorR = float32(bgR) / 0xffff
 		vs[i].ColorG = float32(bgG) / 0xffff
 		vs[i].ColorB = float32(bgB) / 0xffff
@@ -162,6 +164,8 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 		for i := range vs {
 			vs[i].SrcX = 0
 			vs[i].SrcY = 0
+			vs[i].DstX *= float32(viewScale)
+			vs[i].DstY *= float32(viewScale)
 			vs[i].ColorR = float32(bgR) / 0xffff
 			vs[i].ColorG = float32(bgG) / 0xffff
 			vs[i].ColorB = float32(bgB) / 0xffff
@@ -192,6 +196,8 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	for i := range vs {
 		vs[i].SrcX = 0
 		vs[i].SrcY = 0
+		vs[i].DstX *= float32(viewScale)
+		vs[i].DstY *= float32(viewScale)
 		vs[i].ColorR = float32(bdR) / 0xffff
 		vs[i].ColorG = float32(bdG) / 0xffff
 		vs[i].ColorB = float32(bdB) / 0xffff
@@ -205,6 +211,7 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 		op := &text.DrawOptions{}
 		op.GeoM.Translate(float64(textLeft), float64(textTop+i*lineHeight))
 		op.ColorScale.ScaleWithColor(textCol)
+		applyTextView(op)
 		text.Draw(screen, line, bubbleFont, op)
 	}
 }

--- a/network.go
+++ b/network.go
@@ -116,11 +116,14 @@ func sendPlayerInput(connection net.Conn) error {
 	const kMsgPlayerInput = 3
 	flags := uint16(0)
 
-	x, y := ebiten.CursorPosition()
+	xw, yw := ebiten.CursorPosition()
+	x := int((float64(xw) - float64(viewOffsetX)) / viewScale)
+	y := int((float64(yw) - float64(viewOffsetY)) / viewScale)
+	inBounds := x >= 0 && y >= 0 && x < gameAreaSizeX*gs.Scale && y < gameAreaSizeY*gs.Scale
 	baseX := int16(x/gs.Scale - fieldCenterX)
 	baseY := int16(y/gs.Scale - fieldCenterY)
 	baseDown := ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
-	if pointInUI(x, y) {
+	if !inBounds || pointInUI(x, y) {
 		baseDown = false
 	}
 

--- a/night.go
+++ b/night.go
@@ -190,5 +190,6 @@ func drawNightOverlay(screen *ebiten.Image) {
 	op.GeoM.Scale(float64(gs.Scale), float64(gs.Scale))
 	alpha := float32(lvl) / 100.0
 	op.ColorScale.ScaleAlpha(alpha)
+	applyView(op)
 	screen.DrawImage(img, op)
 }


### PR DESCRIPTION
## Summary
- render game directly into a centered subimage and scale via transforms instead of an off-screen surface
- update drawing helpers and overlays to apply viewport scaling and offsets
- scale bubble and night overlay geometry for consistent placement in the resized window

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895cb1ca3a4832a87f4f89908028cba