### PR TITLE
Fix debug packet truncation logic

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -76,8 +76,8 @@ func logDebugPacket(prefix string, data []byte) {
 	})
 	n := len(data)
 	dump := data
-	if debugPacketDumpLen > 0 && n > 0 {
-		dump = data[:0]
+	if debugPacketDumpLen > 0 && n > debugPacketDumpLen {
+		dump = data[:debugPacketDumpLen]
 	}
 	debugLogger.Printf("%s len=%d payload=% x", prefix, n, dump)
 }


### PR DESCRIPTION
## Summary
- Only truncate logged packet payloads when they exceed `debugPacketDumpLen`

## Testing
- `go fmt logger.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897b0ab0fd0832aabaaa693f082802e