### PR TITLE
Record login state in movie recordings

### DIFF
--- a/game.go
+++ b/game.go
@@ -50,6 +50,10 @@ var historyPos int
 var (
 	recorder            *movieRecorder
 	gPlayersListIsStale bool
+	loginGameState      []byte
+	loginMobileData     []byte
+	loginPictureTable   []byte
+	wroteLoginBlocks    bool
 )
 
 // gameWin represents the main playfield window. Its size corresponds to the
@@ -1134,10 +1138,44 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 			handleDisconnect()
 			return
 		}
+		tag := binary.BigEndian.Uint16(m[:2])
 		flags := frameFlags(m)
 		if recorder != nil {
-			if err := recorder.WriteFrame(m, flags); err != nil {
-				logError("record frame: %v", err)
+			if !wroteLoginBlocks {
+				if tag == 2 { // first draw state
+					if len(loginGameState) > 0 {
+						recorder.AddBlock(gameStateBlock(loginGameState), flagGameState)
+					}
+					if len(loginMobileData) > 0 {
+						recorder.AddBlock(loginMobileData, flagMobileData)
+					}
+					if len(loginPictureTable) > 0 {
+						recorder.AddBlock(loginPictureTable, flagPictureTable)
+					}
+					wroteLoginBlocks = true
+					if err := recorder.WriteFrame(m, flags); err != nil {
+						logError("record frame: %v", err)
+					}
+				} else {
+					if flags&flagGameState != 0 {
+						payload := append([]byte(nil), m[2:]...)
+						parseGameState(payload, uint16(clientVersion), uint16(movieRevision))
+						loginGameState = payload
+					}
+					if flags&flagMobileData != 0 {
+						payload := append([]byte(nil), m[2:]...)
+						parseMobileTable(payload, 0, uint16(clientVersion), uint16(movieRevision))
+						loginMobileData = payload
+					}
+					if flags&flagPictureTable != 0 {
+						payload := append([]byte(nil), m[2:]...)
+						loginPictureTable = payload
+					}
+				}
+			} else {
+				if err := recorder.WriteFrame(m, flags); err != nil {
+					logError("record frame: %v", err)
+				}
 			}
 		}
 		latencyMu.Lock()
@@ -1151,7 +1189,6 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 			lastInputSent = time.Time{}
 		}
 		latencyMu.Unlock()
-		tag := binary.BigEndian.Uint16(m[:2])
 		if tag == 2 { // kMsgDrawState
 			noteFrame()
 			handleDrawState(m)
@@ -1186,13 +1223,46 @@ loop:
 			handleDisconnect()
 			break
 		}
+		tag := binary.BigEndian.Uint16(m[:2])
 		flags := frameFlags(m)
 		if recorder != nil {
-			if err := recorder.WriteFrame(m, flags); err != nil {
-				logError("record frame: %v", err)
+			if !wroteLoginBlocks {
+				if tag == 2 { // first draw state
+					if len(loginGameState) > 0 {
+						recorder.AddBlock(gameStateBlock(loginGameState), flagGameState)
+					}
+					if len(loginMobileData) > 0 {
+						recorder.AddBlock(loginMobileData, flagMobileData)
+					}
+					if len(loginPictureTable) > 0 {
+						recorder.AddBlock(loginPictureTable, flagPictureTable)
+					}
+					wroteLoginBlocks = true
+					if err := recorder.WriteFrame(m, flags); err != nil {
+						logError("record frame: %v", err)
+					}
+				} else {
+					if flags&flagGameState != 0 {
+						payload := append([]byte(nil), m[2:]...)
+						parseGameState(payload, uint16(clientVersion), uint16(movieRevision))
+						loginGameState = payload
+					}
+					if flags&flagMobileData != 0 {
+						payload := append([]byte(nil), m[2:]...)
+						parseMobileTable(payload, 0, uint16(clientVersion), uint16(movieRevision))
+						loginMobileData = payload
+					}
+					if flags&flagPictureTable != 0 {
+						payload := append([]byte(nil), m[2:]...)
+						loginPictureTable = payload
+					}
+				}
+			} else {
+				if err := recorder.WriteFrame(m, flags); err != nil {
+					logError("record frame: %v", err)
+				}
 			}
 		}
-		tag := binary.BigEndian.Uint16(m[:2])
 		if tag == 2 { // kMsgDrawState
 			noteFrame()
 			handleDrawState(m)


### PR DESCRIPTION
## Summary
- Capture login game state, mobile table, and picture table before the first frame
- Allow movie recorder to prepend blocks for game state, mobile data, and picture table

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689684ed5f90832a93589f5f311c9a38