### PR TITLE
Check errors when creating UI elements

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -21,7 +21,11 @@ func updateChatWindow() {
 				changed = true
 			}
 		} else {
-			t, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 256, Y: 24}})
+			t, err := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 256, Y: 24}})
+			if err != nil {
+				logError("failed to create chat text: %v", err)
+				continue
+			}
 			chatList.AddItem(t)
 			changed = true
 		}

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -27,7 +27,11 @@ func updateInventoryWindow() {
 				changed = true
 			}
 		} else {
-			t, _ := eui.NewText(&eui.ItemData{Text: text, Size: eui.Point{X: 256, Y: 24}, FontSize: 10})
+			t, err := eui.NewText(&eui.ItemData{Text: text, Size: eui.Point{X: 256, Y: 24}, FontSize: 10})
+			if err != nil {
+				logError("failed to create inventory text: %v", err)
+				continue
+			}
 			inventoryList.AddItem(t)
 			changed = true
 		}

--- a/messages_ui.go
+++ b/messages_ui.go
@@ -25,7 +25,11 @@ func updateMessagesWindow() {
 				changed = true
 			}
 		} else {
-			t, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 500, Y: 24}})
+			t, err := eui.NewText(&eui.ItemData{Text: msg, FontSize: 10, Size: eui.Point{X: 500, Y: 24}})
+			if err != nil {
+				logError("failed to create message text: %v", err)
+				continue
+			}
 			messagesList.AddItem(t)
 			changed = true
 		}
