### PR TITLE
Use linear audio resampling by default

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -831,7 +831,7 @@ func openDebugWindow() {
 			if gs.fastSound {
 				resample = resampleFast
 			} else {
-				resample = resampleSincHQ
+				resample = resampleLinear
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- add linear interpolation resampler
- use linear resampling by default and keep fast nearest option

## Testing
- `go fmt sound.go ui.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689795c3c658832aa8fb095088e0f91a