### PR TITLE
Fix window hit detection for title bar

### DIFF
--- a/input_ui.go
+++ b/input_ui.go
@@ -21,7 +21,13 @@ func pointInUI(x, y int) bool {
 		}
 		pos := win.GetPos()
 		size := win.GetSize()
-		if fx >= pos.X && fx < pos.X+size.X && fy >= pos.Y && fy < pos.Y+size.Y {
+		s := eui.UIScale()
+		frame := (win.Margin + win.Border + win.BorderPad + win.Padding) * s
+		title := win.GetTitleSize()
+		x0, y0 := pos.X, pos.Y
+		x1 := x0 + size.X + frame*2
+		y1 := y0 + size.Y + frame*2 + title
+		if fx >= x0 && fx < x1 && fy >= y0 && fy < y1 {
 			return true
 		}
 	}

--- a/input_ui_test.go
+++ b/input_ui_test.go
@@ -40,3 +40,29 @@ func TestPointInUISkipsMainPortal(t *testing.T) {
 	frontWin.Close()
 	mainWin.Close()
 }
+
+// TestPointInUICoversTitleBar ensures that the window's title area counts as UI.
+func TestPointInUICoversTitleBar(t *testing.T) {
+	// Clean up any existing windows to avoid interference between tests.
+	for _, w := range eui.Windows() {
+		w.Close()
+	}
+
+	win := eui.NewWindow()
+	win.Size = eui.Point{X: 50, Y: 50}
+	win.AddWindow(false)
+	win.Open()
+
+	pos := win.GetPos()
+	size := win.GetSize()
+	s := eui.UIScale()
+	frame := (win.Margin + win.Border + win.BorderPad + win.Padding) * s
+	title := win.GetTitleSize()
+	x := int(pos.X + frame + 1)
+	y := int(pos.Y + size.Y + frame*2 + title/2)
+	if !pointInUI(x, y) {
+		t.Fatalf("pointInUI should include title bar region")
+	}
+
+	win.Close()
+}


### PR DESCRIPTION
## Summary
- include window frame and title bar in UI hit tests
- add test confirming title bar counts as UI

## Testing
- `go vet ./...`
- `go test ./...` *(fails: DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6898f662cd5c832a937423a2fb6ef607