### PR TITLE
Use float-based game scaling for correct window fit

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -107,10 +107,11 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	}
 	y -= 35
 
-	sw, sh := gameAreaSizeX*gs.Scale, gameAreaSizeY*gs.Scale
-	pad := (4 + 2) * gs.Scale
-	tailHeight := 10 * gs.Scale
-	tailHalf := 6 * gs.Scale
+	sw := int(float64(gameAreaSizeX) * gs.Scale)
+	sh := int(float64(gameAreaSizeY) * gs.Scale)
+	pad := int((4 + 2) * gs.Scale)
+	tailHeight := int(10 * gs.Scale)
+	tailHalf := int(6 * gs.Scale)
 
 	maxLineWidth := sw/4 - 2*pad
 	width, lines := wrapText(txt, bubbleFont, float64(maxLineWidth))

--- a/font.go
+++ b/font.go
@@ -29,7 +29,7 @@ func initFont() {
 	}
 	mainFont = &text.GoTextFace{
 		Source: regular,
-		Size:   gs.MainFontSize * float64(gs.Scale),
+		Size:   gs.MainFontSize * gs.Scale,
 	}
 
 	bold, err := text.NewGoTextFaceSource(bytes.NewReader(notoSansBold))
@@ -38,7 +38,7 @@ func initFont() {
 	}
 	mainFontBold = &text.GoTextFace{
 		Source: bold,
-		Size:   gs.MainFontSize * float64(gs.Scale),
+		Size:   gs.MainFontSize * gs.Scale,
 	}
 
 	italic, err := text.NewGoTextFaceSource(bytes.NewReader(notoSansItalic))
@@ -47,7 +47,7 @@ func initFont() {
 	}
 	mainFontItalic = &text.GoTextFace{
 		Source: italic,
-		Size:   gs.MainFontSize * float64(gs.Scale),
+		Size:   gs.MainFontSize * gs.Scale,
 	}
 
 	boldItalic, err := text.NewGoTextFaceSource(bytes.NewReader(notoSansBoldItalic))
@@ -56,12 +56,12 @@ func initFont() {
 	}
 	mainFontBoldItalic = &text.GoTextFace{
 		Source: boldItalic,
-		Size:   gs.MainFontSize * float64(gs.Scale),
+		Size:   gs.MainFontSize * gs.Scale,
 	}
 
 	//Bubble
 	bubbleFont = &text.GoTextFace{
 		Source: bold,
-		Size:   gs.BubbleFontSize * float64(gs.Scale),
+		Size:   gs.BubbleFontSize * gs.Scale,
 	}
 }

--- a/game.go
+++ b/game.go
@@ -27,8 +27,8 @@ const defaultHandPictID = 6
 // scaleForFiltering returns scaling factors that extend the image by one
 // pixel in each dimension. This prevents visible gaps between textures when
 // drawing with linear filtering.
