### PR TITLE
Optimize window updates

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -12,12 +12,24 @@ func updateChatWindow() {
 		return
 	}
 	msgs := getChatMessages()
-	chatList.Contents = chatList.Contents[:0]
-	for _, msg := range msgs {
-		t, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 256, Y: 24}})
-		chatList.AddItem(t)
+	changed := false
+	for i, msg := range msgs {
+		if i < len(chatList.Contents) {
+			if chatList.Contents[i].Text != msg {
+				chatList.Contents[i].Text = msg
+				changed = true
+			}
+		} else {
+			t, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 256, Y: 24}})
+			chatList.AddItem(t)
+			changed = true
+		}
 	}
-	if chatWin != nil {
+	if len(chatList.Contents) > len(msgs) {
+		chatList.Contents = chatList.Contents[:len(msgs)]
+		changed = true
+	}
+	if changed && chatWin != nil {
 		chatWin.Refresh()
 	}
 }

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -15,17 +15,29 @@ func updateInventoryWindow() {
 		return
 	}
 	items := getInventory()
-	inventoryList.Contents = inventoryList.Contents[:0]
-	for _, it := range items {
+	changed := false
+	for i, it := range items {
 		text := it.Name
 		if it.Equipped {
 			text = "* " + text
 		}
-		t, _ := eui.NewText(&eui.ItemData{Text: text, Size: eui.Point{X: 256, Y: 24}, FontSize: 10})
-		inventoryList.AddItem(t)
+		if i < len(inventoryList.Contents) {
+			if inventoryList.Contents[i].Text != text {
+				inventoryList.Contents[i].Text = text
+				changed = true
+			}
+		} else {
+			t, _ := eui.NewText(&eui.ItemData{Text: text, Size: eui.Point{X: 256, Y: 24}, FontSize: 10})
+			inventoryList.AddItem(t)
+			changed = true
+		}
 		logDebug("Ivn Name: %v, ID: %v", it.Name, it.ID)
 	}
-	if inventoryWin != nil {
+	if len(inventoryList.Contents) > len(items) {
+		inventoryList.Contents = inventoryList.Contents[:len(items)]
+		changed = true
+	}
+	if changed && inventoryWin != nil {
 		inventoryWin.Refresh()
 	}
 }

--- a/messages_ui.go
+++ b/messages_ui.go
@@ -12,18 +12,39 @@ func updateMessagesWindow() {
 		return
 	}
 	msgs := getMessages()
-	messagesList.Contents = messagesList.Contents[:0]
-	for _, msg := range msgs {
-		t, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 500, Y: 24}})
-		messagesList.AddItem(t)
-	}
 	inputMsg := "[Command Input Bar] (Press enter to switch to command mode)"
 	if inputActive {
 		inputMsg = string(inputText)
 	}
-	t, _ := eui.NewText(&eui.ItemData{Text: inputMsg, FontSize: 10, Size: eui.Point{X: 500, Y: 24}})
-	messagesList.AddItem(t)
-	if messagesWin != nil {
+	changed := false
+	for i, msg := range msgs {
+		if i < len(messagesList.Contents) {
+			if messagesList.Contents[i].Text != msg {
+				messagesList.Contents[i].Text = msg
+				changed = true
+			}
+		} else {
+			t, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 500, Y: 24}})
+			messagesList.AddItem(t)
+			changed = true
+		}
+	}
+	inputIdx := len(msgs)
+	if inputIdx < len(messagesList.Contents) {
+		if messagesList.Contents[inputIdx].Text != inputMsg {
+			messagesList.Contents[inputIdx].Text = inputMsg
+			changed = true
+		}
+	} else {
+		t, _ := eui.NewText(&eui.ItemData{Text: inputMsg, FontSize: 10, Size: eui.Point{X: 500, Y: 24}})
+		messagesList.AddItem(t)
+		changed = true
+	}
+	if len(messagesList.Contents) > inputIdx+1 {
+		messagesList.Contents = messagesList.Contents[:inputIdx+1]
+		changed = true
+	}
+	if changed && messagesWin != nil {
 		messagesWin.Refresh()
 	}
 }


### PR DESCRIPTION
## Summary
- Update inventory, chat, and messages windows to update existing UI items instead of rebuilding lists
- Only refresh windows when content changes

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897f6e669fc832a8c7ae35b8b3d0fe0