### PR TITLE
Avoid locking during sound volume updates

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -101,10 +101,15 @@ func updateSoundVolume() {
 	if gs.Mute {
 		vol = 0
 	}
+	players := make([]*audio.Player, 0, len(soundPlayers))
 	for sp := range soundPlayers {
-		sp.SetVolume(vol)
+		players = append(players, sp)
 	}
 	soundMu.Unlock()
+
+	for _, sp := range players {
+		sp.SetVolume(vol)
+	}
 }
 
 func initSinc() {


### PR DESCRIPTION
## Summary
- copy soundPlayers while holding lock and adjust volumes after unlock

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689907bba6d0832a8d0548c62c3ce332