### PR TITLE
Fix settings window pin constant

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -549,7 +549,7 @@ func openSettingsWindow() {
 	settingsWin.AutoSize = true
 	settingsWin.Movable = false
 	settingsWin.Open = true
-	settingsWin.PinTo = eui.PART_TOP_LEFT
+	settingsWin.PinTo = eui.PIN_TOP_LEFT
 
 	mainFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	var width float32 = 250


### PR DESCRIPTION
## Summary
- use `eui.PIN_TOP_LEFT` for settings window anchoring

## Testing
- `go fmt ui.go`


------
https://chatgpt.com/codex/tasks/task_e_689829262a8c832abf4a37ce4de65fad