### PR TITLE
Handle errors when closing sound players

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -64,14 +64,18 @@ var (
 		soundMu.Lock()
 		for sp := range soundPlayers {
 			if !sp.IsPlaying() {
-				sp.Close()
+				if err := sp.Close(); err != nil {
+					logError("close sound player: %v", err)
+				}
 				delete(soundPlayers, sp)
 			}
 		}
 		if maxSounds > 0 && len(soundPlayers) >= maxSounds {
 			soundMu.Unlock()
 			logDebug("playSound(%d) too many sound players (%d)", id, len(soundPlayers))
-			p.Close()
+			if err := p.Close(); err != nil {
+				logError("close sound player: %v", err)
+			}
 			return
 		}
 		soundPlayers[p] = struct{}{}


### PR DESCRIPTION
## Summary
- Log failures when closing completed sound players
- Log errors when closing new player if too many sounds are playing

## Testing
- `go test ./...` *(fails: undefined: eui.Pin)*

------
https://chatgpt.com/codex/tasks/task_e_6898167d9d54832a808d585aeb09bddf