### PR TITLE
Align game content with window to remove top-left gap

### DIFF
--- a/game.go
+++ b/game.go
@@ -433,9 +433,9 @@ func gameContentOrigin() (int, int) {
 	s := eui.UIScale()
 	pos := gameWin.GetPos()
 	frame := (gameWin.Margin + gameWin.Border + gameWin.BorderPad + gameWin.Padding) * s
-	x := pos.X + frame
-	y := pos.Y + frame + gameWin.GetTitleSize()
-	return int(x), int(y)
+        x := pos.X + frame
+        y := pos.Y + frame + gameWin.GetTitleSize()
+        return int(math.Round(float64(x))), int(math.Round(float64(y)))
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {


### PR DESCRIPTION
## Summary
- round game content origin to nearest pixel to eliminate top-left gap between window and content

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896e1e93ad4832a8006adfd30fe3533