### PR TITLE
Start in maximized window

### DIFF
--- a/game.go
+++ b/game.go
@@ -984,8 +984,12 @@ func runGame(ctx context.Context) {
 	gameCtx = ctx
 
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
-	ebiten.SetWindowSize(initialWindowW, initialWindowH)
-	lastWinW, lastWinH = initialWindowW, initialWindowH
+	w, h := ebiten.ScreenSizeInFullscreen()
+	if w == 0 || h == 0 {
+		w, h = initialWindowW, initialWindowH
+	}
+	ebiten.SetWindowSize(w, h)
+	lastWinW, lastWinH = w, h
 	ebiten.MaximizeWindow()
 
 	if err := ebiten.RunGame(&Game{}); err != nil {


### PR DESCRIPTION
## Summary
- Detect screen size and set initial Ebiten window to fill the display
- Fall back to prior dimensions if screen size can't be determined

## Testing
- `go test ./...` *(fails: GLFW library is not initialized, missing DISPLAY variable)*

------
https://chatgpt.com/codex/tasks/task_e_6896a8331cf8832a9ad65f52c457fabf