### PR TITLE
Scale speech bubble offset with display scale

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -108,7 +108,7 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	if txt == "" {
 		return
 	}
-	y -= 35
+	y -= int(35 * gs.scale)
 
 	sw := int(float64(gameAreaSizeX) * gs.scale)
 	sh := int(float64(gameAreaSizeY) * gs.scale)


### PR DESCRIPTION
## Summary
- scale speech bubble vertical offset by current screen scale so bubbles stay aligned with mobiles

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68994aa50c40832aa32d0efcf50929d1