### PR TITLE
Decouple UI and game scaling

### DIFF
--- a/game.go
+++ b/game.go
@@ -274,6 +274,8 @@ func (g *Game) Update() error {
 			}
 			if newScale != gs.Scale {
 				gs.Scale = newScale
+				initFont()
+				settingsDirty = true
 			}
 		}
 	}
@@ -1026,6 +1028,8 @@ func runGame(ctx context.Context) {
 	gameWin.AspectB = 1
 
 	gameWin.AddWindow(false)
+
+	resizeUI()
 
 	initUI()
 

--- a/settings.go
+++ b/settings.go
@@ -29,6 +29,7 @@ var gs settings = settings{
 	DenoisePercent:    0.2,
 	ShowFPS:           true,
 	Scale:             2,
+	UIScale:           1.0,
 
 	vsync:            true,
 	nightEffect:      true,
@@ -61,7 +62,8 @@ type settings struct {
 	DenoisePercent    float64
 	ShowFPS           bool
 
-	Scale int
+	Scale   int
+	UIScale float64
 
 	imgPlanesDebug   bool
 	smoothingDebug   bool
@@ -128,10 +130,9 @@ func saveSettings() {
 }
 
 func resizeUI() {
-	var val float32 = 1.0
-	if gs.Scale == 1 {
-		val = 0.5
+	eui.SetUIScale(float32(gs.UIScale))
+	if gameWin != nil {
+		scale := eui.UIScale()
+		gameWin.Size = eui.Point{X: float32(gameAreaSizeX*gs.Scale) / scale, Y: float32(gameAreaSizeY*gs.Scale) / scale}
 	}
-
-	eui.SetUIScale(val)
 }

--- a/ui.go
+++ b/ui.go
@@ -507,17 +507,15 @@ func openSettingsWindow() {
 	label, _ = eui.NewText(&eui.ItemData{Text: "\nGraphics Settings:", FontSize: 15, Size: eui.Point{X: 150, Y: 50}})
 	mainFlow.AddItem(label)
 
-	scaleSlider, scaleEvents := eui.NewSlider(&eui.ItemData{Label: "Scaling", MinValue: 1, MaxValue: 5, Value: float32(gs.Scale), Size: eui.Point{X: width, Y: 24}, IntOnly: true})
-	scaleEvents.Handle = func(ev eui.UIEvent) {
+	uiScaleSlider, uiScaleEvents := eui.NewSlider(&eui.ItemData{Label: "UI Scaling", MinValue: 0.5, MaxValue: 2.5, Value: float32(gs.UIScale), Size: eui.Point{X: width - 10, Y: 24}})
+	uiScaleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
-			gs.Scale = int(ev.Value)
-			initFont()
+			gs.UIScale = float64(ev.Value)
 			resizeUI()
-			ebiten.SetWindowSize(gameAreaSizeX*gs.Scale, gameAreaSizeY*gs.Scale)
 			settingsDirty = true
 		}
 	}
-	mainFlow.AddItem(scaleSlider)
+	mainFlow.AddItem(uiScaleSlider)
 
 	denoiseCB, denoiseEvents := eui.NewCheckbox(&eui.ItemData{Text: "Image Denoise", Size: eui.Point{X: width, Y: 24}, Checked: gs.DenoiseImages})
 	denoiseEvents.Handle = func(ev eui.UIEvent) {


### PR DESCRIPTION
## Summary
- Separate interface scaling from game world scale by introducing a dedicated `UIScale` setting
- Add UI scaling slider and adjust resize logic so the Clan Lord window keeps constant bounds while the world scale fits within them
- Recompute fonts and persist settings when game scale changes

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689675a4d24c832a8ebc9d20ab254cf9