### PR TITLE
Limit pixel data cache with LRU eviction

### DIFF
--- a/draw_pixels_bench_test.go
+++ b/draw_pixels_bench_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"container/list"
 	"image/color"
 	"testing"
 
@@ -25,7 +26,8 @@ func BenchmarkNonTransparentPixels(b *testing.B) {
 	pixelCountCache = make(map[uint16]int)
 	pixelCountMu.Unlock()
 	pixelDataMu.Lock()
-	pixelDataCache = make(map[uint16][]byte)
+	pixelDataCache = make(map[uint16]*list.Element)
+	pixelDataList = list.New()
 	pixelDataMu.Unlock()
 
 	// Warm up once so the benchmark measures cached calls.


### PR DESCRIPTION
## Summary
- bound pixel data cache to 128 entries with LRU eviction to avoid unbounded memory
- update nonTransparentPixels to use the LRU cache
- adjust benchmark for new cache structure

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897cdfc8a00832aab3df0f9ad8b0d68