### PR TITLE
cache pixel buffers for nonTransparentPixels

### DIFF
--- a/draw_pixels_bench_test.go
+++ b/draw_pixels_bench_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// BenchmarkNonTransparentPixels verifies that repeated calls do not repeatedly
+// read pixels from the GPU by benchmarking successive invocations.
+func BenchmarkNonTransparentPixels(b *testing.B) {
+	// Prepare a small image with all opaque pixels.
+	img := ebiten.NewImage(16, 16)
+	img.Fill(color.White)
+
+	// Prime the image cache so loadImage returns our image.
+	imageMu.Lock()
+	imageCache[makeImageKey(1, 0)] = img
+	imageMu.Unlock()
+
+	// Clear caches to ensure the first call performs the ReadPixels, and
+	// subsequent calls reuse the cached buffer.
+	pixelCountMu.Lock()
+	pixelCountCache = make(map[uint16]int)
+	pixelCountMu.Unlock()
+	pixelDataMu.Lock()
+	pixelDataCache = make(map[uint16][]byte)
+	pixelDataMu.Unlock()
+
+	// Warm up once so the benchmark measures cached calls.
+	if c := nonTransparentPixels(1); c != 16*16 {
+		b.Fatalf("unexpected pixel count %d", c)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if nonTransparentPixels(1) != 16*16 {
+			b.Fatal("pixel count mismatch")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- cache raw pixel data to avoid repeated ReadPixels GPU stalls
- add benchmark for nonTransparentPixels to confirm cached behavior

## Testing
- `go vet ./...`
- `xvfb-run -a go test -run=^$ -bench=NonTransparentPixels ./...` *(fails: ReadPixels cannot be called before the game starts)*

------
https://chatgpt.com/codex/tasks/task_e_6897c76f37b4832aa1ccc3d176646177