### PR TITLE
Add volume controls and mute toggle

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -50,6 +50,8 @@ var gs settings = settings{
 	smoothMoving:     true,
 	fastBars:         true,
 	bubbleMessages:   false,
+	Volume:           0.5,
+	Mute:             false,
 	scale:            2,
 
 	GameWindow:      WindowState{Open: true},
@@ -99,6 +101,8 @@ type settings struct {
 	smoothMoving     bool
 	fastBars         bool
 	bubbleMessages   bool
+	Volume           float64
+	Mute             bool
 	recordAssetStats bool
 	scale            float64
 
@@ -155,6 +159,7 @@ func applySettings() {
 	}
 	ebiten.SetVsyncEnabled(gs.vsync)
 	initFont()
+	updateSoundVolume()
 }
 
 func saveSettings() {

--- a/sound.go
+++ b/sound.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	maxSounds  = 64
-	mainVolume = 0.5
 	sincTaps   = 16   // filter half-width for high quality sinc resampling
 	sincPhases = 1024 // number of fractional phases for precomputed table
 )
@@ -52,7 +51,11 @@ var (
 		}
 
 		p := audioContext.NewPlayerFromBytes(pcm)
-		p.SetVolume(mainVolume)
+		vol := gs.Volume
+		if gs.Mute {
+			vol = 0
+		}
+		p.SetVolume(vol)
 
 		soundMu.Lock()
 		for sp := range soundPlayers {
@@ -90,6 +93,18 @@ func initSoundContext() {
 	}
 
 	audioContext = audio.NewContext(rate)
+}
+
+func updateSoundVolume() {
+	soundMu.Lock()
+	vol := gs.Volume
+	if gs.Mute {
+		vol = 0
+	}
+	for sp := range soundPlayers {
+		sp.SetVolume(vol)
+	}
+	soundMu.Unlock()
 }
 
 func initSinc() {

--- a/ui.go
+++ b/ui.go
@@ -125,6 +125,44 @@ func initUI() {
 	}
 	overlay.AddItem(helpBtn)
 
+	volumeSlider, volumeEvents := eui.NewSlider()
+	volumeSlider.Label = "Volume"
+	volumeSlider.MinValue = 0
+	volumeSlider.MaxValue = 1
+	volumeSlider.Value = float32(gs.Volume)
+	volumeSlider.Size = eui.Point{X: 100, Y: 24}
+	volumeSlider.FontSize = 18
+	volumeEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.Volume = float64(ev.Value)
+			settingsDirty = true
+			updateSoundVolume()
+		}
+	}
+	overlay.AddItem(volumeSlider)
+
+	muteBtn, muteEvents := eui.NewButton()
+	muteBtn.Text = "Mute"
+	if gs.Mute {
+		muteBtn.Text = "Unmute"
+	}
+	muteBtn.Size = eui.Point{X: 64, Y: 24}
+	muteBtn.FontSize = 18
+	muteEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			gs.Mute = !gs.Mute
+			if gs.Mute {
+				muteBtn.Text = "Unmute"
+			} else {
+				muteBtn.Text = "Mute"
+			}
+			muteBtn.Dirty = true
+			settingsDirty = true
+			updateSoundVolume()
+		}
+	}
+	overlay.AddItem(muteBtn)
+
 	recordBtn, recordEvents := eui.NewButton()
 	recordBtn.Text = "Record Movie"
 	recordBtn.Size = eui.Point{X: 128, Y: 24}


### PR DESCRIPTION
## Summary
- Add volume slider and mute button to toolbar
- Persist volume and mute settings and apply across sounds

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_6898d1514788832aaefd775307234c24