### PR TITLE
Store draw state data for debugging

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -658,9 +658,10 @@ func parseDrawState(data []byte) error {
 	if len(data) < p+stateLen {
 		return errors.New(stage)
 	}
-	stateData := data[p : p+stateLen]
+	rawStateData := data[p : p+stateLen]
 
 	stateMu.Lock()
+	state.stateData = append(state.stateData[:0], rawStateData...)
 	state.prevHP = state.hp
 	state.prevHPMax = state.hpMax
 	state.prevSP = state.sp
@@ -839,10 +840,12 @@ func parseDrawState(data []byte) error {
 	}
 	stateMu.Unlock()
 
+	logDebug("state data stored (%d bytes)", len(rawStateData))
 	logDebug("draw state cmd=%d ack=%d resend=%d desc=%d pict=%d again=%d mobile=%d state=%d",
-		ackCmd, ackFrame, resendFrame, len(descs), len(pics), pictAgain, len(mobiles), len(stateData))
+		ackCmd, ackFrame, resendFrame, len(descs), len(pics), pictAgain, len(mobiles), len(rawStateData))
 
 	stage = "info strings"
+	stateData := rawStateData
 	for {
 		if len(stateData) == 0 {
 			return errors.New(stage)

--- a/game.go
+++ b/game.go
@@ -132,6 +132,7 @@ type drawState struct {
 	prevDescs   map[uint8]frameDescriptor
 	prevTime    time.Time
 	curTime     time.Time
+	stateData   []byte
 
 	bubbles []bubble
 
@@ -175,6 +176,7 @@ type drawSnapshot struct {
 	prevDescs                   map[uint8]frameDescriptor
 	prevTime                    time.Time
 	curTime                     time.Time
+	stateData                   []byte
 	bubbles                     []bubble
 	hp, hpMax                   int
 	sp, spMax                   int
@@ -197,6 +199,7 @@ func captureDrawSnapshot() drawSnapshot {
 		mobiles:        make([]frameMobile, 0, len(state.mobiles)),
 		prevTime:       state.prevTime,
 		curTime:        state.curTime,
+		stateData:      append([]byte(nil), state.stateData...),
 		hp:             state.hp,
 		hpMax:          state.hpMax,
 		sp:             state.sp,


### PR DESCRIPTION
## Summary
- track raw draw state bytes in drawState and drawSnapshot
- record state data in parseDrawState and log its size for debugging

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6898d23b97c0832ab297dea7ca48c92c