### PR TITLE
Use dirty flags for window updates

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -56,7 +56,7 @@ func parseBackendInfo(data []byte) {
 	p.Class = class
 	p.Clan = clan
 	playersMu.Unlock()
-	updatePlayersWindow()
+	playersDirty.Store(true)
 }
 
 // parseBackendShare parses "be-sh" messages describing sharing relationships.
@@ -93,7 +93,7 @@ func parseBackendShare(data []byte) {
 		p.Sharing = true
 		playersMu.Unlock()
 	}
-	updatePlayersWindow()
+	playersDirty.Store(true)
 }
 
 // parseBackendWho parses "be-wh" messages listing players.
@@ -116,7 +116,7 @@ func parseBackendWho(data []byte) {
 		}
 		data = data[idx+1:]
 	}
-	updatePlayersWindow()
+	playersDirty.Store(true)
 }
 
 // parseNames extracts a slice of names from a sequence of "-pn name -pn" entries.

--- a/chat_messages.go
+++ b/chat_messages.go
@@ -30,6 +30,7 @@ func addChatMessage(msg string) {
 	if len(chatMsgs) > maxChatMessages {
 		chatMsgs = chatMsgs[len(chatMsgs)-maxChatMessages:]
 	}
+	chatDirty.Store(true)
 }
 
 func getChatMessages() []string {

--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -2,10 +2,15 @@
 
 package main
 
-import "github.com/Distortions81/EUI/eui"
+import (
+	"sync/atomic"
+
+	"github.com/Distortions81/EUI/eui"
+)
 
 var chatWin *eui.WindowData
 var chatList *eui.ItemData
+var chatDirty atomic.Bool
 
 func updateChatWindow() {
 	if chatList == nil {
@@ -42,5 +47,5 @@ func openChatWindow() {
 	chatWin.AddItem(chatList)
 	chatWin.AddWindow(false)
 
-	updateChatWindow()
+	chatDirty.Store(true)
 }

--- a/draw.go
+++ b/draw.go
@@ -413,7 +413,7 @@ func parseInventory(data []byte) ([]byte, bool) {
 	for len(data) > 0 && data[0] == 0 {
 		data = data[1:]
 	}
-	updateInventoryWindow()
+	inventoryDirty.Store(true)
 	return data, true
 }
 

--- a/game.go
+++ b/game.go
@@ -278,6 +278,8 @@ func (g *Game) Update() error {
 		saveSettings()
 		settingsDirty = false
 	}
+	prevInputActive := inputActive
+	prevInputText := string(inputText)
 
 	if inputActive {
 		inputText = append(inputText, ebiten.AppendInputChars(nil)...)
@@ -337,6 +339,10 @@ func (g *Game) Update() error {
 			inputText = inputText[:0]
 			historyPos = len(inputHistory)
 		}
+	}
+
+	if prevInputActive != inputActive || prevInputText != string(inputText) {
+		messagesDirty.Store(true)
 	}
 
 	if !inputActive {
@@ -439,8 +445,18 @@ func gameContentOrigin() (int, int) {
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {
-	updateMessagesWindow()
-	updateChatWindow()
+	if playersDirty.Swap(false) {
+		updatePlayersWindow()
+	}
+	if inventoryDirty.Swap(false) {
+		updateInventoryWindow()
+	}
+	if messagesDirty.Swap(false) {
+		updateMessagesWindow()
+	}
+	if chatDirty.Swap(false) {
+		updateChatWindow()
+	}
 	ox, oy := gameContentOrigin()
 	if gameWin != nil {
 		size := gameWin.GetSize()

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -3,11 +3,14 @@
 package main
 
 import (
+	"sync/atomic"
+
 	"github.com/Distortions81/EUI/eui"
 )
 
 var inventoryWin *eui.WindowData
 var inventoryList *eui.ItemData
+var inventoryDirty atomic.Bool
 
 func updateInventoryWindow() {
 	if inventoryList == nil {

--- a/messages.go
+++ b/messages.go
@@ -31,6 +31,7 @@ func addMessage(msg string) {
 	if len(messages) > maxMessages {
 		messages = messages[len(messages)-maxMessages:]
 	}
+	messagesDirty.Store(true)
 }
 
 func getMessages() []string {

--- a/messages_ui.go
+++ b/messages_ui.go
@@ -2,10 +2,15 @@
 
 package main
 
-import "github.com/Distortions81/EUI/eui"
+import (
+	"sync/atomic"
+
+	"github.com/Distortions81/EUI/eui"
+)
 
 var messagesWin *eui.WindowData
 var messagesList *eui.ItemData
+var messagesDirty atomic.Bool
 
 func updateMessagesWindow() {
 	if messagesList == nil {
@@ -48,5 +53,5 @@ func openMessagesWindow() {
 	messagesWin.AddItem(messagesList)
 	messagesWin.AddWindow(false)
 
-	updateMessagesWindow()
+	messagesDirty.Store(true)
 }

--- a/player.go
+++ b/player.go
@@ -35,7 +35,7 @@ func getPlayer(name string) *Player {
 	}
 	p = &Player{Name: name}
 	players[name] = p
-	updatePlayersWindow()
+	playersDirty.Store(true)
 	return p
 }
 
@@ -52,7 +52,7 @@ func updatePlayerAppearance(name string, pictID uint16, colors []byte, isNPC boo
 	}
 	p.IsNPC = isNPC
 	playersMu.Unlock()
-	updatePlayersWindow()
+	playersDirty.Store(true)
 }
 
 func getPlayers() []Player {

--- a/players_ui.go
+++ b/players_ui.go
@@ -5,12 +5,14 @@ package main
 import (
 	"fmt"
 	"sort"
+	"sync/atomic"
 
 	"github.com/Distortions81/EUI/eui"
 )
 
 var playersWin *eui.WindowData
 var playersList *eui.ItemData
+var playersDirty atomic.Bool
 
 func updatePlayersWindow() {
 	if playersList == nil {

--- a/ui.go
+++ b/ui.go
@@ -1101,7 +1101,7 @@ func openInventoryWindow() {
 	inventoryWin.AddWindow(false)
 	inventoryWin.Position = eui.Point{X: 0, Y: 0}
 	inventoryWin.Refresh()
-	updateInventoryWindow()
+	inventoryDirty.Store(true)
 	if inventoryBox != nil {
 		inventoryBox.Checked = true
 		inventoryBox.Dirty = true
@@ -1127,7 +1127,7 @@ func openPlayersWindow() {
 	playersWin.AddItem(playersList)
 	playersWin.AddWindow(false)
 	playersWin.Refresh()
-	updatePlayersWindow()
+	playersDirty.Store(true)
 }
 
 func openHelpWindow() {


### PR DESCRIPTION
## Summary
- Avoid refreshing player, inventory, console and chat windows every frame
- Introduce atomic dirty flags and refresh windows only when their state changes

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896e3bfe8b0832ab4e183beb8e47214