### PR TITLE
Optimize image denoising

### DIFF
--- a/climg/climg.go
+++ b/climg/climg.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"image"
-	"image/color"
 	"io"
 	"log"
 	"os"
@@ -471,7 +470,11 @@ func (c *CLImages) Get(id uint32, custom []byte, forceTransparent bool) *ebiten.
 		b = uint8(int(b) * int(a) / 255)
 		x := i%width + 1
 		y := i/width + 1
-		img.SetRGBA(x, y, color.RGBA{r, g, b, a})
+		off := y*img.Stride + x*4
+		img.Pix[off] = r
+		img.Pix[off+1] = g
+		img.Pix[off+2] = b
+		img.Pix[off+3] = a
 	}
 
 	if c.Denoise {

--- a/climg/denoise.go
+++ b/climg/denoise.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"image/color"
 	"math"
+	"sync"
 )
 
 // denoiseImage softens pixels by blending with neighbours. Pixels that are
@@ -16,17 +17,20 @@ func denoiseImage(img *image.RGBA, sharpness, maxPercent float64) {
 	w, h := bounds.Dx(), bounds.Dy()
 
 	// Work on a copy so neighbour checks aren't affected by in-place writes.
-	src := image.NewRGBA(bounds)
+	src := getTempRGBA(bounds)
 	copy(src.Pix, img.Pix)
 
 	for y := 1; y < h-1; y++ {
+		yoff := y * src.Stride
 		for x := 1; x < w-1; x++ {
-			c := src.RGBAAt(x, y)
+			off := yoff + x*4
+			c := color.RGBA{src.Pix[off], src.Pix[off+1], src.Pix[off+2], src.Pix[off+3]}
 
 			// Check only direct neighbours.
 			neighbours := []image.Point{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
 			for _, n := range neighbours {
-				ncol := src.RGBAAt(x+n.X, y+n.Y)
+				nOff := (y+n.Y)*src.Stride + (x+n.X)*4
+				ncol := color.RGBA{src.Pix[nOff], src.Pix[nOff+1], src.Pix[nOff+2], src.Pix[nOff+3]}
 				dist := colourDist(c, ncol)
 				nd := float64(dist) / 195075.0
 				if nd < 1 {
@@ -36,10 +40,32 @@ func denoiseImage(img *image.RGBA, sharpness, maxPercent float64) {
 					}
 				}
 			}
-			img.SetRGBA(x, y, c)
+			dstOff := y*img.Stride + x*4
+			img.Pix[dstOff] = c.R
+			img.Pix[dstOff+1] = c.G
+			img.Pix[dstOff+2] = c.B
+			img.Pix[dstOff+3] = c.A
 		}
 	}
+	putTempRGBA(src)
 }
+
+var rgbaPool = sync.Pool{New: func() any { return &image.RGBA{} }}
+
+func getTempRGBA(bounds image.Rectangle) *image.RGBA {
+	img := rgbaPool.Get().(*image.RGBA)
+	w, h := bounds.Dx(), bounds.Dy()
+	need := w * h * 4
+	if cap(img.Pix) < need {
+		img.Pix = make([]uint8, need)
+	}
+	img.Pix = img.Pix[:need]
+	img.Stride = w * 4
+	img.Rect = bounds
+	return img
+}
+
+func putTempRGBA(img *image.RGBA) { rgbaPool.Put(img) }
 
 // colourDist returns the squared Euclidean distance between two colours.
 const dt = 15

--- a/climg/denoise_stub.go
+++ b/climg/denoise_stub.go
@@ -1,0 +1,8 @@
+//go:build nodenoise
+
+package climg
+
+import "image"
+
+// denoiseImage is a stub used when the nodenoise build tag is set.
+func denoiseImage(img *image.RGBA, sharpness, maxPercent float64) {}


### PR DESCRIPTION
## Summary
- Avoid RGBAAt/SetRGBA calls by working directly with Pix slices
- Reuse temporary RGBA buffers to reduce allocations
- Add `nodenoise` build tag to allow skipping denoise step

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h and pkg-config dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897cdd9a914832ab64717b166aa9d64