### PR TITLE
Add fullscreen option in settings

### DIFF
--- a/game.go
+++ b/game.go
@@ -1102,7 +1102,11 @@ func runGame(ctx context.Context) {
 		w, h = initialWindowW, initialWindowH
 	}
 	ebiten.SetWindowSize(w, h)
-	ebiten.MaximizeWindow()
+	if gs.Fullscreen {
+		ebiten.SetFullscreen(true)
+	} else {
+		ebiten.MaximizeWindow()
+	}
 
 	op := &ebiten.RunGameOptions{ScreenTransparent: false}
 	if err := ebiten.RunGameWithOptions(&Game{}, op); err != nil {

--- a/settings.go
+++ b/settings.go
@@ -34,6 +34,7 @@ var gs settings = settings{
 	DenoisePercent:    0.2,
 	ShowFPS:           true,
 	UIScale:           1.0,
+	Fullscreen:        false,
 
 	imgPlanesDebug:   false,
 	smoothingDebug:   false,
@@ -85,6 +86,7 @@ type settings struct {
 	DenoisePercent    float64
 	ShowFPS           bool
 	UIScale           float64
+	Fullscreen        bool
 
 	imgPlanesDebug   bool
 	smoothingDebug   bool
@@ -158,6 +160,7 @@ func applySettings() {
 		initSinc()
 	}
 	ebiten.SetVsyncEnabled(gs.vsync)
+	ebiten.SetFullscreen(gs.Fullscreen)
 	initFont()
 	updateSoundVolume()
 }

--- a/ui.go
+++ b/ui.go
@@ -780,6 +780,19 @@ func makeSettingsWindow() {
 	}
 	mainFlow.AddItem(uiScaleSlider)
 
+	fullscreenCB, fullscreenEvents := eui.NewCheckbox()
+	fullscreenCB.Text = "Fullscreen"
+	fullscreenCB.Size = eui.Point{X: width, Y: 24}
+	fullscreenCB.Checked = gs.Fullscreen
+	fullscreenEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.Fullscreen = ev.Checked
+			ebiten.SetFullscreen(gs.Fullscreen)
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(fullscreenCB)
+
 	denoiseCB, denoiseEvents := eui.NewCheckbox()
 	denoiseCB.Text = "Image Denoise"
 	denoiseCB.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- Add `Fullscreen` setting and apply it on startup
- Expose fullscreen toggle in the settings UI and handle changes
- Ensure game startup respects fullscreen state

## Testing
- `go vet ./...` *(fails: replacement directory /home/dist/github/EUI/ does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6898f5b4f5ac832ab9d7df46f19e2679