### PR TITLE
Refactor window initialization logic

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -43,19 +43,9 @@ func openChatWindow() {
 	}
 	chatWin = eui.NewWindow(&eui.WindowData{})
 	chatWin.Title = "Chat"
-	if gs.ChatWindow.Size.X > 0 && gs.ChatWindow.Size.Y > 0 {
-		chatWin.Size = eui.Point{X: float32(gs.ChatWindow.Size.X), Y: float32(gs.ChatWindow.Size.Y)}
-	} else {
+	initWindow(chatWin, gs.ChatWindow, eui.PIN_BOTTOM_RIGHT)
+	if chatWin.Size.X == 0 || chatWin.Size.Y == 0 {
 		chatWin.Size = eui.Point{X: 700, Y: 300}
-	}
-	chatWin.Closable = true
-	chatWin.Resizable = true
-	chatWin.AutoSize = false
-	chatWin.Movable = false
-	chatWin.Open = true
-	chatWin.PinTo = eui.PIN_BOTTOM_RIGHT
-	if gs.ChatWindow.Position.X != 0 || gs.ChatWindow.Position.Y != 0 {
-		chatWin.Position = eui.Point{X: float32(gs.ChatWindow.Position.X), Y: float32(gs.ChatWindow.Position.Y)}
 	}
 
 	chatList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}

--- a/messages_ui.go
+++ b/messages_ui.go
@@ -57,20 +57,10 @@ func openMessagesWindow() {
 		}
 	}
 	messagesWin = eui.NewWindow(&eui.WindowData{})
-	if gs.MessagesWindow.Size.X > 0 && gs.MessagesWindow.Size.Y > 0 {
-		messagesWin.Size = eui.Point{X: float32(gs.MessagesWindow.Size.X), Y: float32(gs.MessagesWindow.Size.Y)}
-	} else {
-		messagesWin.Size = eui.Point{X: 700, Y: 300}
-	}
 	messagesWin.Title = "Console"
-	messagesWin.Closable = true
-	messagesWin.Resizable = true
-	messagesWin.AutoSize = false
-	messagesWin.Movable = false
-	messagesWin.Open = true
-	messagesWin.PinTo = eui.PIN_BOTTOM_LEFT
-	if gs.MessagesWindow.Position.X != 0 || gs.MessagesWindow.Position.Y != 0 {
-		messagesWin.Position = eui.Point{X: float32(gs.MessagesWindow.Position.X), Y: float32(gs.MessagesWindow.Position.Y)}
+	initWindow(messagesWin, gs.MessagesWindow, eui.PIN_BOTTOM_LEFT)
+	if messagesWin.Size.X == 0 || messagesWin.Size.Y == 0 {
+		messagesWin.Size = eui.Point{X: 700, Y: 300}
 	}
 
 	messagesList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}