-func scaleForFiltering(scale, w, h int) (float64, float64) {
-	return float64(scale) + 2.5/float64(w), float64(scale) + 2.5/float64(h)
+func scaleForFiltering(scale float64, w, h int) (float64, float64) {
+	return scale + 2.5/float64(w), scale + 2.5/float64(h)
 }
 
 var mouseX, mouseY int16
@@ -260,12 +260,13 @@ func (g *Game) Update() error {
 
 	if gameWin != nil {
 		size := gameWin.GetSize()
-		w, h := int(size.X), int(size.Y)
-		if w != lastWinW || h != lastWinH {
-			lastWinW, lastWinH = w, h
-			ebiten.SetWindowSize(w, h)
-			newScale := w / gameAreaSizeX
-			if s := h / gameAreaSizeY; s < newScale {
+		w, h := float64(size.X), float64(size.Y)
+		wi, hi := int(math.Round(w)), int(math.Round(h))
+		if wi != lastWinW || hi != lastWinH {
+			lastWinW, lastWinH = wi, hi
+			ebiten.SetWindowSize(wi, hi)
+			newScale := w / float64(gameAreaSizeX)
+			if s := h / float64(gameAreaSizeY); s < newScale {
 				newScale = s
 			}
 			if newScale < 1 {
@@ -380,8 +381,8 @@ func (g *Game) Update() error {
 				if walkToggled {
 					walkToggled = false
 				} else {
-					walkTargetX = int16(mx/gs.Scale - fieldCenterX)
-					walkTargetY = int16(my/gs.Scale - fieldCenterY)
+					walkTargetX = int16(float64(mx)/gs.Scale - float64(fieldCenterX))
+					walkTargetY = int16(float64(my)/gs.Scale - float64(fieldCenterY))
 					walkToggled = true
 				}
 			}
@@ -390,8 +391,8 @@ func (g *Game) Update() error {
 				if overUI || mx < 0 || my < 0 || mx >= w || my >= h {
 					walkToggled = false
 				} else {
-					walkTargetX = int16(mx/gs.Scale - fieldCenterX)
-					walkTargetY = int16(my/gs.Scale - fieldCenterY)
+					walkTargetX = int16(float64(mx)/gs.Scale - float64(fieldCenterX))
+					walkTargetY = int16(float64(my)/gs.Scale - float64(fieldCenterY))
 				}
 			}
 		} else {
@@ -560,8 +561,8 @@ func drawScene(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha float6
 					}
 				}
 			}
-			x := (int(math.Round(hpos)) + fieldCenterX) * gs.Scale
-			y := (int(math.Round(vpos)) + fieldCenterY) * gs.Scale
+			x := int((math.Round(hpos) + float64(fieldCenterX)) * gs.Scale)
+			y := int((math.Round(vpos) + float64(fieldCenterY)) * gs.Scale)
 			borderCol, bgCol, textCol := bubbleColors(b.Type)
 			drawBubble(screen, b.Text, x, y, b.Type, b.Far, b.NoArrow, borderCol, bgCol, textCol)
 		}
@@ -582,8 +583,10 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 			}
 		}
 	}
-	x := (int(math.Round(h))+fieldCenterX)*gs.Scale + ox
-	y := (int(math.Round(v))+fieldCenterY)*gs.Scale + oy
+	x := int((math.Round(h) + float64(fieldCenterX)) * gs.Scale)
+	y := int((math.Round(v) + float64(fieldCenterY)) * gs.Scale)
+	x += ox
+	y += oy
 	var img *ebiten.Image
 	plane := 0
 	if d, ok := descMap[m.Index]; ok {
@@ -632,15 +635,15 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 			tmp.DrawImage(img, op2)
 			op := &ebiten.DrawImageOptions{}
 			op.Filter = drawFilter
-			op.GeoM.Scale(float64(gs.Scale), float64(gs.Scale))
-			op.GeoM.Translate(float64(x-tmp.Bounds().Dx()*gs.Scale/2), float64(y-tmp.Bounds().Dy()*gs.Scale/2))
+			op.GeoM.Scale(gs.Scale, gs.Scale)
+			op.GeoM.Translate(float64(x)-float64(tmp.Bounds().Dx())*gs.Scale/2, float64(y)-float64(tmp.Bounds().Dy())*gs.Scale/2)
 			screen.DrawImage(tmp, op)
 			recycleTempImage(tmp)
 		} else {
 			op := &ebiten.DrawImageOptions{}
 			op.Filter = drawFilter
-			op.GeoM.Scale(float64(gs.Scale), float64(gs.Scale))
-			op.GeoM.Translate(float64(x-size*gs.Scale/2), float64(y-size*gs.Scale/2))
+			op.GeoM.Scale(gs.Scale, gs.Scale)
+			op.GeoM.Translate(float64(x)-float64(size)*gs.Scale/2, float64(y)-float64(size)*gs.Scale/2)
 			screen.DrawImage(img, op)
 		}
 		if d, ok := descMap[m.Index]; ok {
@@ -652,7 +655,7 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 				w, h := text.Measure(d.Name, mainFont, 0)
 				iw := int(math.Ceil(w))
 				ih := int(math.Ceil(h))
-				top := y + (20 * gs.Scale)
+				top := y + int(20*gs.Scale)
 				left := x - iw/2
 				if hudPixel == nil {
 					hudPixel = ebiten.NewImage(1, 1)
@@ -676,14 +679,14 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 					}
 					barClr := nameBackColors[back]
 					barClr.A = alpha
-					top := y + size*gs.Scale/2 + 2*gs.Scale
-					left := x - 6*gs.Scale
+					top := y + int(float64(size)*gs.Scale/2+2*gs.Scale)
+					left := x - int(6*gs.Scale)
 					if hudPixel == nil {
 						hudPixel = ebiten.NewImage(1, 1)
 						hudPixel.Fill(color.White)
 					}
 					op := &ebiten.DrawImageOptions{}
-					op.GeoM.Scale(float64(12*gs.Scale), float64(2*gs.Scale))
+					op.GeoM.Scale(12*gs.Scale, 2*gs.Scale)
 					op.GeoM.Translate(float64(left), float64(top))
 					op.ColorM.Scale(float64(barClr.R)/255, float64(barClr.G)/255, float64(barClr.B)/255, float64(barClr.A)/255)
 					screen.DrawImage(hudPixel, op)
@@ -693,20 +696,20 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 		if gs.imgPlanesDebug {
 			metrics := mainFont.Metrics()
 			lbl := fmt.Sprintf("%dm", plane)
-			xPos := x - size*gs.Scale/2
+			xPos := x - int(float64(size)*gs.Scale/2)
 			op := &text.DrawOptions{}
-			op.GeoM.Translate(float64(xPos), float64(y-size*gs.Scale/2)-metrics.HAscent)
+			op.GeoM.Translate(float64(xPos), float64(y)-float64(size)*gs.Scale/2-metrics.HAscent)
 			op.ColorScale.ScaleWithColor(color.RGBA{0, 255, 255, 255})
 			text.Draw(screen, lbl, mainFont, op)
 		}
 	} else {
-		vector.DrawFilledRect(screen, float32(x-3*gs.Scale), float32(y-3*gs.Scale), float32(6*gs.Scale), float32(6*gs.Scale), color.RGBA{0xff, 0, 0, 0xff}, false)
+		vector.DrawFilledRect(screen, float32(float64(x)-3*gs.Scale), float32(float64(y)-3*gs.Scale), float32(6*gs.Scale), float32(6*gs.Scale), color.RGBA{0xff, 0, 0, 0xff}, false)
 		if gs.imgPlanesDebug {
 			metrics := mainFont.Metrics()
 			lbl := fmt.Sprintf("%dm", plane)
-			xPos := x - 3*gs.Scale
+			xPos := x - int(3*gs.Scale)
 			op := &text.DrawOptions{}
-			op.GeoM.Translate(float64(xPos), float64(y-3*gs.Scale)-metrics.HAscent)
+			op.GeoM.Translate(float64(xPos), float64(y)-3*gs.Scale-metrics.HAscent)
 			op.ColorScale.ScaleWithColor(color.White)
 			text.Draw(screen, lbl, mainFont, op)
 		}
@@ -754,8 +757,10 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		}
 	}
 
