### PR TITLE
Track ack commands and lighting flags in draw state

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -661,6 +661,8 @@ func parseDrawState(data []byte) error {
 	stateData := data[p : p+stateLen]
 
 	stateMu.Lock()
+	state.ackCmd = ackCmd
+	state.lightingFlags = lighting
 	state.prevHP = state.hp
 	state.prevHPMax = state.hpMax
 	state.prevSP = state.sp
@@ -837,10 +839,12 @@ func parseDrawState(data []byte) error {
 	for _, m := range mobiles {
 		state.mobiles[m.Index] = m
 	}
+	ack := state.ackCmd
+	light := state.lightingFlags
 	stateMu.Unlock()
 
-	logDebug("draw state cmd=%d ack=%d resend=%d desc=%d pict=%d again=%d mobile=%d state=%d",
-		ackCmd, ackFrame, resendFrame, len(descs), len(pics), pictAgain, len(mobiles), len(stateData))
+	logDebug("draw state cmd=%d ack=%d resend=%d light=%#x desc=%d pict=%d again=%d mobile=%d state=%d",
+		ack, ackFrame, resendFrame, light, len(descs), len(pics), pictAgain, len(mobiles), len(stateData))
 
 	stage = "info strings"
 	for {

--- a/game.go
+++ b/game.go
@@ -141,6 +141,8 @@ type drawState struct {
 	prevHP, prevHPMax           int
 	prevSP, prevSPMax           int
 	prevBalance, prevBalanceMax int
+	ackCmd                      uint8
+	lightingFlags               uint8
 }
 
 var (
@@ -182,6 +184,8 @@ type drawSnapshot struct {
 	prevHP, prevHPMax           int
 	prevSP, prevSPMax           int
 	prevBalance, prevBalanceMax int
+	ackCmd                      uint8
+	lightingFlags               uint8
 }
 
 // captureDrawSnapshot copies the shared draw state under a mutex.
@@ -209,6 +213,8 @@ func captureDrawSnapshot() drawSnapshot {
 		prevSPMax:      state.prevSPMax,
 		prevBalance:    state.prevBalance,
 		prevBalanceMax: state.prevBalanceMax,
+		ackCmd:         state.ackCmd,
+		lightingFlags:  state.lightingFlags,
 	}
 
 	for idx, d := range state.descriptors {


### PR DESCRIPTION
## Summary
- record ack command number and lighting flags in shared draw state and snapshots
- propagate parsed ack command and lighting info and include in debug logs

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898d2217c84832aa5df644eb38a0c23