### PR TITLE
Optimize image pixel loop with direct Pix assignments

### DIFF
--- a/climg/climg.go
+++ b/climg/climg.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"image"
-	"image/color"
 	"io"
 	"log"
 	"os"
@@ -456,6 +455,8 @@ func (c *CLImages) Get(id uint32, custom []byte, forceTransparent bool) *ebiten.
 		transparent = true
 	}
 
+	pix := img.Pix
+	stride := img.Stride
 	for i := 0; i < pixelCount; i++ {
 		idx := col[data[i]]
 		r := uint8(pal[idx*3])
@@ -469,9 +470,11 @@ func (c *CLImages) Get(id uint32, custom []byte, forceTransparent bool) *ebiten.
 		r = uint8(int(r) * int(a) / 255)
 		g = uint8(int(g) * int(a) / 255)
 		b = uint8(int(b) * int(a) / 255)
-		x := i%width + 1
-		y := i/width + 1
-		img.SetRGBA(x, y, color.RGBA{r, g, b, a})
+		off := (i/width+1)*stride + (i%width+1)*4
+		pix[off+0] = r
+		pix[off+1] = g
+		pix[off+2] = b
+		pix[off+3] = a
 	}
 
 	if c.Denoise {

--- a/pixelbench/pixel_loop_bench_test.go
+++ b/pixelbench/pixel_loop_bench_test.go
@@ -1,0 +1,79 @@
+package pixelbench
+
+import (
+	"image"
+	"image/color"
+	"testing"
+)
+
+// BenchmarkDecodeSetRGBA measures the old pixel loop that used SetRGBA.
+func BenchmarkDecodeSetRGBA(b *testing.B) {
+	const (
+		width  = 64
+		height = 64
+	)
+	pixelCount := width * height
+	data := make([]byte, pixelCount)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	pal := make([]byte, 256*3)
+	for i := range pal {
+		pal[i] = byte(i)
+	}
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		img := image.NewRGBA(image.Rect(0, 0, width+2, height+2))
+		for i := 0; i < pixelCount; i++ {
+			idx := int(data[i])
+			r := pal[idx*3]
+			g := pal[idx*3+1]
+			bl := pal[idx*3+2]
+			a := byte(0x80)
+			r = byte(int(r) * int(a) / 255)
+			g = byte(int(g) * int(a) / 255)
+			bl = byte(int(bl) * int(a) / 255)
+			x := i%width + 1
+			y := i/width + 1
+			img.SetRGBA(x, y, color.RGBA{r, g, bl, a})
+		}
+	}
+}
+
+// BenchmarkDecodeWritePix measures writing pixels directly to the Pix slice.
+func BenchmarkDecodeWritePix(b *testing.B) {
+	const (
+		width  = 64
+		height = 64
+	)
+	pixelCount := width * height
+	data := make([]byte, pixelCount)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	pal := make([]byte, 256*3)
+	for i := range pal {
+		pal[i] = byte(i)
+	}
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		img := image.NewRGBA(image.Rect(0, 0, width+2, height+2))
+		pix := img.Pix
+		stride := img.Stride
+		for i := 0; i < pixelCount; i++ {
+			idx := int(data[i])
+			r := pal[idx*3]
+			g := pal[idx*3+1]
+			bl := pal[idx*3+2]
+			a := byte(0x80)
+			r = byte(int(r) * int(a) / 255)
+			g = byte(int(g) * int(a) / 255)
+			bl = byte(int(bl) * int(a) / 255)
+			off := (i/width+1)*stride + (i%width+1)*4
+			pix[off+0] = r
+			pix[off+1] = g
+			pix[off+2] = bl
+			pix[off+3] = a
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- write premultiplied RGBA directly to img.Pix instead of SetRGBA
- add benchmark comparing SetRGBA loop vs Pix slice assignment

## Testing
- `go vet ./...`
- `go fmt ./climg ./pixelbench`
- `go test ./pixelbench -bench=. -benchmem -run=^$`


------
https://chatgpt.com/codex/tasks/task_e_6897cdc1bf50832aa3627f0e75f12599