-	x := (int(math.Round(float64(p.H)+offX+mobileX))+fieldCenterX)*gs.Scale + ox
-	y := (int(math.Round(float64(p.V)+offY+mobileY))+fieldCenterY)*gs.Scale + oy
+	x := int((math.Round(float64(p.H)+offX+mobileX) + float64(fieldCenterX)) * gs.Scale)
+	y := int((math.Round(float64(p.V)+offY+mobileY) + float64(fieldCenterY)) * gs.Scale)
+	x += ox
+	y += oy
 
 	if img != nil {
 		if gs.BlendPicts && prevImg != nil {
@@ -778,7 +783,7 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 			op2.GeoM.Translate(float64(offXPix), float64(offYPix))
 			tmp.DrawImage(img, op2)
 			tw, th := tmp.Bounds().Dx(), tmp.Bounds().Dy()
-			sx, sy := float64(gs.Scale), float64(gs.Scale)
+			sx, sy := gs.Scale, gs.Scale
 			if gs.textureFiltering {
 				sx, sy = scaleForFiltering(gs.Scale, tw, th)
 			}
@@ -789,7 +794,7 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 			screen.DrawImage(tmp, op)
 			recycleTempImage(tmp)
 		} else {
-			sx, sy := float64(gs.Scale), float64(gs.Scale)
+			sx, sy := gs.Scale, gs.Scale
 			if gs.textureFiltering {
 				sx, sy = scaleForFiltering(gs.Scale, w, h)
 			}
@@ -806,9 +811,9 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		if gs.imgPlanesDebug {
 			metrics := mainFont.Metrics()
 			lbl := fmt.Sprintf("%dp", plane)
-			xPos := x - w*gs.Scale/2
+			xPos := x - int(float64(w)*gs.Scale/2)
 			opTxt := &text.DrawOptions{}
-			opTxt.GeoM.Translate(float64(xPos), float64(y-h*gs.Scale/2)-metrics.HAscent)
+			opTxt.GeoM.Translate(float64(xPos), float64(y)-float64(h)*gs.Scale/2-metrics.HAscent)
 			opTxt.ColorScale.ScaleWithColor(color.RGBA{255, 255, 0, 0})
 			text.Draw(screen, lbl, mainFont, opTxt)
 		}
@@ -817,13 +822,13 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		if gs.smoothingDebug && p.Moving {
 			clr = color.RGBA{0xff, 0, 0, 0xff}
 		}
-		vector.DrawFilledRect(screen, float32(x-2*gs.Scale), float32(y-2*gs.Scale), float32(4*gs.Scale), float32(4*gs.Scale), clr, false)
+		vector.DrawFilledRect(screen, float32(float64(x)-2*gs.Scale), float32(float64(y)-2*gs.Scale), float32(4*gs.Scale), float32(4*gs.Scale), clr, false)
 		if gs.imgPlanesDebug {
 			metrics := mainFont.Metrics()
 			lbl := fmt.Sprintf("%dp", plane)
-			xPos := x - 2*gs.Scale
+			xPos := x - int(2*gs.Scale)
 			opTxt := &text.DrawOptions{}
-			opTxt.GeoM.Translate(float64(xPos), float64(y-2*gs.Scale)-metrics.HAscent)
+			opTxt.GeoM.Translate(float64(xPos), float64(y)-2*gs.Scale-metrics.HAscent)
 			opTxt.ColorScale.ScaleWithColor(color.RGBA{255, 255, 0, 0})
 			text.Draw(screen, lbl, mainFont, opTxt)
 		}
@@ -874,16 +879,16 @@ func drawStatusBars(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha f
 		op.ColorM.Scale(float64(clr.R)/255, float64(clr.G)/255, float64(clr.B)/255, float64(clr.A)/255)
 		screen.DrawImage(hudPixel, op)
 	}
-	barWidth := 110 * gs.Scale
-	barHeight := 8 * gs.Scale
-	fieldWidth := gameAreaSizeX * gs.Scale
+	barWidth := int(110 * gs.Scale)
+	barHeight := int(8 * gs.Scale)
+	fieldWidth := int(float64(gameAreaSizeX) * gs.Scale)
 	slot := (fieldWidth - 3*barWidth) / 6
-	barY := gameAreaSizeY*gs.Scale - 20*gs.Scale - barHeight
+	barY := int(float64(gameAreaSizeY)*gs.Scale-20*gs.Scale) - barHeight
 	x := slot
 	step := barWidth + 2*slot
 	drawBar := func(x int, cur, max int, clr color.RGBA) {
 		frameClr := color.RGBA{0xff, 0xff, 0xff, 0xff}
-		vector.StrokeRect(screen, float32(ox+x-gs.Scale), float32(oy+barY-gs.Scale), float32(barWidth+2*gs.Scale), float32(barHeight+2*gs.Scale), 1, frameClr, false)
+		vector.StrokeRect(screen, float32(float64(ox+x)-gs.Scale), float32(float64(oy+barY)-gs.Scale), float32(barWidth)+float32(2*gs.Scale), float32(barHeight)+float32(2*gs.Scale), 1, frameClr, false)
 		if max > 0 && cur > 0 {
 			w := barWidth * cur / max
 			fillClr := color.RGBA{clr.R, clr.G, clr.B, 128}
@@ -913,7 +918,7 @@ func drawServerFPS(screen *ebiten.Image, ox, oy int, fps float64) {
 	msg := fmt.Sprintf("FPS: %0.2f UPS: %0.2f LAT: %dms", ebiten.ActualFPS(), fps, lat.Milliseconds())
 	w, _ := text.Measure(msg, mainFont, 0)
 	op := &text.DrawOptions{}
-	op.GeoM.Translate(float64(ox+gameAreaSizeX*gs.Scale)-w-float64(4*gs.Scale), float64(oy+4*gs.Scale))
+	op.GeoM.Translate(float64(ox)+float64(gameAreaSizeX)*gs.Scale-w-4*gs.Scale, float64(oy)+4*gs.Scale)
 	op.ColorScale.ScaleWithColor(color.White)
 	text.Draw(screen, msg, mainFont, op)
 }
@@ -921,8 +926,8 @@ func drawServerFPS(screen *ebiten.Image, ox, oy int, fps float64) {
 // drawEquippedItems renders icons for all currently equipped items in the top left.
 func drawEquippedItems(screen *ebiten.Image, ox, oy int) {
 	items := getInventory()
-	x := ox + 4*gs.Scale
-	y := oy + 4*gs.Scale
+	x := ox + int(4*gs.Scale)
+	y := oy + int(4*gs.Scale)
 	drawn := 0
 	for _, it := range items {
 		if !it.Equipped {
@@ -933,10 +938,10 @@ func drawEquippedItems(screen *ebiten.Image, ox, oy int) {
 			continue
 		}
 		op := &ebiten.DrawImageOptions{}
-		op.GeoM.Scale(float64(gs.Scale), float64(gs.Scale))
+		op.GeoM.Scale(gs.Scale, gs.Scale)
 		op.GeoM.Translate(float64(x), float64(y))
 		screen.DrawImage(img, op)
-		x += img.Bounds().Dx()*gs.Scale + 4*gs.Scale
+		x += int(float64(img.Bounds().Dx())*gs.Scale) + int(4*gs.Scale)
 		drawn++
 	}
 	if drawn == 0 {
@@ -944,16 +949,16 @@ func drawEquippedItems(screen *ebiten.Image, ox, oy int) {
 		if img == nil {
 			return
 		}
-		w := img.Bounds().Dx() * gs.Scale
+		w := int(float64(img.Bounds().Dx()) * gs.Scale)
 		opRight := &ebiten.DrawImageOptions{}
-		opRight.GeoM.Scale(float64(gs.Scale), float64(gs.Scale))
+		opRight.GeoM.Scale(gs.Scale, gs.Scale)
 		opRight.GeoM.Translate(float64(x), float64(y))
 		screen.DrawImage(img, opRight)
 
 		opLeft := &ebiten.DrawImageOptions{}
-		opLeft.GeoM.Scale(-float64(gs.Scale), float64(gs.Scale))
+		opLeft.GeoM.Scale(-gs.Scale, gs.Scale)
 		opLeft.GeoM.Translate(float64(w), 0)
-		opLeft.GeoM.Translate(float64(x+w+4*gs.Scale), float64(y))
+		opLeft.GeoM.Translate(float64(x+w)+4*gs.Scale, float64(y))
 		screen.DrawImage(img, opLeft)
 	}
 }
@@ -962,21 +967,21 @@ func drawEquippedItems(screen *ebiten.Image, ox, oy int) {
 func drawInputOverlay(screen *ebiten.Image, ox, oy int, txt string) {
 	metrics := mainFont.Metrics()
 	textHeight := int(math.Ceil(metrics.HAscent + metrics.HDescent))
-	pad := 2 * gs.Scale
+	pad := int(2 * gs.Scale)
 	barHeight := textHeight + pad*2
 
 	if inputBg == nil || inputBg.Bounds().Dy() != barHeight {
-		inputBg = ebiten.NewImage(gameAreaSizeX*gs.Scale, barHeight)
+		inputBg = ebiten.NewImage(int(float64(gameAreaSizeX)*gs.Scale), barHeight)
 		inputBg.Fill(color.RGBA{0, 0, 0, 128})
 	}
 
-	barTop := oy + gameAreaSizeY*gs.Scale - barHeight
+	barTop := oy + int(float64(gameAreaSizeY)*gs.Scale) - barHeight
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(float64(ox), float64(barTop))
 	screen.DrawImage(inputBg, op)
 
 	opTxt := &text.DrawOptions{}
-	opTxt.GeoM.Translate(float64(ox+4*gs.Scale), float64(barTop+pad))
+	opTxt.GeoM.Translate(float64(ox)+4*gs.Scale, float64(barTop+pad))
 	opTxt.ColorScale.ScaleWithColor(color.White)
 	text.Draw(screen, txt, mainFont, opTxt)
 }
@@ -995,7 +1000,7 @@ func runGame(ctx context.Context) {
 
 	gameWin = eui.NewWindow(&eui.WindowData{})
 	gameWin.Title = "Clan Lord"
-	gameWin.Size = eui.Point{X: float32(gameAreaSizeX * gs.Scale), Y: float32(gameAreaSizeY * gs.Scale)}
+	gameWin.Size = eui.Point{X: float32(float64(gameAreaSizeX) * gs.Scale), Y: float32(float64(gameAreaSizeY) * gs.Scale)}
 	gameWin.Closable = false
 	gameWin.Resizable = true
 	gameWin.Movable = true
@@ -1011,8 +1016,10 @@ func runGame(ctx context.Context) {
 
 	initUI()
 
-	ebiten.SetWindowSize(gameAreaSizeX*gs.Scale, gameAreaSizeY*gs.Scale)
-	lastWinW, lastWinH = gameAreaSizeX*gs.Scale, gameAreaSizeY*gs.Scale
+	w := int(math.Round(float64(gameAreaSizeX) * gs.Scale))
+	h := int(math.Round(float64(gameAreaSizeY) * gs.Scale))
+	ebiten.SetWindowSize(w, h)
+	lastWinW, lastWinH = w, h
 	ebiten.SetWindowTitle("ThoomSpeak")
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 	ebiten.SetVsyncEnabled(gs.vsync)

--- a/movie_player.go
+++ b/movie_player.go
@@ -47,7 +47,7 @@ func (p *moviePlayer) initUI() {
 	win.Closable = false
 	win.Resizable = false
 	win.AutoSize = true
-	win.Position = eui.Point{X: float32((gameAreaSizeX * gs.Scale) / 2), Y: 5}
+	win.Position = eui.Point{X: float32(float64(gameAreaSizeX) * gs.Scale / 2), Y: 5}
 	win.Closable = false
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}

--- a/network.go
+++ b/network.go
@@ -117,8 +117,8 @@ func sendPlayerInput(connection net.Conn) error {
 	flags := uint16(0)
 
 	x, y := ebiten.CursorPosition()
-	baseX := int16(x/gs.Scale - fieldCenterX)
-	baseY := int16(y/gs.Scale - fieldCenterY)
+	baseX := int16(float64(x)/gs.Scale - float64(fieldCenterX))
+	baseY := int16(float64(y)/gs.Scale - float64(fieldCenterY))
 	baseDown := ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
 	if pointInUI(x, y) {
 		baseDown = false

--- a/night.go
+++ b/night.go
@@ -187,7 +187,7 @@ func drawNightOverlay(screen *ebiten.Image, ox, oy int) {
 	}
 
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(float64(gs.Scale), float64(gs.Scale))
+	op.GeoM.Scale(gs.Scale, gs.Scale)
 	alpha := float32(lvl) / 100.0
 	op.ColorScale.ScaleAlpha(alpha)
 	op.GeoM.Translate(float64(ox), float64(oy))

--- a/settings.go
+++ b/settings.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -28,7 +29,7 @@ var gs settings = settings{
 	DenoiseSharpness:  4.0,
 	DenoisePercent:    0.2,
 	ShowFPS:           true,
-	Scale:             2,
+	Scale:             2.0,
 	UIScale:           1.0,
 
 	vsync:            true,
@@ -62,7 +63,7 @@ type settings struct {
 	DenoisePercent    float64
 	ShowFPS           bool
 
-	Scale   int
+	Scale   float64
 	UIScale float64
 
 	imgPlanesDebug   bool
@@ -96,7 +97,9 @@ func loadSettings() bool {
 
 	initFont()
 	resizeUI()
-	ebiten.SetWindowSize(gameAreaSizeX*gs.Scale, gameAreaSizeY*gs.Scale)
+	w := int(math.Round(float64(gameAreaSizeX) * gs.Scale))
+	h := int(math.Round(float64(gameAreaSizeY) * gs.Scale))
+	ebiten.SetWindowSize(w, h)
 	return true
 }
 
@@ -114,7 +117,9 @@ func applySettings() {
 	ebiten.SetVsyncEnabled(gs.vsync)
 	initFont()
 	resizeUI()
-	ebiten.SetWindowSize(gameAreaSizeX*gs.Scale, gameAreaSizeY*gs.Scale)
+	w := int(math.Round(float64(gameAreaSizeX) * gs.Scale))
+	h := int(math.Round(float64(gameAreaSizeY) * gs.Scale))
+	ebiten.SetWindowSize(w, h)
 }
 
 func saveSettings() {
@@ -132,7 +137,10 @@ func saveSettings() {
 func resizeUI() {
 	eui.SetUIScale(float32(gs.UIScale))
 	if gameWin != nil {
-		scale := eui.UIScale()
-		gameWin.Size = eui.Point{X: float32(gameAreaSizeX*gs.Scale) / scale, Y: float32(gameAreaSizeY*gs.Scale) / scale}
+		scale := float64(eui.UIScale())
+		gameWin.Size = eui.Point{
+			X: float32(float64(gameAreaSizeX) * gs.Scale / scale),
+			Y: float32(float64(gameAreaSizeY) * gs.Scale / scale),
+		}
 	}
 }

--- a/splash.go
+++ b/splash.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/draw"
 	"log"
+	"math"
 
 	"github.com/hajimehoshi/ebiten/v2"
 )
@@ -32,7 +33,8 @@ func drawSplash(screen *ebiten.Image, ox, oy int) {
 	if splashImg == nil {
 		return
 	}
-	sw, sh := gameAreaSizeX*gs.Scale, gameAreaSizeY*gs.Scale
+	sw := int(math.Round(float64(gameAreaSizeX) * gs.Scale))
+	sh := int(math.Round(float64(gameAreaSizeY) * gs.Scale))
 	iw, ih := splashImg.Bounds().Dx(), splashImg.Bounds().Dy()
 	scaleX := float64(sw) / float64(iw)
 	scaleY := float64(sh) / float64(ih)

--- a/ui.go
+++ b/ui.go
@@ -119,7 +119,7 @@ func openDownloadsWindow(status dataFilesStatus) {
 	downloadWin.Resizable = false
 	downloadWin.AutoSize = true
 	downloadWin.Movable = false
-	downloadWin.Position = eui.Point{X: float32((gameAreaSizeX * gs.Scale) / 2), Y: float32((gameAreaSizeY * gs.Scale) / 2)}
+	downloadWin.Position = eui.Point{X: float32(float64(gameAreaSizeX) * gs.Scale / 2), Y: float32(float64(gameAreaSizeY) * gs.Scale / 2)}
 	downloadWin.Open = true
 
 	startedDownload := false
@@ -260,7 +260,7 @@ func openAddCharacterWindow() {
 	addCharWin.Resizable = false
 	addCharWin.AutoSize = true
 	addCharWin.Movable = false
-	addCharWin.Position = eui.Point{X: float32((gameAreaSizeX * gs.Scale) / 2), Y: float32((gameAreaSizeY * gs.Scale) / 2)}
+	addCharWin.Position = eui.Point{X: float32(float64(gameAreaSizeX) * gs.Scale / 2), Y: float32(float64(gameAreaSizeY) * gs.Scale / 2)}
 	addCharWin.Open = true
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
@@ -448,7 +448,7 @@ func openErrorWindow(msg string) {
 	win.Resizable = false
 	win.AutoSize = true
 	win.Movable = false
-	win.Position = eui.Point{X: float32((gameAreaSizeX * gs.Scale) / 2), Y: 5}
+	win.Position = eui.Point{X: float32(float64(gameAreaSizeX) * gs.Scale / 2), Y: 5}
 	win.Open = true
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}


### PR DESCRIPTION
## Summary
- track game scale as a float value
- resize window and UI using float math so game rendering fills the Clan Lord window

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689684a191bc832aa26c52fa3cd756ea