### PR TITLE
Avoid resizing Clan Lord game window

### DIFF
--- a/game.go
+++ b/game.go
@@ -408,22 +408,21 @@ func updateGameScale() {
 	if size.X <= 0 || size.Y <= 0 {
 		return
 	}
-	scaleW := float64(size.X) / float64(gameAreaSizeX)
-	scaleH := float64(size.Y) / float64(gameAreaSizeY)
-	newScale := math.Round(math.Min(scaleW, scaleH))
+
+	// Use an even-numbered drawing area to avoid gaps between tiles.
+	w := float64(int(size.X) &^ 1)
+	h := float64(int(size.Y) &^ 1)
+
+	scaleW := w / float64(gameAreaSizeX)
+	scaleH := h / float64(gameAreaSizeY)
+	newScale := math.Floor(math.Min(scaleW, scaleH))
 	if newScale < 1 {
 		newScale = 1
 	}
-	desired := eui.Point{
-		X: float32(gameAreaSizeX) * float32(newScale),
-		Y: float32(gameAreaSizeY) * float32(newScale),
-	}
+
 	if gs.Scale != newScale {
 		gs.Scale = newScale
-		gameWin.Size = desired
 		initFont()
-	} else if size.X != desired.X || size.Y != desired.Y {
-		gameWin.Size = desired
 	}
 }
 
@@ -445,8 +444,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	ox, oy := gameContentOrigin()
 	if gameWin != nil {
 		size := gameWin.GetSize()
+		w := float32(int(size.X) &^ 1)
+		h := float32(int(size.Y) &^ 1)
 		bg := color.RGBA(gameWin.Theme.Window.BGColor)
-		vector.DrawFilledRect(screen, float32(ox), float32(oy), float32(size.X), float32(size.Y), bg, false)
+		vector.DrawFilledRect(screen, float32(ox), float32(oy), w, h, bg, false)
 	}
 	if clmov == "" && tcpConn == nil {
 		drawSplash(screen, ox, oy)


### PR DESCRIPTION
## Summary
- Determine game scale from even pixel dimensions without resizing the Clan Lord window
- Draw the game using even-width and height to avoid tile gaps

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6896ccfd7c84832aaf1306b12ae7cbe2