### PR TITLE
Avoid deadlock when updating sound volume

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -101,10 +101,20 @@ func updateSoundVolume() {
 	if gs.Mute {
 		vol = 0
 	}
+	players := make([]*audio.Player, 0, len(soundPlayers))
 	for sp := range soundPlayers {
-		sp.SetVolume(vol)
+		if sp.IsPlaying() {
+			players = append(players, sp)
+		} else {
+			sp.Close()
+			delete(soundPlayers, sp)
+		}
 	}
 	soundMu.Unlock()
+
+	for _, sp := range players {
+		sp.SetVolume(vol)
+	}
 }
 
 func initSinc() {


### PR DESCRIPTION
## Summary
- copy soundPlayers while holding lock, remove inactive players, and adjust volumes after unlock

## Testing
- `go fmt sound.go`
- `go vet ./...` *(fails: github.com/Distortions81/EUI replacement directory does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689907bba6d0832a8d0548c62c3ce332