### PR TITLE
Refresh UI windows when inventory or player data changes

### DIFF
--- a/game.go
+++ b/game.go
@@ -319,6 +319,15 @@ func (g *Game) Update() error {
 
 	updateDebugStats()
 
+	if inventoryDirty {
+		updateInventoryWindow()
+		inventoryDirty = false
+	}
+	if playersDirty {
+		updatePlayersWindow()
+		playersDirty = false
+	}
+
 	if settingsDirty {
 		saveSettings()
 		settingsDirty = false

--- a/inventory.go
+++ b/inventory.go
@@ -22,11 +22,11 @@ func resetInventory() {
 	inventoryMu.Lock()
 	inventoryItems = inventoryItems[:0]
 	inventoryMu.Unlock()
+	inventoryDirty = true
 }
 
 func addInventoryItem(id uint16, idx int, name string, equip bool) {
 	inventoryMu.Lock()
-	defer inventoryMu.Unlock()
 	if idx < 0 || idx > len(inventoryItems) {
 		idx = len(inventoryItems)
 	}
@@ -37,11 +37,12 @@ func addInventoryItem(id uint16, idx int, name string, equip bool) {
 	for i := range inventoryItems {
 		inventoryItems[i].Index = i
 	}
+	inventoryMu.Unlock()
+	inventoryDirty = true
 }
 
 func removeInventoryItem(id uint16, idx int) {
 	inventoryMu.Lock()
-	defer inventoryMu.Unlock()
 	if idx >= 0 && idx < len(inventoryItems) && inventoryItems[idx].ID == id {
 		inventoryItems = append(inventoryItems[:idx], inventoryItems[idx+1:]...)
 	} else {
@@ -55,6 +56,8 @@ func removeInventoryItem(id uint16, idx int) {
 	for i := range inventoryItems {
 		inventoryItems[i].Index = i
 	}
+	inventoryMu.Unlock()
+	inventoryDirty = true
 }
 
 func equipInventoryItem(id uint16, idx int, equip bool) {
@@ -70,6 +73,7 @@ func equipInventoryItem(id uint16, idx int, equip bool) {
 		}
 	}
 	inventoryMu.Unlock()
+	inventoryDirty = true
 }
 
 func renameInventoryItem(id uint16, idx int, name string) {
@@ -85,6 +89,7 @@ func renameInventoryItem(id uint16, idx int, name string) {
 		}
 	}
 	inventoryMu.Unlock()
+	inventoryDirty = true
 }
 
 func getInventory() []inventoryItem {
@@ -114,4 +119,5 @@ func setFullInventory(ids []uint16, equipped []bool) {
 	inventoryMu.Lock()
 	inventoryItems = items
 	inventoryMu.Unlock()
+	inventoryDirty = true
 }


### PR DESCRIPTION
## Summary
- Refresh inventory and players UI windows only when their data changes
- Track inventory mutations with a dirty flag so the window updates on demand

## Testing
- `gofmt -w game.go inventory.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897fccf6970832a94974f0479a91374