--- a/ui.go
+++ b/ui.go
@@ -179,12 +179,10 @@ func openDownloadsWindow(status dataFilesStatus) {
 
 	downloadWin = eui.NewWindow(&eui.WindowData{})
 	downloadWin.Title = "Downloads"
+	initWindow(downloadWin, WindowState{}, eui.PIN_BOTTOM_CENTER)
 	downloadWin.Closable = false
 	downloadWin.Resizable = false
 	downloadWin.AutoSize = true
-	downloadWin.Movable = false
-	downloadWin.PinTo = eui.PIN_BOTTOM_CENTER
-	downloadWin.Open = true
 
 	startedDownload := false
 
@@ -326,12 +324,10 @@ func openAddCharacterWindow() {
 	}
 	addCharWin = eui.NewWindow(&eui.WindowData{})
 	addCharWin.Title = "Add Character"
+	initWindow(addCharWin, WindowState{}, eui.PIN_BOTTOM_CENTER)
 	addCharWin.Closable = false
 	addCharWin.Resizable = false
 	addCharWin.AutoSize = true
-	addCharWin.Movable = false
-	addCharWin.Open = true
-	addCharWin.PinTo = eui.PIN_BOTTOM_CENTER
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 
@@ -403,12 +399,10 @@ func openLoginWindow() {
 
 	loginWin = eui.NewWindow(&eui.WindowData{})
 	loginWin.Title = "Login"
+	initWindow(loginWin, WindowState{}, eui.PIN_MID_CENTER)
 	loginWin.Closable = false
 	loginWin.Resizable = false
 	loginWin.AutoSize = true
-	loginWin.Movable = false
-	loginWin.PinTo = eui.PIN_MID_CENTER
-	loginWin.Open = true
 
 	loginFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	charactersList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
@@ -514,12 +508,10 @@ func openLoginWindow() {
 func openErrorWindow(msg string) {
 	win := eui.NewWindow(&eui.WindowData{})
 	win.Title = "Error"
+	initWindow(win, WindowState{}, eui.PIN_MID_CENTER)
 	win.Closable = false
 	win.Resizable = false
 	win.AutoSize = true
-	win.Movable = false
-	win.PinTo = eui.PIN_MID_CENTER
-	win.Open = true
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	text, _ := eui.NewText(&eui.ItemData{Text: msg, FontSize: 8, Size: eui.Point{X: 500, Y: 25}})
@@ -541,12 +533,9 @@ func openSettingsWindow() {
 	}
 	settingsWin = eui.NewWindow(&eui.WindowData{})
 	settingsWin.Title = "Settings"
-	settingsWin.Closable = true
+	initWindow(settingsWin, WindowState{}, eui.PART_TOP_LEFT)
 	settingsWin.Resizable = false
 	settingsWin.AutoSize = true
-	settingsWin.Movable = false
-	settingsWin.Open = true
-	settingsWin.PinTo = eui.PART_TOP_LEFT
 
 	mainFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	var width float32 = 250
@@ -749,12 +738,9 @@ func openDebugWindow() {
 	var width float32 = 250
 	debugWin = eui.NewWindow(&eui.WindowData{})
 	debugWin.Title = "Debug Settings"
-	debugWin.Closable = true
+	initWindow(debugWin, WindowState{}, eui.PIN_MID_CENTER)
 	debugWin.Resizable = false
 	debugWin.AutoSize = true
-	debugWin.Movable = false
-	debugWin.Open = true
-	debugWin.PinTo = eui.PIN_MID_CENTER
 
 	debugFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 
@@ -1049,12 +1035,10 @@ func openWindowsWindow() {
 	}
 	windowsWin = eui.NewWindow(&eui.WindowData{})
 	windowsWin.Title = "Windows"
+	initWindow(windowsWin, WindowState{}, eui.PIN_TOP_CENTER)
 	windowsWin.Closable = false
 	windowsWin.Resizable = false
 	windowsWin.AutoSize = true
-	windowsWin.Movable = false
-	windowsWin.Open = true
-	windowsWin.PinTo = eui.PIN_TOP_CENTER
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 
@@ -1120,21 +1104,10 @@ func openInventoryWindow() {
 	}
 	inventoryWin = eui.NewWindow(&eui.WindowData{})
 	inventoryWin.Title = "Inventory"
+	initWindow(inventoryWin, gs.InventoryWindow, eui.PIN_TOP_LEFT)
 	inventoryWin.Closable = false
 	inventoryWin.Resizable = false
 	inventoryWin.AutoSize = true
-	inventoryWin.Movable = false
-	inventoryWin.PinTo = eui.PIN_TOP_LEFT
-	inventoryWin.Open = true
-
-	if gs.InventoryWindow.Size.X > 0 && gs.InventoryWindow.Size.Y > 0 {
-		inventoryWin.Size = eui.Point{X: float32(gs.InventoryWindow.Size.X), Y: float32(gs.InventoryWindow.Size.Y)}
-	}
-	if gs.InventoryWindow.Position.X != 0 || gs.InventoryWindow.Position.Y != 0 {
-		inventoryWin.Position = eui.Point{X: float32(gs.InventoryWindow.Position.X), Y: float32(gs.InventoryWindow.Position.Y)}
-	} else {
-		inventoryWin.Position = eui.Point{X: 0, Y: 0}
-	}
 
 	inventoryList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	title, _ := eui.NewText(&eui.ItemData{Text: "Inventory", Size: eui.Point{X: 256, Y: 128}})
@@ -1157,19 +1130,12 @@ func openPlayersWindow() {
 	}
 	playersWin = eui.NewWindow(&eui.WindowData{})
 	playersWin.Title = "Players"
-	if gs.PlayersWindow.Size.X > 0 && gs.PlayersWindow.Size.Y > 0 {
-		playersWin.Size = eui.Point{X: float32(gs.PlayersWindow.Size.X), Y: float32(gs.PlayersWindow.Size.Y)}
-	} else {
+	initWindow(playersWin, gs.PlayersWindow, eui.PIN_TOP_RIGHT)
+	if playersWin.Size.X == 0 || playersWin.Size.Y == 0 {
 		playersWin.Size = eui.Point{X: 300, Y: 600}
 	}
 	playersWin.Closable = false
 	playersWin.Resizable = false
-	playersWin.Movable = false
-	playersWin.PinTo = eui.PIN_TOP_RIGHT
-	playersWin.Open = true
-	if gs.PlayersWindow.Position.X != 0 || gs.PlayersWindow.Position.Y != 0 {
-		playersWin.Position = eui.Point{X: float32(gs.PlayersWindow.Position.X), Y: float32(gs.PlayersWindow.Position.Y)}
-	}
 
 	playersList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	playersWin.AddItem(playersList)
@@ -1184,12 +1150,9 @@ func openHelpWindow() {
 	}
 	helpWin = eui.NewWindow(&eui.WindowData{})
 	helpWin.Title = "Help"
-	helpWin.Closable = true
+	initWindow(helpWin, WindowState{}, eui.PIN_MID_CENTER)
 	helpWin.Resizable = false
 	helpWin.AutoSize = true
-	helpWin.Movable = false
-	helpWin.PinTo = eui.PIN_MID_CENTER
-	helpWin.Open = true
 
 	helpFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	helpTexts := []string{

--- a/window.go
+++ b/window.go
@@ -1,0 +1,20 @@
+package main
+
+import "github.com/Distortions81/EUI/eui"
+
+// initWindow applies common window settings such as size, position,
+// pinning and basic flags.
+func initWindow(data *eui.WindowData, cfg WindowState, pin eui.Pin) {
+	if cfg.Size.X > 0 && cfg.Size.Y > 0 {
+		data.Size = eui.Point{X: float32(cfg.Size.X), Y: float32(cfg.Size.Y)}
+	}
+	if cfg.Position.X != 0 || cfg.Position.Y != 0 {
+		data.Position = eui.Point{X: float32(cfg.Position.X), Y: float32(cfg.Position.Y)}
+	}
+	data.Closable = true
+	data.Resizable = true
+	data.AutoSize = false
+	data.Movable = false
+	data.Open = true
+	data.PinTo = pin
+}


### PR DESCRIPTION
## Summary
- add `initWindow` helper to unify size, pin, and flag setup
- use `initWindow` in chat, messages, inventory, and other window openers

## Testing
- `gofmt -w window.go chat_messages_ui.go messages_ui.go ui.go`
- `go vet .` *(fails: `fatal error: X11/extensions/Xrandr.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_689808879da0832a8de00747bd6b868a