@@ -37,9 +41,13 @@ func updateMessagesWindow() {
 			changed = true
 		}
 	} else {
-		t, _ := eui.NewText(&eui.ItemData{Text: inputMsg, FontSize: 10, Size: eui.Point{X: 500, Y: 24}})
-		messagesList.AddItem(t)
-		changed = true
+		t, err := eui.NewText(&eui.ItemData{Text: inputMsg, FontSize: 10, Size: eui.Point{X: 500, Y: 24}})
+		if err != nil {
+			logError("failed to create input text: %v", err)
+		} else {
+			messagesList.AddItem(t)
+			changed = true
+		}
 	}
 	if len(messagesList.Contents) > inputIdx+1 {
 		messagesList.Contents = messagesList.Contents[:inputIdx+1]

--- a/movie_player.go
+++ b/movie_player.go
@@ -55,8 +55,13 @@ func (p *moviePlayer) initUI() {
 	// Time slider flow
 	tFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL}
 
-	p.curLabel, _ = eui.NewText(&eui.ItemData{Text: "0s", Size: eui.Point{X: 60, Y: 24}, FontSize: 10})
-	tFlow.AddItem(p.curLabel)
+	var err error
+	p.curLabel, err = eui.NewText(&eui.ItemData{Text: "0s", Size: eui.Point{X: 60, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create current time label: %v", err)
+	} else {
+		tFlow.AddItem(p.curLabel)
+	}
 
 	max := float32(len(p.frames))
 	var events *eui.EventHandler
@@ -70,8 +75,12 @@ func (p *moviePlayer) initUI() {
 
 	totalDur := time.Duration(len(p.frames)) * time.Second / time.Duration(p.fps)
 	totalDur = totalDur.Round(time.Second)
-	p.totalLabel, _ = eui.NewText(&eui.ItemData{Text: durafmt.Parse(totalDur).LimitFirstN(2).Format(shortUnits), Size: eui.Point{X: 60, Y: 24}, FontSize: 10})
-	tFlow.AddItem(p.totalLabel)
+	p.totalLabel, err = eui.NewText(&eui.ItemData{Text: durafmt.Parse(totalDur).LimitFirstN(2).Format(shortUnits), Size: eui.Point{X: 60, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create total time label: %v", err)
+	} else {
+		tFlow.AddItem(p.totalLabel)
+	}
 
 	flow.AddItem(tFlow)
 
@@ -125,8 +134,12 @@ func (p *moviePlayer) initUI() {
 	}
 	bFlow.AddItem(forward)
 
-	spacer, _ := eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: 40, Y: 24}})
-	bFlow.AddItem(spacer)
+	spacer, err := eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: 40, Y: 24}})
+	if err != nil {
+		logError("failed to create spacer text: %v", err)
+	} else {
+		bFlow.AddItem(spacer)
+	}
 
 	half, halfEv := eui.NewButton(&eui.ItemData{Text: "--", Size: eui.Point{X: 40, Y: 24}})
 	halfEv.Handle = func(ev eui.UIEvent) {
@@ -169,9 +182,13 @@ func (p *moviePlayer) initUI() {
 	bFlow.AddItem(dbl)
 
 	buf := fmt.Sprintf("%v fps", p.fps)
-	fpsInfo, _ := eui.NewText(&eui.ItemData{Text: buf, Size: eui.Point{X: 100, Y: 24}, FontSize: 15, Alignment: eui.ALIGN_CENTER})
-	p.fpsLabel = fpsInfo
-	bFlow.AddItem(fpsInfo)
+	fpsInfo, err := eui.NewText(&eui.ItemData{Text: buf, Size: eui.Point{X: 100, Y: 24}, FontSize: 15, Alignment: eui.ALIGN_CENTER})
+	if err != nil {
+		logError("failed to create fps info text: %v", err)
+	} else {
+		p.fpsLabel = fpsInfo
+		bFlow.AddItem(fpsInfo)
+	}
 
 	flow.AddItem(bFlow)
 	win.AddItem(flow)

--- a/players_ui.go
+++ b/players_ui.go
@@ -30,10 +30,18 @@ func updatePlayersWindow() {
 	}
 
 	buf := fmt.Sprintf("Players Online: %v", len(exiles))
-	t, _ := eui.NewText(&eui.ItemData{ItemType: eui.ITEM_TEXT, Text: buf, FontSize: 10, Size: eui.Point{X: 100, Y: 24}})
+	t, err := eui.NewText(&eui.ItemData{ItemType: eui.ITEM_TEXT, Text: buf, FontSize: 10, Size: eui.Point{X: 100, Y: 24}})
+	if err != nil {
+		logError("failed to create players online text: %v", err)
+		return
+	}
 	playersList.AddItem(t)
 	for _, p := range exiles {
-		t, _ = eui.NewText(&eui.ItemData{Text: p.Name, FontSize: 10, Size: eui.Point{X: 100, Y: 24}})
+		t, err = eui.NewText(&eui.ItemData{Text: p.Name, FontSize: 10, Size: eui.Point{X: 100, Y: 24}})
+		if err != nil {
+			logError("failed to create player name text: %v", err)
+			continue
+		}
 		playersList.AddItem(t)
 	}
 	playersDirty = true

--- a/ui.go
+++ b/ui.go
@@ -159,8 +159,13 @@ func initUI() {
 		}
 	}
 	overlay.AddItem(recordBtn)
-	recordStatus, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: 80, Y: 24}, FontSize: 18, Color: eui.ColorRed})
-	overlay.AddItem(recordStatus)
+	var err error
+	recordStatus, err = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: 80, Y: 24}, FontSize: 18, Color: eui.ColorRed})
+	if err != nil {
+		logError("failed to create record status text: %v", err)
+	} else {
+		overlay.AddItem(recordStatus)
+	}
 
 	eui.AddOverlayFlow(overlay)
 
