### PR TITLE
Fix input ordering for layered EUI windows

### DIFF
--- a/input_ui.go
+++ b/input_ui.go
@@ -12,8 +12,11 @@ var overlayLogOnce sync.Once
 // pointInUI reports whether the given screen coordinate lies within any EUI window or overlay.
 func pointInUI(x, y int) bool {
 	fx, fy := float32(x), float32(y)
-	for _, win := range eui.Windows() {
-		if !win.Open {
+
+	wins := eui.Windows()
+	for i := len(wins) - 1; i >= 0; i-- {
+		win := wins[i]
+		if !win.Open || win.MainPortal {
 			continue
 		}
 		pos := win.GetPos()
@@ -26,7 +29,9 @@ func pointInUI(x, y int) bool {
 	// Log overlay bounds once to aid debugging of hit detection.
 	overlayLogOnce.Do(logOverlayBounds)
 
-	for _, ov := range eui.Overlays() {
+	ovs := eui.Overlays()
+	for i := len(ovs) - 1; i >= 0; i-- {
+		ov := ovs[i]
 		if !ov.Open {
 			continue
 		}

--- a/input_ui_test.go
+++ b/input_ui_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Distortions81/EUI/eui"
+)
+
+// TestPointInUISkipsMainPortal ensures that the base game window does not block
+// interaction with other UI windows.
+func TestPointInUISkipsMainPortal(t *testing.T) {
+	// Clean up any existing windows to avoid interference between tests.
+	for _, w := range eui.Windows() {
+		w.RemoveWindow()
+	}
+
+	// Main portal window covering 100x100 at origin.
+	mainWin := eui.NewWindow(&eui.WindowData{})
+	mainWin.Size = eui.Point{X: 100, Y: 100}
+	mainWin.Open = true
+	mainWin.MainPortal = true
+	mainWin.AddWindow(false)
+
+	// With only the main portal, the point should not be considered over UI.
+	if pointInUI(10, 10) {
+		t.Fatalf("pointInUI should ignore MainPortal window")
+	}
+
+	// Add a regular window at the same position.
+	frontWin := eui.NewWindow(&eui.WindowData{})
+	frontWin.Size = eui.Point{X: 20, Y: 20}
+	frontWin.Open = true
+	frontWin.AddWindow(false)
+
+	if !pointInUI(10, 10) {
+		t.Fatalf("pointInUI should detect top window")
+	}
+
+	// Cleanup
+	frontWin.RemoveWindow()
+	mainWin.RemoveWindow()
+}


### PR DESCRIPTION
## Summary
- prevent MainPortal window from blocking interaction with other EUI windows by processing windows and overlays front-to-back
- add unit test verifying MainPortal is ignored for UI hit detection

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68968ec44e44832a9ed138cc4e73c134