### PR TITLE
Handle download cleanup errors

### DIFF
--- a/update.go
+++ b/update.go
@@ -42,7 +42,9 @@ func downloadGZ(url, dest string) error {
 	removeTmp := true
 	defer func() {
 		if removeTmp {
-			os.Remove(tmp)
+			if err := os.Remove(tmp); err != nil {
+				logError("remove %v: %v", tmp, err)
+			}
 		}
 	}()
 	if _, err := io.Copy(f, gz); err != nil {


### PR DESCRIPTION
## Summary
- Log failures when removing temporary update files

## Testing
- `go test ./...` *(fails: eui.EventHandler does not implement error; undefined: ebiten.RunOnMainThread)*

------
https://chatgpt.com/codex/tasks/task_e_689816787688832a94033701f9d9a9d7