### PR TITLE
Use float32 for denoise blending

### DIFF
--- a/climg/climg.go
+++ b/climg/climg.go
@@ -478,7 +478,7 @@ func (c *CLImages) Get(id uint32, custom []byte, forceTransparent bool) *ebiten.
 	}
 
 	if c.Denoise {
-		denoiseImage(img, c.DenoiseSharpness, c.DenoisePercent)
+		denoiseImage(img, float32(c.DenoiseSharpness), float32(c.DenoisePercent))
 	}
 
 	eimg := ebiten.NewImageFromImage(img)

--- a/climg/denoise.go
+++ b/climg/denoise.go
@@ -3,8 +3,9 @@ package climg
 import (
 	"image"
 	"image/color"
-	"math"
 	"sync"
+
+	"maze.io/x/math32"
 )
 
 // denoiseImage softens pixels by blending with neighbours. Pixels that are
@@ -12,7 +13,7 @@ import (
 // dissimilar pixels are blended less. The sharpness parameter controls how
 // quickly the blend amount falls off as colours become more different. Only
 // the immediate horizontal and vertical neighbours are considered.
-func denoiseImage(img *image.RGBA, sharpness, maxPercent float64) {
+func denoiseImage(img *image.RGBA, sharpness, maxPercent float32) {
 	bounds := img.Bounds()
 	w, h := bounds.Dx(), bounds.Dy()
 
@@ -32,9 +33,9 @@ func denoiseImage(img *image.RGBA, sharpness, maxPercent float64) {
 				nOff := (y+n.Y)*src.Stride + (x+n.X)*4
 				ncol := color.RGBA{src.Pix[nOff], src.Pix[nOff+1], src.Pix[nOff+2], src.Pix[nOff+3]}
 				dist := colourDist(c, ncol)
-				nd := float64(dist) / 195075.0
+				nd := float32(dist) / 195075.0
 				if nd < 1 {
-					blend := maxPercent * math.Pow(1-nd, sharpness)
+					blend := maxPercent * math32.Pow(1-nd, sharpness)
 					if blend > 0 {
 						c = mixColour(c, ncol, blend)
 					}
@@ -83,12 +84,12 @@ func colourDist(a, b color.RGBA) int {
 }
 
 // mixColour blends two colours together by the provided percentage.
-func mixColour(a, b color.RGBA, p float64) color.RGBA {
+func mixColour(a, b color.RGBA, p float32) color.RGBA {
 	inv := 1 - p
 	return color.RGBA{
-		R: uint8(float64(a.R)*inv + float64(b.R)*p),
-		G: uint8(float64(a.G)*inv + float64(b.G)*p),
-		B: uint8(float64(a.B)*inv + float64(b.B)*p),
-		A: uint8(float64(a.A)*inv + float64(b.A)*p),
+		R: uint8(float32(a.R)*inv + float32(b.R)*p),
+		G: uint8(float32(a.G)*inv + float32(b.G)*p),
+		B: uint8(float32(a.B)*inv + float32(b.B)*p),
+		A: uint8(float32(a.A)*inv + float32(b.A)*p),
 	}
 }

--- a/climg/denoise_stub.go
+++ b/climg/denoise_stub.go
@@ -5,4 +5,4 @@ package climg
 import "image"
 
 // denoiseImage is a stub used when the nodenoise build tag is set.
-func denoiseImage(img *image.RGBA, sharpness, maxPercent float64) {}
+func denoiseImage(img *image.RGBA, sharpness, maxPercent float32) {}


### PR DESCRIPTION
## Summary
- Switch denoise sharpness and percentage calculations to `float32`.
- Replace `math.Pow` with `math32.Pow` in pixel blending.
- Update helpers and call sites to accept `float32` blend values.

## Testing
- `gofmt -w climg/denoise.go climg/denoise_stub.go climg/climg.go`
- `go vet ./climg`


------
https://chatgpt.com/codex/tasks/task_e_68980803c2fc832a845e1ee618bb3d57