### PR TITLE
Cache image planes for picture sorting

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -24,6 +24,7 @@ type framePicture struct {
 	PictID       uint16
 	H, V         int16
 	PrevH, PrevV int16
+	Plane        int
 	Moving       bool
 	Background   bool
 	Owned        bool
@@ -51,13 +52,8 @@ const (
 
 func sortPictures(pics []framePicture) {
 	sort.Slice(pics, func(i, j int) bool {
-		pi, pj := 0, 0
-		if clImages != nil {
-			pi = clImages.Plane(uint32(pics[i].PictID))
-			pj = clImages.Plane(uint32(pics[j].PictID))
-		}
-		if pi != pj {
-			return pi < pj
+		if pics[i].Plane != pics[j].Plane {
+			return pics[i].Plane < pics[j].Plane
 		}
 		if pics[i].V == pics[j].V {
 			return pics[i].H < pics[j].H
@@ -527,7 +523,11 @@ func parseDrawState(data []byte) error {
 		id := uint16(idBits)
 		h := signExtend(hBits, 11)
 		v := signExtend(vBits, 11)
-		pics = append(pics, framePicture{PictID: id, H: h, V: v})
+		plane := 0
+		if clImages != nil {
+			plane = clImages.Plane(uint32(id))
+		}
+		pics = append(pics, framePicture{PictID: id, H: h, V: v, Plane: plane})
 	}
 	p += br.bitPos / 8
 	if br.bitPos%8 != 0 {

--- a/game.go
+++ b/game.go
@@ -562,14 +562,10 @@ func drawScene(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha float6
 	zeroPics := make([]framePicture, 0)
 	posPics := make([]framePicture, 0)
 	for _, p := range snap.pictures {
-		plane := 0
-		if clImages != nil {
-			plane = clImages.Plane(uint32(p.PictID))
-		}
 		switch {
-		case plane < 0:
+		case p.Plane < 0:
 			negPics = append(negPics, p)
-		case plane == 0:
+		case p.Plane == 0:
 			zeroPics = append(zeroPics, p)
 		default:
 			posPics = append(posPics, p)
@@ -822,11 +818,10 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 	}
 
 	frame := 0
-	plane := 0
 	if clImages != nil {
 		frame = clImages.FrameIndex(uint32(p.PictID), frameCounter)
-		plane = clImages.Plane(uint32(p.PictID))
 	}
+	plane := p.Plane
 
 	img := loadImageFrame(p.PictID, frame)
 	var prevImg *ebiten.Image

--- a/movie.go
+++ b/movie.go
@@ -93,8 +93,12 @@ func parseMovie(path string, clientVersion int) ([][]byte, error) {
 				id := binary.BigEndian.Uint16(data[pos : pos+2])
 				h := int16(binary.BigEndian.Uint16(data[pos+2 : pos+4]))
 				v := int16(binary.BigEndian.Uint16(data[pos+4 : pos+6]))
+				plane := 0
+				if clImages != nil {
+					plane = clImages.Plane(uint32(id))
+				}
 				pos += 6
-				pics = append(pics, framePicture{PictID: id, H: h, V: v})
+				pics = append(pics, framePicture{PictID: id, H: h, V: v, Plane: plane})
 			}
 			if pos+4 <= len(data) {
 				pos += 4
@@ -148,8 +152,12 @@ func parseGameState(gs []byte, version, revision uint16) {
 				id := binary.BigEndian.Uint16(gs[pos : pos+2])
 				h := int16(binary.BigEndian.Uint16(gs[pos+2 : pos+4]))
 				v := int16(binary.BigEndian.Uint16(gs[pos+4 : pos+6]))
+				plane := 0
+				if clImages != nil {
+					plane = clImages.Plane(uint32(id))
+				}
 				pos += 6
-				pics = append(pics, framePicture{PictID: id, H: h, V: v})
+				pics = append(pics, framePicture{PictID: id, H: h, V: v, Plane: plane})
 			}
 			if pos+4 <= len(gs) {
 				pos += 4


### PR DESCRIPTION
## Summary
- add `Plane` field to `framePicture` and precompute planes once
- sort and render pictures using stored plane values to avoid duplicate lookups
- compute plane values when loading picture tables

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897aa947bb0832ab146de4512709557