### PR TITLE
Clean up boolean assignments

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -56,7 +56,7 @@ func parseBackendInfo(data []byte) {
 	p.Class = class
 	p.Clan = clan
 	playersMu.Unlock()
-	playersDirty = (true)
+	playersDirty = true
 }
 
 // parseBackendShare parses "be-sh" messages describing sharing relationships.
@@ -93,7 +93,7 @@ func parseBackendShare(data []byte) {
 		p.Sharing = true
 		playersMu.Unlock()
 	}
-	playersDirty = (true)
+	playersDirty = true
 }
 
 // parseBackendWho parses "be-wh" messages listing players.
@@ -116,7 +116,7 @@ func parseBackendWho(data []byte) {
 		}
 		data = data[idx+1:]
 	}
-	playersDirty = (true)
+	playersDirty = true
 }
 
 // parseNames extracts a slice of names from a sequence of "-pn name -pn" entries.

--- a/draw.go
+++ b/draw.go
@@ -499,7 +499,7 @@ func parseInventory(data []byte) ([]byte, bool) {
 	for len(data) > 0 && data[0] == 0 {
 		data = data[1:]
 	}
-	inventoryDirty = (true)
+	inventoryDirty = true
 	return data, true
 }
 

--- a/player.go
+++ b/player.go
@@ -35,7 +35,7 @@ func getPlayer(name string) *Player {
 	}
 	p = &Player{Name: name}
 	players[name] = p
-	playersDirty = (true)
+	playersDirty = true
 	return p
 }
 
@@ -52,7 +52,7 @@ func updatePlayerAppearance(name string, pictID uint16, colors []byte, isNPC boo
 	}
 	p.IsNPC = isNPC
 	playersMu.Unlock()
-	playersDirty = (true)
+	playersDirty = true
 }
 
 func getPlayers() []Player {

--- a/ui.go
+++ b/ui.go
@@ -1209,7 +1209,7 @@ func openInventoryWindow() {
 	inventoryWin.AddItem(inventoryList)
 	inventoryWin.AddWindow(false)
 	//inventoryWin.Refresh()
-	inventoryDirty = (true)
+	inventoryDirty = true
 	if inventoryBox != nil {
 		inventoryBox.Checked = true
 		inventoryBox.Dirty = true
@@ -1235,7 +1235,7 @@ func openPlayersWindow() {
 	playersWin.AddItem(playersList)
 	playersWin.AddWindow(false)
 	//playersWin.Refresh()
-	playersDirty = (true)
+	playersDirty = true
 }
 
 func openHelpWindow() {


### PR DESCRIPTION
## Summary
- Remove unnecessary parentheses around boolean literals in player, draw, UI, and backend parsers

## Testing
- `go test ./...` *(fails: missing types and build errors)*

------
https://chatgpt.com/codex/tasks/task_e_689816436f94832a8c9640e728335b01