### PR TITLE
Implement dirty flags for UI windows to reduce refreshes

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -6,6 +6,7 @@ import "github.com/Distortions81/EUI/eui"
 
 var chatWin *eui.WindowData
 var chatList *eui.ItemData
+var chatDirty bool
 
 func updateChatWindow() {
 	if chatList == nil {
@@ -29,8 +30,8 @@ func updateChatWindow() {
 		chatList.Contents = chatList.Contents[:len(msgs)]
 		changed = true
 	}
-	if changed && chatWin != nil {
-		chatWin.Refresh()
+	if changed {
+		chatDirty = true
 	}
 }
 

--- a/game.go
+++ b/game.go
@@ -319,6 +319,33 @@ func (g *Game) Update() error {
 
 	updateDebugStats()
 
+	if playersDirty {
+		updatePlayersWindow()
+		if playersWin != nil {
+			playersWin.Refresh()
+		}
+		playersDirty = false
+	}
+	if inventoryDirty {
+		updateInventoryWindow()
+		if inventoryWin != nil {
+			inventoryWin.Refresh()
+		}
+		inventoryDirty = false
+	}
+	if messagesDirty {
+		if messagesWin != nil {
+			messagesWin.Refresh()
+		}
+		messagesDirty = false
+	}
+	if chatDirty {
+		if chatWin != nil {
+			chatWin.Refresh()
+		}
+		chatDirty = false
+	}
+
 	if settingsDirty {
 		saveSettings()
 		settingsDirty = false

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -37,7 +37,7 @@ func updateInventoryWindow() {
 		inventoryList.Contents = inventoryList.Contents[:len(items)]
 		changed = true
 	}
-	if changed && inventoryWin != nil {
-		inventoryWin.Refresh()
+	if changed {
+		inventoryDirty = true
 	}
 }

--- a/messages_ui.go
+++ b/messages_ui.go
@@ -6,6 +6,7 @@ import "github.com/Distortions81/EUI/eui"
 
 var messagesWin *eui.WindowData
 var messagesList *eui.ItemData
+var messagesDirty bool
 
 func updateMessagesWindow() {
 	if messagesList == nil {
@@ -44,8 +45,8 @@ func updateMessagesWindow() {
 		messagesList.Contents = messagesList.Contents[:inputIdx+1]
 		changed = true
 	}
-	if changed && messagesWin != nil {
-		messagesWin.Refresh()
+	if changed {
+		messagesDirty = true
 	}
 }
 

--- a/players_ui.go
+++ b/players_ui.go
@@ -36,7 +36,5 @@ func updatePlayersWindow() {
 		t, _ = eui.NewText(&eui.ItemData{Text: p.Name, FontSize: 10, Size: eui.Point{X: 100, Y: 24}})
 		playersList.AddItem(t)
 	}
-	if playersWin != nil {
-		playersWin.Refresh()
-	}
+	playersDirty = true
 }


### PR DESCRIPTION
## Summary
- add dirty flags for players, inventory, messages, and chat windows
- update game loop to refresh windows once per cycle and clear flags

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897fcbc1ef0832aaee5c74ec635c654