### PR TITLE
Clear UI slice contents before reuse

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -27,6 +27,9 @@ func updateChatWindow() {
 		}
 	}
 	if len(chatList.Contents) > len(msgs) {
+		for i := len(msgs); i < len(chatList.Contents); i++ {
+			chatList.Contents[i] = nil
+		}
 		chatList.Contents = chatList.Contents[:len(msgs)]
 		changed = true
 	}

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -34,6 +34,9 @@ func updateInventoryWindow() {
 		logDebug("Ivn Name: %v, ID: %v", it.Name, it.ID)
 	}
 	if len(inventoryList.Contents) > len(items) {
+		for i := len(items); i < len(inventoryList.Contents); i++ {
+			inventoryList.Contents[i] = nil
+		}
 		inventoryList.Contents = inventoryList.Contents[:len(items)]
 		changed = true
 	}

--- a/messages_ui.go
+++ b/messages_ui.go
@@ -42,6 +42,9 @@ func updateMessagesWindow() {
 		changed = true
 	}
 	if len(messagesList.Contents) > inputIdx+1 {
+		for i := inputIdx + 1; i < len(messagesList.Contents); i++ {
+			messagesList.Contents[i] = nil
+		}
 		messagesList.Contents = messagesList.Contents[:inputIdx+1]
 		changed = true
 	}

--- a/players_ui.go
+++ b/players_ui.go
@@ -19,6 +19,9 @@ func updatePlayersWindow() {
 	}
 	ps := getPlayers()
 	sort.Slice(ps, func(i, j int) bool { return ps[i].Name < ps[j].Name })
+	for i := range playersList.Contents {
+		playersList.Contents[i] = nil
+	}
 	playersList.Contents = playersList.Contents[:0]
 
 	var exiles []Player

--- a/ui.go
+++ b/ui.go
@@ -265,6 +265,9 @@ func updateCharacterButtons() {
 			passHash = characters[0].PassHash
 		}
 	}
+	for i := range charactersList.Contents {
+		charactersList.Contents[i] = nil
+	}
 	charactersList.Contents = charactersList.Contents[:0]
 	if len(characters) == 0 {
 		empty, _ := eui.NewText(&eui.ItemData{Text: "empty", Size: eui.Point{X: 160, Y: 64}})


### PR DESCRIPTION
## Summary
- nil out slice elements before reslicing in `updatePlayersWindow`
- clear reused slices in other update functions to avoid retaining UI items

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898088dedc0832a8381427c132495f3