### PR TITLE
Mask unused area outside game view

### DIFF
--- a/game.go
+++ b/game.go
@@ -466,6 +466,21 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	}
 	drawEquippedItems(screen, ox, oy)
 
+	if gameWin != nil {
+		size := gameWin.GetSize()
+		w := float32(int(size.X) &^ 1)
+		h := float32(int(size.Y) &^ 1)
+		fw := float32(float64(gameAreaSizeX) * gs.Scale)
+		fh := float32(float64(gameAreaSizeY) * gs.Scale)
+		dark := color.RGBA{0x40, 0x40, 0x40, 0xff}
+		if fw < w {
+			vector.DrawFilledRect(screen, float32(ox)+fw, float32(oy), w-fw, fh, dark, false)
+		}
+		if fh < h {
+			vector.DrawFilledRect(screen, float32(ox), float32(oy)+fh, w, h-fh, dark, false)
+		}
+	}
+
 	eui.Draw(screen)
 	drawStatusBars(screen, ox, oy, snap, alpha)
 	if gs.ShowFPS {


### PR DESCRIPTION
## Summary
- Cover unused portions of the Clan Lord window with a dark gray mask so the game view never exposes off-screen areas.

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896da30d81c832aa9993ddbc26fe7f1