### PR TITLE
Dispose cached images before clearing cache

### DIFF
--- a/climg/climg.go
+++ b/climg/climg.go
@@ -497,6 +497,9 @@ func (c *CLImages) NumFrames(id uint32) int {
 // ClearCache removes all cached images so they will be reloaded on demand.
 func (c *CLImages) ClearCache() {
 	c.mu.Lock()
+	for _, img := range c.cache {
+		img.Dispose()
+	}
 	c.cache = make(map[string]*ebiten.Image)
 	c.mu.Unlock()
 }


### PR DESCRIPTION
## Summary
- Dispose cached ebiten images before clearing the cache to free GPU memory

## Testing
- `gofmt -w climg/climg.go`
- `go vet ./climg`


------
https://chatgpt.com/codex/tasks/task_e_6897cdb3c288832a942ae3ea10f704eb