### PR TITLE
Add option to enable world sizes beyond double

### DIFF
--- a/game.go
+++ b/game.go
@@ -425,6 +425,9 @@ func updateGameScale() {
 	if newScale < 1 {
 		newScale = 1
 	}
+	if !gs.MoreWorldSizes && newScale > 2 {
+		newScale = 2
+	}
 
 	if gs.Scale != newScale {
 		gs.Scale = newScale
@@ -439,9 +442,9 @@ func gameContentOrigin() (int, int) {
 	s := eui.UIScale()
 	pos := gameWin.GetPos()
 	frame := (gameWin.Margin + gameWin.Border + gameWin.BorderPad + gameWin.Padding) * s
-        x := pos.X + frame
-        y := pos.Y + frame + gameWin.GetTitleSize()
-        return int(math.Round(float64(x))), int(math.Round(float64(y)))
+	x := pos.X + frame
+	y := pos.Y + frame + gameWin.GetTitleSize()
+	return int(math.Round(float64(x))), int(math.Round(float64(y)))
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {

--- a/settings.go
+++ b/settings.go
@@ -29,6 +29,7 @@ var gs settings = settings{
 	ShowFPS:           true,
 	Scale:             2.0,
 	UIScale:           1.0,
+	MoreWorldSizes:    true,
 
 	vsync:            true,
 	nightEffect:      true,
@@ -61,8 +62,9 @@ type settings struct {
 	DenoisePercent    float64
 	ShowFPS           bool
 
-	Scale   float64
-	UIScale float64
+	Scale          float64
+	UIScale        float64
+	MoreWorldSizes bool
 
 	imgPlanesDebug   bool
 	smoothingDebug   bool

--- a/ui.go
+++ b/ui.go
@@ -622,6 +622,15 @@ func openSettingsWindow() {
 	}
 	mainFlow.AddItem(uiScaleSlider)
 
+	worldSizeCB, worldSizeEvents := eui.NewCheckbox(&eui.ItemData{Text: "Allow More World Sizes", Size: eui.Point{X: width, Y: 24}, Checked: gs.MoreWorldSizes})
+	worldSizeEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.MoreWorldSizes = ev.Checked
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(worldSizeCB)
+
 	denoiseCB, denoiseEvents := eui.NewCheckbox(&eui.ItemData{Text: "Image Denoise", Size: eui.Point{X: width, Y: 24}, Checked: gs.DenoiseImages})
 	denoiseEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {


### PR DESCRIPTION
## Summary
- add `MoreWorldSizes` setting and UI toggle
- allow world scale to exceed 2x when enabled

## Testing
- `gofmt -w settings.go game.go ui.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896e890b3ec832aa72c014b60053ed7