@@ -190,11 +195,19 @@ func openDownloadsWindow(status dataFilesStatus) {
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 
-	t, _ := eui.NewText(&eui.ItemData{Text: "Files we must download:", FontSize: 15, Size: eui.Point{X: 200, Y: 25}})
-	flow.AddItem(t)
+	t, err := eui.NewText(&eui.ItemData{Text: "Files we must download:", FontSize: 15, Size: eui.Point{X: 200, Y: 25}})
+	if err != nil {
+		logError("failed to create download header text: %v", err)
+	} else {
+		flow.AddItem(t)
+	}
 
 	for _, f := range status.Files {
-		t, _ := eui.NewText(&eui.ItemData{Text: f, FontSize: 15, Size: eui.Point{X: 200, Y: 25}})
+		t, err := eui.NewText(&eui.ItemData{Text: f, FontSize: 15, Size: eui.Point{X: 200, Y: 25}})
+		if err != nil {
+			logError("failed to create filename text: %v", err)
+			continue
+		}
 		flow.AddItem(t)
 	}
 
@@ -267,8 +280,12 @@ func updateCharacterButtons() {
 	}
 	charactersList.Contents = charactersList.Contents[:0]
 	if len(characters) == 0 {
-		empty, _ := eui.NewText(&eui.ItemData{Text: "empty", Size: eui.Point{X: 160, Y: 64}})
-		charactersList.AddItem(empty)
+		empty, err := eui.NewText(&eui.ItemData{Text: "empty", Size: eui.Point{X: 160, Y: 64}})
+		if err != nil {
+			logError("failed to create empty character text: %v", err)
+		} else {
+			charactersList.AddItem(empty)
+		}
 		name = ""
 		passHash = ""
 	} else {
@@ -479,8 +496,12 @@ func openLoginWindow() {
 	loginFlow.AddItem(charactersList)
 	updateCharacterButtons()
 
-	label, _ := eui.NewText(&eui.ItemData{Text: "", FontSize: 15, Size: eui.Point{X: 1, Y: 25}})
-	loginFlow.AddItem(label)
+	label, err := eui.NewText(&eui.ItemData{Text: "", FontSize: 15, Size: eui.Point{X: 1, Y: 25}})
+	if err != nil {
+		logError("failed to create spacer text: %v", err)
+	} else {
+		loginFlow.AddItem(label)
+	}
 
 	connBtn, connEvents := eui.NewButton(&eui.ItemData{Text: "Connect", Size: eui.Point{X: 200, Y: 48}, Padding: 10})
 	connEvents.Handle = func(ev eui.UIEvent) {
@@ -522,8 +543,12 @@ func openErrorWindow(msg string) {
 	win.Open = true
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
-	text, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 8, Size: eui.Point{X: 500, Y: 25}})
-	flow.AddItem(text)
+	text, err := eui.NewText(&eui.ItemData{Text: msg, FontSize: 8, Size: eui.Point{X: 500, Y: 25}})
+	if err != nil {
+		logError("failed to create error text: %v", err)
+	} else {
+		flow.AddItem(text)
+	}
 	okBtn, okEvents := eui.NewButton(&eui.ItemData{Text: "OK", Size: eui.Point{X: 200, Y: 24}})
 	okEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
@@ -551,8 +576,12 @@ func openSettingsWindow() {
 	mainFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	var width float32 = 250
 
-	label, _ := eui.NewText(&eui.ItemData{Text: "\nControls:", FontSize: 15, Size: eui.Point{X: 100, Y: 50}})
-	mainFlow.AddItem(label)
+	label, err := eui.NewText(&eui.ItemData{Text: "\nControls:", FontSize: 15, Size: eui.Point{X: 100, Y: 50}})
+	if err != nil {
+		logError("failed to create controls label: %v", err)
+	} else {
+		mainFlow.AddItem(label)
+	}
 
 	toggle, toggleEvents := eui.NewCheckbox(&eui.ItemData{Text: "Click-to-toggle movement", Size: eui.Point{X: width, Y: 24}, Checked: gs.ClickToToggle})
 	toggleEvents.Handle = func(ev eui.UIEvent) {
@@ -575,8 +604,12 @@ func openSettingsWindow() {
 	}
 	mainFlow.AddItem(keySpeedSlider)
 
-	label, _ = eui.NewText(&eui.ItemData{Text: "\nText Sizes:", FontSize: 15, Size: eui.Point{X: 100, Y: 50}})
-	mainFlow.AddItem(label)
+	label, err = eui.NewText(&eui.ItemData{Text: "\nText Sizes:", FontSize: 15, Size: eui.Point{X: 100, Y: 50}})
+	if err != nil {
+		logError("failed to create text sizes label: %v", err)
+	} else {
+		mainFlow.AddItem(label)
+	}
 
 	chatFontSlider, chatFontEvents := eui.NewSlider(&eui.ItemData{Label: "Chat", MinValue: 6, MaxValue: 24, Value: float32(gs.BubbleFontSize), Size: eui.Point{X: width - 10, Y: 24}})
 	chatFontEvents.Handle = func(ev eui.UIEvent) {
@@ -598,8 +631,12 @@ func openSettingsWindow() {
 	}
 	mainFlow.AddItem(labelFontSlider)
 
-	label, _ = eui.NewText(&eui.ItemData{Text: "\nOpacity Settings:", FontSize: 15, Size: eui.Point{X: 150, Y: 50}})
-	mainFlow.AddItem(label)
+	label, err = eui.NewText(&eui.ItemData{Text: "\nOpacity Settings:", FontSize: 15, Size: eui.Point{X: 150, Y: 50}})
+	if err != nil {
+		logError("failed to create opacity settings label: %v", err)
+	} else {
+		mainFlow.AddItem(label)
+	}
 
 	bubbleOpSlider, bubbleOpEvents := eui.NewSlider(&eui.ItemData{Label: "Message Bubble", MinValue: 0, MaxValue: 1, Value: float32(gs.BubbleOpacity), Size: eui.Point{X: width - 10, Y: 24}})
 	bubbleOpEvents.Handle = func(ev eui.UIEvent) {
@@ -619,8 +656,12 @@ func openSettingsWindow() {
 	}
 	mainFlow.AddItem(nameBgSlider)
 
-	label, _ = eui.NewText(&eui.ItemData{Text: "\nGraphics Settings:", FontSize: 15, Size: eui.Point{X: 150, Y: 50}})
-	mainFlow.AddItem(label)
+	label, err = eui.NewText(&eui.ItemData{Text: "\nGraphics Settings:", FontSize: 15, Size: eui.Point{X: 150, Y: 50}})
+	if err != nil {
+		logError("failed to create graphics settings label: %v", err)
+	} else {
+		mainFlow.AddItem(label)
+	}
 
 	uiScaleSlider, uiScaleEvents := eui.NewSlider(&eui.ItemData{Label: "UI Scaling", MinValue: 0.5, MaxValue: 2.5, Value: float32(gs.UIScale), Size: eui.Point{X: width - 10, Y: 24}})
 	uiScaleEvents.Handle = func(ev eui.UIEvent) {
@@ -908,20 +949,40 @@ func openDebugWindow() {
 	}
 	debugFlow.AddItem(smoothinCB)
 
-	cacheLabel, _ := eui.NewText(&eui.ItemData{Text: "Caches:", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
-	debugFlow.AddItem(cacheLabel)
+	cacheLabel, err := eui.NewText(&eui.ItemData{Text: "Caches:", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create cache label: %v", err)
+	} else {
+		debugFlow.AddItem(cacheLabel)
+	}
 
-	sheetCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
-	debugFlow.AddItem(sheetCacheLabel)
+	sheetCacheLabel, err = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create sheet cache label: %v", err)
+	} else {
+		debugFlow.AddItem(sheetCacheLabel)
+	}
 
-	frameCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
-	debugFlow.AddItem(frameCacheLabel)
+	frameCacheLabel, err = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create frame cache label: %v", err)
+	} else {
+		debugFlow.AddItem(frameCacheLabel)
+	}
 
-	mobileCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
-	debugFlow.AddItem(mobileCacheLabel)
+	mobileCacheLabel, err = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create mobile cache label: %v", err)
+	} else {
+		debugFlow.AddItem(mobileCacheLabel)
+	}
 
-	soundCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
-	debugFlow.AddItem(soundCacheLabel)
+	soundCacheLabel, err = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create sound cache label: %v", err)
+	} else {
+		debugFlow.AddItem(soundCacheLabel)
+	}
 
 	clearCacheBtn, clearCacheEvents := eui.NewButton(&eui.ItemData{Text: "Clear All Caches", Size: eui.Point{X: width, Y: 24}})
 	clearCacheEvents.Handle = func(ev eui.UIEvent) {
@@ -931,8 +992,12 @@ func openDebugWindow() {
 		}
 	}
 	debugFlow.AddItem(clearCacheBtn)
-	totalCacheLabel, _ = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
-	debugFlow.AddItem(totalCacheLabel)
+	totalCacheLabel, err = eui.NewText(&eui.ItemData{Text: "", Size: eui.Point{X: width, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create total cache label: %v", err)
+	} else {
+		debugFlow.AddItem(totalCacheLabel)
+	}
 
 	debugWin.AddItem(debugFlow)
 
@@ -964,8 +1029,12 @@ func openDebugWindow() {
 	}
 	soundTestFlow.AddItem(minusBtn)
 
-	soundTestLabel, _ = eui.NewText(&eui.ItemData{Text: "0", Size: eui.Point{X: 40, Y: 24}, FontSize: 10})
-	soundTestFlow.AddItem(soundTestLabel)
+	soundTestLabel, err = eui.NewText(&eui.ItemData{Text: "0", Size: eui.Point{X: 40, Y: 24}, FontSize: 10})
+	if err != nil {
+		logError("failed to create sound test label: %v", err)
+	} else {
+		soundTestFlow.AddItem(soundTestLabel)
+	}
 
 	plusBtn, plusEvents := eui.NewButton(&eui.ItemData{Text: "+", Size: eui.Point{X: 24, Y: 24}})
 	plusEvents.Handle = func(ev eui.UIEvent) {
@@ -1137,8 +1206,12 @@ func openInventoryWindow() {
 	}
 
 	inventoryList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
-	title, _ := eui.NewText(&eui.ItemData{Text: "Inventory", Size: eui.Point{X: 256, Y: 128}})
-	inventoryWin.AddItem(title)
+	title, err := eui.NewText(&eui.ItemData{Text: "Inventory", Size: eui.Point{X: 256, Y: 128}})
+	if err != nil {
+		logError("failed to create inventory title: %v", err)
+	} else {
+		inventoryWin.AddItem(title)
+	}
 	inventoryWin.AddItem(inventoryList)
 	inventoryWin.AddWindow(false)
 	//inventoryWin.Refresh()
@@ -1201,7 +1274,11 @@ func openHelpWindow() {
 		"Escape - Cancel typing",
 	}
 	for _, line := range helpTexts {
-		t, _ := eui.NewText(&eui.ItemData{Text: line, Size: eui.Point{X: 300, Y: 24}, FontSize: 15})
+		t, err := eui.NewText(&eui.ItemData{Text: line, Size: eui.Point{X: 300, Y: 24}, FontSize: 15})
+		if err != nil {
+			logError("failed to create help text: %v", err)
+			continue
+		}
 		helpFlow.AddItem(t)
 	}
 	helpWin.AddItem(helpFlow)


### PR DESCRIPTION
## Summary
- log failures creating text elements across messages, players, chat, inventory, movie player and other UI windows
- surface UI initialization problems by checking `eui.New*` errors

## Testing
- `go fmt messages_ui.go players_ui.go ui.go chat_messages_ui.go inventory_ui.go movie_player.go`
- `go vet ./...` *(fails: cannot use eui.NewText(... ) as error value)*

------
https://chatgpt.com/codex/tasks/task_e_689808779c58832a952420a4f4eeea06