### PR TITLE
Add checksum verification for images

### DIFF
--- a/climg/checksum.go
+++ b/climg/checksum.go
@@ -1,0 +1,62 @@
+package climg
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func simpleEncrypt(data []byte) {
+	key := []byte{0x3C, 0x5A, 0x69, 0x93, 0xA5, 0xC6}
+	for i := range data {
+		data[i] ^= key[i%len(key)]
+	}
+}
+
+func doChecksum(data []byte, s1, s2 *uint32) {
+	const base = 65521
+	for _, b := range data {
+		*s1 = (*s1 + uint32(b)) % base
+		*s2 = (*s2 + *s1) % base
+	}
+}
+
+func calculateChecksum(bits, colors, light []byte, ref *dataLocation) uint32 {
+	s1 := uint32(1)
+	s2 := uint32(0)
+	if bits == nil || colors == nil || ref == nil {
+		return 0
+	}
+	doChecksum(bits, &s1, &s2)
+	doChecksum(colors, &s1, &s2)
+	if light != nil {
+		doChecksum(light, &s1, &s2)
+	}
+	buf := &bytes.Buffer{}
+	binary.Write(buf, binary.BigEndian, ref.version)
+	binary.Write(buf, binary.BigEndian, ref.imageID)
+	binary.Write(buf, binary.BigEndian, ref.colorID)
+	binary.Write(buf, binary.BigEndian, uint32(0))
+	binary.Write(buf, binary.BigEndian, ref.flags)
+	binary.Write(buf, binary.BigEndian, ref.unusedFlags)
+	binary.Write(buf, binary.BigEndian, ref.unusedFlags2)
+	binary.Write(buf, binary.BigEndian, ref.lightingID)
+	binary.Write(buf, binary.BigEndian, ref.plane)
+	binary.Write(buf, binary.BigEndian, ref.numFrames)
+	binary.Write(buf, binary.BigEndian, ref.numAnims)
+	n := int(ref.numAnims)
+	if n > len(ref.animFrameTable) {
+		n = len(ref.animFrameTable)
+	}
+	for i := 0; i < n; i++ {
+		binary.Write(buf, binary.BigEndian, ref.animFrameTable[i])
+	}
+	doChecksum(buf.Bytes(), &s1, &s2)
+	idbuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(idbuf, ref.id)
+	doChecksum(idbuf, &s1, &s2)
+	sum := (s2 << 16) + (s1 & 0xFFFF)
+	tmp := make([]byte, 4)
+	binary.BigEndian.PutUint32(tmp, sum)
+	simpleEncrypt(tmp)
+	return binary.BigEndian.Uint32(tmp)
+}

--- a/climg/checksum_test.go
+++ b/climg/checksum_test.go
@@ -1,0 +1,101 @@
+package climg
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"testing"
+)
+
+func buildTestFile(t *testing.T, corrupt bool) string {
+	bits := []byte{1, 2, 3, 4}
+	colors := []byte{5, 6, 7, 8}
+	ref := &dataLocation{
+		id:        1,
+		version:   1,
+		imageID:   2,
+		colorID:   3,
+		numFrames: 1,
+		numAnims:  0,
+	}
+	sum := calculateChecksum(bits, colors, nil, ref)
+	if corrupt {
+		sum++
+	}
+	// build idref record
+	idrefBuf := &bytes.Buffer{}
+	binary.Write(idrefBuf, binary.BigEndian, ref.version)
+	binary.Write(idrefBuf, binary.BigEndian, ref.imageID)
+	binary.Write(idrefBuf, binary.BigEndian, ref.colorID)
+	binary.Write(idrefBuf, binary.BigEndian, sum)
+	binary.Write(idrefBuf, binary.BigEndian, uint32(0)) // flags
+	binary.Write(idrefBuf, binary.BigEndian, uint32(0)) // unusedFlags
+	binary.Write(idrefBuf, binary.BigEndian, uint32(0)) // unusedFlags2
+	binary.Write(idrefBuf, binary.BigEndian, int32(0))  // lightingID
+	binary.Write(idrefBuf, binary.BigEndian, int16(0))  // plane
+	binary.Write(idrefBuf, binary.BigEndian, uint16(1)) // numFrames
+	binary.Write(idrefBuf, binary.BigEndian, uint16(0)) // numAnims
+	idrefData := idrefBuf.Bytes()
+
+	entryCount := uint32(3)
+	headerSize := 12
+	tableSize := int(entryCount) * 16
+	offset := uint32(headerSize + tableSize)
+
+	buf := &bytes.Buffer{}
+	binary.Write(buf, binary.BigEndian, uint16(0xFFFF))
+	binary.Write(buf, binary.BigEndian, entryCount)
+	binary.Write(buf, binary.BigEndian, uint32(0))
+	binary.Write(buf, binary.BigEndian, uint16(0))
+
+	// bits entry
+	binary.Write(buf, binary.BigEndian, offset)
+	binary.Write(buf, binary.BigEndian, uint32(len(bits)))
+	binary.Write(buf, binary.BigEndian, uint32(TYPE_IMAGE))
+	binary.Write(buf, binary.BigEndian, uint32(2))
+	offset += uint32(len(bits))
+
+	// color entry
+	binary.Write(buf, binary.BigEndian, offset)
+	binary.Write(buf, binary.BigEndian, uint32(len(colors)))
+	binary.Write(buf, binary.BigEndian, uint32(TYPE_COLOR))
+	binary.Write(buf, binary.BigEndian, uint32(3))
+	offset += uint32(len(colors))
+
+	// idref entry
+	binary.Write(buf, binary.BigEndian, offset)
+	binary.Write(buf, binary.BigEndian, uint32(len(idrefData)))
+	binary.Write(buf, binary.BigEndian, uint32(TYPE_IDREF))
+	binary.Write(buf, binary.BigEndian, uint32(1))
+
+	// data
+	buf.Write(bits)
+	buf.Write(colors)
+	buf.Write(idrefData)
+
+	tmp, err := os.CreateTemp("", "climg-test-*.bin")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if _, err := tmp.Write(buf.Bytes()); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	tmp.Close()
+	return tmp.Name()
+}
+
+func TestLoadChecksumValid(t *testing.T) {
+	path := buildTestFile(t, false)
+	defer os.Remove(path)
+	if _, err := Load(path); err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+}
+
+func TestLoadChecksumMismatch(t *testing.T) {
+	path := buildTestFile(t, true)
+	defer os.Remove(path)
+	if _, err := Load(path); err == nil {
+		t.Fatalf("expected checksum error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- port legacy checksum and XOR encryption logic into `climg`
- verify image checksums on load, skipping when disabled
- add tests for valid and mismatched checksum scenarios

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898404061b4832a8e88895bd602ecf0