### PR TITLE
Split precache option into sounds and images

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -40,16 +40,28 @@ var assetsPrecached = false
 func precacheAssets() {
 
 	for {
-		if clImages == nil || clSounds == nil {
+		if (gs.precacheImages && clImages == nil) || (gs.precacheSounds && clSounds == nil) {
 			time.Sleep(time.Millisecond * 100)
 		} else {
 			break
 		}
 	}
 
-	addMessage("Pre-loading game sounds and images...")
+	var preloadMsg string
+	switch {
+	case gs.precacheImages && gs.precacheSounds:
+		preloadMsg = "Pre-loading game sounds and images..."
+	case gs.precacheImages:
+		preloadMsg = "Pre-loading game images..."
+	case gs.precacheSounds:
+		preloadMsg = "Pre-loading game sounds..."
+	}
+	if preloadMsg != "" {
+		addMessage(preloadMsg)
+	}
+
 	wg := sizedwaitgroup.New(runtime.NumCPU())
-	if clImages != nil {
+	if gs.precacheImages && clImages != nil {
 		for _, id := range clImages.IDs() {
 			wg.Add()
 			go func(id uint32) {
@@ -59,7 +71,7 @@ func precacheAssets() {
 		}
 	}
 
-	if clSounds != nil {
+	if gs.precacheSounds && clSounds != nil {
 		for _, id := range clSounds.IDs() {
 			wg.Add()
 			go func(id uint32) {
@@ -70,5 +82,17 @@ func precacheAssets() {
 	}
 	wg.Wait()
 	assetsPrecached = true
-	addMessage("All images and sounds have been loaded.")
+
+	var doneMsg string
+	switch {
+	case gs.precacheImages && gs.precacheSounds:
+		doneMsg = "All images and sounds have been loaded."
+	case gs.precacheImages:
+		doneMsg = "All images have been loaded."
+	case gs.precacheSounds:
+		doneMsg = "All sounds have been loaded."
+	}
+	if doneMsg != "" {
+		addMessage(doneMsg)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func main() {
 		logError("failed to load CL_Sounds: %v", err)
 	}
 
-	if gs.precacheAssets {
+	if gs.precacheSounds || gs.precacheImages {
 		go precacheAssets()
 	}
 
@@ -136,7 +136,7 @@ func main() {
 		mp := newMoviePlayer(frames, clMovFPS, cancel)
 		mp.initUI()
 
-		if gs.precacheAssets && !assetsPrecached {
+		if (gs.precacheSounds || gs.precacheImages) && !assetsPrecached {
 			for !assetsPrecached {
 				time.Sleep(time.Millisecond * 100)
 			}

--- a/settings.go
+++ b/settings.go
@@ -35,6 +35,8 @@ var gs settings = settings{
 	vsync:            true,
 	nightEffect:      true,
 	lateInputUpdates: true,
+	precacheSounds:   true,
+	precacheImages:   false,
 	cacheWholeSheet:  true,
 	smoothMoving:     true,
 	fastBars:         true,
@@ -80,7 +82,8 @@ type settings struct {
 	vsync            bool
 	fastSound        bool
 	nightEffect      bool
-	precacheAssets   bool
+	precacheSounds   bool
+	precacheImages   bool
 	textureFiltering bool
 	lateInputUpdates bool
 	cacheWholeSheet  bool

--- a/ui.go
+++ b/ui.go
@@ -459,7 +459,7 @@ func openLoginWindow() {
 				ctx, cancel := context.WithCancel(gameCtx)
 				mp := newMoviePlayer(frames, clMovFPS, cancel)
 				mp.initUI()
-				if gs.precacheAssets && !assetsPrecached {
+				if (gs.precacheSounds || gs.precacheImages) && !assetsPrecached {
 					for !assetsPrecached {
 						time.Sleep(100 * time.Millisecond)
 					}
@@ -788,14 +788,23 @@ func openDebugWindow() {
 	}
 	debugFlow.AddItem(showFPSCB)
 
-	precacheCB, precacheEvents := eui.NewCheckbox(&eui.ItemData{Text: "Precache Sounds and Sprites", Size: eui.Point{X: width, Y: 24}, Checked: gs.precacheAssets})
-	precacheEvents.Handle = func(ev eui.UIEvent) {
+	precacheSoundCB, precacheSoundEvents := eui.NewCheckbox(&eui.ItemData{Text: "Precache Sounds", Size: eui.Point{X: width, Y: 24}, Checked: gs.precacheSounds})
+	precacheSoundEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
-			gs.precacheAssets = ev.Checked
+			gs.precacheSounds = ev.Checked
 			settingsDirty = true
 		}
 	}
-	debugFlow.AddItem(precacheCB)
+	debugFlow.AddItem(precacheSoundCB)
+
+	precacheImageCB, precacheImageEvents := eui.NewCheckbox(&eui.ItemData{Text: "Precache Images", Size: eui.Point{X: width, Y: 24}, Checked: gs.precacheImages})
+	precacheImageEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.precacheImages = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(precacheImageCB)
 
 	filt, filtEvents := eui.NewCheckbox(&eui.ItemData{Text: "Image Filtering", Size: eui.Point{X: width, Y: 24}, Checked: gs.textureFiltering})
 	filtEvents.Handle = func(ev eui.UIEvent) {


### PR DESCRIPTION
## Summary
- Add separate `precacheSounds` and `precacheImages` settings with sounds enabled by default
- Update asset preload logic and settings UI to respect individual options

## Testing
- `go vet ./...`
- `go fmt ./...`


------
https://chatgpt.com/codex/tasks/task_e_689785fb831c832aae713cb24f7949dc