### PR TITLE
Initialize and increment position in resampleSincHQ

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -194,8 +194,8 @@ func resampleSincHQ(src []int16, srcRate, dstRate int) []int16 {
 	dst := make([]int16, n)
 	ratio := float32(srcRate) / float32(dstRate)
 
+	pos := float32(0)
 	for i := 0; i < n; i++ {
-		pos := float32(i) * ratio
 		idx := int(pos)
 		frac := pos - float32(idx)
 
@@ -227,6 +227,7 @@ func resampleSincHQ(src []int16, srcRate, dstRate int) []int16 {
 			sum = float32(math.MinInt16)
 		}
 		dst[i] = int16(math.Round(float64(sum)))
+		pos += ratio
 	}
 	return dst
 }


### PR DESCRIPTION
## Summary
- Precompute and increment resampling position in resampleSincHQ to avoid per-iteration multiplication

## Testing
- `gofmt -w sound.go`
- `go vet .`


------
https://chatgpt.com/codex/tasks/task_e_6897ab670e28832aad1428b0109a087a