### PR TITLE
Auto-open player and inventory windows

### DIFF
--- a/game.go
+++ b/game.go
@@ -1008,6 +1008,10 @@ func runGame(ctx context.Context) {
 	h := int(math.Round(float64(gameAreaSizeY) * gs.Scale))
 	ebiten.SetWindowSize(w, h)
 	lastWinW, lastWinH = w, h
+
+	openInventoryWindow()
+	openPlayersWindow()
+
 	ebiten.SetWindowTitle("ThoomSpeak")
 	ebiten.SetVsyncEnabled(gs.vsync)
 	ebiten.SetTPS(ebiten.SyncWithFPS)

--- a/ui.go
+++ b/ui.go
@@ -1029,6 +1029,8 @@ func openInventoryWindow() {
 	inventoryWin.AddItem(title)
 	inventoryWin.AddItem(inventoryList)
 	inventoryWin.AddWindow(false)
+	inventoryWin.Position = eui.Point{X: 0, Y: 0}
+	inventoryWin.Refresh()
 	updateInventoryWindow()
 }
 
@@ -1050,6 +1052,10 @@ func openPlayersWindow() {
 	playersWin.Resizable = true
 	playersWin.AutoSize = true
 	playersWin.AddWindow(false)
+	w, _ := ebiten.WindowSize()
+	scale := float64(eui.UIScale())
+	playersWin.Position = eui.Point{X: float32(float64(w)/scale) - playersWin.Size.X, Y: 0}
+	playersWin.Refresh()
 	updatePlayersWindow()
 }
 


### PR DESCRIPTION
## Summary
- open inventory and players windows automatically on startup
- position inventory window at top-left and players window at top-right without pinning

## Testing
- `go test ./...` *(fails: GLFW library is not initialized due to missing DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_689693526874832a9dbfe5761e0595bf