### PR TITLE
Add chat bubbles window

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	maxChatMessages     = 5
+	chatMessageLifetime = 15 * time.Second
+)
+
+type chatMessage struct {
+	text   string
+	expire time.Time
+}
+
+var (
+	chatMsgMu sync.Mutex
+	chatMsgs  []chatMessage
+)
+
+func addChatMessage(msg string) {
+	if msg == "" {
+		return
+	}
+	chatMsgMu.Lock()
+	defer chatMsgMu.Unlock()
+	chatMsgs = append(chatMsgs, chatMessage{text: msg, expire: time.Now().Add(chatMessageLifetime)})
+	if len(chatMsgs) > maxChatMessages {
+		chatMsgs = chatMsgs[len(chatMsgs)-maxChatMessages:]
+	}
+}
+
+func getChatMessages() []string {
+	chatMsgMu.Lock()
+	defer chatMsgMu.Unlock()
+	now := time.Now()
+	var out []string
+	var keep []chatMessage
+	for _, m := range chatMsgs {
+		if now.After(m.expire) {
+			continue
+		}
+		out = append(out, m.text)
+		keep = append(keep, m)
+	}
+	chatMsgs = keep
+	return out
+}

--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -1,0 +1,45 @@
+//go:build !test
+
+package main
+
+import "github.com/Distortions81/EUI/eui"
+
+var chatWin *eui.WindowData
+var chatList *eui.ItemData
+
+func updateChatWindow() {
+	if chatList == nil {
+		return
+	}
+	msgs := getChatMessages()
+	chatList.Contents = chatList.Contents[:0]
+	for _, msg := range msgs {
+		t, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 256, Y: 24}})
+		chatList.AddItem(t)
+	}
+	if chatWin != nil {
+		chatWin.Refresh()
+	}
+}
+
+func openChatWindow() {
+	if chatWin != nil {
+		return
+	}
+	chatWin = eui.NewWindow(&eui.WindowData{})
+	chatWin.Title = "Chat"
+	chatWin.Closable = false
+	chatWin.Resizable = false
+	chatWin.AutoSize = true
+	chatWin.Movable = true
+	chatWin.Open = true
+
+	chatList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
+	chatWin.AddItem(chatList)
+	chatWin.AddWindow(false)
+
+	w := float32(256)
+	h := float32(150)
+	chatWin.Position = eui.Point{X: float32(float64(gameAreaSizeX)*gs.Scale) - w, Y: float32(float64(gameAreaSizeY)*gs.Scale) - h}
+	updateChatWindow()
+}

--- a/chat_messages_ui_test.go
+++ b/chat_messages_ui_test.go
@@ -1,0 +1,6 @@
+//go:build test
+
+package main
+
+func updateChatWindow() {}
+func openChatWindow()   {}

--- a/decode.go
+++ b/decode.go
@@ -337,7 +337,7 @@ func handleInfoText(data []byte) {
 			continue
 		}
 		if _, txt, _, _, _, _ := decodeBubble(line); txt != "" {
-			//fmt.Println(txt)
+			addChatMessage(txt)
 			if gs.bubbleMessages {
 				addMessage(txt)
 			}

--- a/draw.go
+++ b/draw.go
@@ -911,6 +911,7 @@ func parseDrawState(data []byte) error {
 					}
 				}
 			}
+			addChatMessage(msg)
 			if gs.bubbleMessages {
 				addMessage(msg)
 			}

--- a/game.go
+++ b/game.go
@@ -428,6 +428,7 @@ func gameContentOrigin() (int, int) {
 
 func (g *Game) Draw(screen *ebiten.Image) {
 	updateMessagesWindow()
+	updateChatWindow()
 	ox, oy := gameContentOrigin()
 	if clmov == "" && tcpConn == nil {
 		drawSplash(screen, ox, oy)

--- a/ui.go
+++ b/ui.go
@@ -169,6 +169,7 @@ func initUI() {
 	eui.AddOverlayFlow(overlay)
 
 	openMessagesWindow()
+	openChatWindow()
 }
 
 func openDownloadsWindow(status dataFilesStatus) {


### PR DESCRIPTION
## Summary
- track chat bubble messages separately
- show chat messages in a new bottom-right chat window
- surface bubble text updates and refresh the chat window each frame

## Testing
- `go test -tags test ./...` *(fails: undefined DebugMode in EUI)*
- `go test ./...` *(fails: glfw: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68969394ea54832ab0c66bf73147d8d5