### PR TITLE
Persist window layout settings

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -35,13 +35,20 @@ func openChatWindow() {
 	}
 	chatWin = eui.NewWindow(&eui.WindowData{})
 	chatWin.Title = "Chat"
-	chatWin.Size = eui.Point{X: 700, Y: 300}
+	if gs.ChatWindow.Size.X > 0 && gs.ChatWindow.Size.Y > 0 {
+		chatWin.Size = eui.Point{X: float32(gs.ChatWindow.Size.X), Y: float32(gs.ChatWindow.Size.Y)}
+	} else {
+		chatWin.Size = eui.Point{X: 700, Y: 300}
+	}
 	chatWin.Closable = true
 	chatWin.Resizable = true
 	chatWin.AutoSize = false
 	chatWin.Movable = false
 	chatWin.Open = true
 	chatWin.PinTo = eui.PIN_BOTTOM_RIGHT
+	if gs.ChatWindow.Position.X != 0 || gs.ChatWindow.Position.Y != 0 {
+		chatWin.Position = eui.Point{X: float32(gs.ChatWindow.Position.X), Y: float32(gs.ChatWindow.Position.Y)}
+	}
 
 	chatList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	chatWin.AddItem(chatList)

--- a/game.go
+++ b/game.go
@@ -270,6 +270,10 @@ type Game struct{}
 func (g *Game) Update() error {
 	eui.Update()
 
+	if syncWindowSettings() {
+		settingsDirty = true
+	}
+
 	updateGameScale()
 
 	updateDebugStats()
@@ -439,9 +443,9 @@ func gameContentOrigin() (int, int) {
 	s := eui.UIScale()
 	pos := gameWin.GetPos()
 	frame := (gameWin.Margin + gameWin.Border + gameWin.BorderPad + gameWin.Padding) * s
-        x := pos.X + frame
-        y := pos.Y + frame + gameWin.GetTitleSize()
-        return int(math.Round(float64(x))), int(math.Round(float64(y)))
+	x := pos.X + frame
+	y := pos.Y + frame + gameWin.GetTitleSize()
+	return int(math.Round(float64(x))), int(math.Round(float64(y)))
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {
@@ -1052,8 +1056,16 @@ func initGame() {
 
 	gameWin = eui.NewWindow(&eui.WindowData{})
 	gameWin.Title = "Clan Lord"
-	gameWin.Size = eui.Point{X: float32(gameAreaSizeX), Y: float32(gameAreaSizeY)}
-	gameWin.Position = eui.Point{X: 350, Y: 100}
+	if gs.GameWindow.Size.X > 0 && gs.GameWindow.Size.Y > 0 {
+		gameWin.Size = eui.Point{X: float32(gs.GameWindow.Size.X), Y: float32(gs.GameWindow.Size.Y)}
+	} else {
+		gameWin.Size = eui.Point{X: float32(gameAreaSizeX), Y: float32(gameAreaSizeY)}
+	}
+	if gs.GameWindow.Position.X != 0 || gs.GameWindow.Position.Y != 0 {
+		gameWin.Position = eui.Point{X: float32(gs.GameWindow.Position.X), Y: float32(gs.GameWindow.Position.Y)}
+	} else {
+		gameWin.Position = eui.Point{X: 350, Y: 100}
+	}
 	gameWin.Closable = false
 	gameWin.Resizable = true
 	gameWin.Movable = true
@@ -1065,8 +1077,12 @@ func initGame() {
 
 	gameWin.AddWindow(false)
 
-	openInventoryWindow()
-	openPlayersWindow()
+	if gs.InventoryWindow.Open {
+		openInventoryWindow()
+	}
+	if gs.PlayersWindow.Open {
+		openPlayersWindow()
+	}
 
 	initUI()
 

--- a/messages_ui.go
+++ b/messages_ui.go
@@ -40,7 +40,11 @@ func openMessagesWindow() {
 		}
 	}
 	messagesWin = eui.NewWindow(&eui.WindowData{})
-	messagesWin.Size = eui.Point{X: 700, Y: 300}
+	if gs.MessagesWindow.Size.X > 0 && gs.MessagesWindow.Size.Y > 0 {
+		messagesWin.Size = eui.Point{X: float32(gs.MessagesWindow.Size.X), Y: float32(gs.MessagesWindow.Size.Y)}
+	} else {
+		messagesWin.Size = eui.Point{X: 700, Y: 300}
+	}
 	messagesWin.Title = "Console"
 	messagesWin.Closable = true
 	messagesWin.Resizable = true
@@ -48,6 +52,9 @@ func openMessagesWindow() {
 	messagesWin.Movable = false
 	messagesWin.Open = true
 	messagesWin.PinTo = eui.PIN_BOTTOM_LEFT
+	if gs.MessagesWindow.Position.X != 0 || gs.MessagesWindow.Position.Y != 0 {
+		messagesWin.Position = eui.Point{X: float32(gs.MessagesWindow.Position.X), Y: float32(gs.MessagesWindow.Position.Y)}
+	}
 
 	messagesList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	messagesWin.AddItem(messagesList)

--- a/ui.go
+++ b/ui.go
@@ -164,8 +164,12 @@ func initUI() {
 
 	eui.AddOverlayFlow(overlay)
 
-	openMessagesWindow()
-	openChatWindow()
+	if gs.MessagesWindow.Open {
+		openMessagesWindow()
+	}
+	if gs.ChatWindow.Open {
+		openChatWindow()
+	}
 }
 
 func openDownloadsWindow(status dataFilesStatus) {
@@ -1029,7 +1033,7 @@ func openWindowsWindow() {
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 
-	playersBox, playersBoxEvents := eui.NewCheckbox(&eui.ItemData{Text: "Players", Size: eui.Point{X: 128, Y: 24}})
+	playersBox, playersBoxEvents := eui.NewCheckbox(&eui.ItemData{Text: "Players", Size: eui.Point{X: 128, Y: 24}, Checked: playersWin != nil})
 	playersBoxEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			if ev.Checked {
@@ -1094,12 +1098,20 @@ func openInventoryWindow() {
 	inventoryWin.PinTo = eui.PIN_TOP_LEFT
 	inventoryWin.Open = true
 
+	if gs.InventoryWindow.Size.X > 0 && gs.InventoryWindow.Size.Y > 0 {
+		inventoryWin.Size = eui.Point{X: float32(gs.InventoryWindow.Size.X), Y: float32(gs.InventoryWindow.Size.Y)}
+	}
+	if gs.InventoryWindow.Position.X != 0 || gs.InventoryWindow.Position.Y != 0 {
+		inventoryWin.Position = eui.Point{X: float32(gs.InventoryWindow.Position.X), Y: float32(gs.InventoryWindow.Position.Y)}
+	} else {
+		inventoryWin.Position = eui.Point{X: 0, Y: 0}
+	}
+
 	inventoryList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	title, _ := eui.NewText(&eui.ItemData{Text: "Inventory", Size: eui.Point{X: 256, Y: 128}})
 	inventoryWin.AddItem(title)
 	inventoryWin.AddItem(inventoryList)
 	inventoryWin.AddWindow(false)
-	inventoryWin.Position = eui.Point{X: 0, Y: 0}
 	inventoryWin.Refresh()
 	inventoryDirty.Store(true)
 	if inventoryBox != nil {
@@ -1116,12 +1128,19 @@ func openPlayersWindow() {
 	}
 	playersWin = eui.NewWindow(&eui.WindowData{})
 	playersWin.Title = "Players"
-	playersWin.Size = eui.Point{X: 300, Y: 600}
+	if gs.PlayersWindow.Size.X > 0 && gs.PlayersWindow.Size.Y > 0 {
+		playersWin.Size = eui.Point{X: float32(gs.PlayersWindow.Size.X), Y: float32(gs.PlayersWindow.Size.Y)}
+	} else {
+		playersWin.Size = eui.Point{X: 300, Y: 600}
+	}
 	playersWin.Closable = false
 	playersWin.Resizable = false
 	playersWin.Movable = false
 	playersWin.PinTo = eui.PIN_TOP_RIGHT
 	playersWin.Open = true
+	if gs.PlayersWindow.Position.X != 0 || gs.PlayersWindow.Position.Y != 0 {
+		playersWin.Position = eui.Point{X: float32(gs.PlayersWindow.Position.X), Y: float32(gs.PlayersWindow.Position.Y)}
+	}
 
 	playersList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	playersWin.AddItem(playersList)


### PR DESCRIPTION
## Summary
- Track open state, position, and size for game and UI windows in settings
- Restore window layout on startup and update settings when windows move

## Testing
- `gofmt -w settings.go game.go ui.go messages_ui.go chat_messages_ui.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896ea6da02c832ab120bca786219d21