### PR TITLE
Add periodic auto-save for settings

### DIFF
--- a/game.go
+++ b/game.go
@@ -321,6 +321,17 @@ func (g *Game) Update() error {
 		initGame()
 	})
 
+	if syncWindowSettings() {
+		settingsDirty = true
+	}
+	if time.Since(lastSettingsSave) >= 5*time.Second {
+		if settingsDirty {
+			saveSettings()
+			settingsDirty = false
+		}
+		lastSettingsSave = time.Now()
+	}
+
 	if inputActive {
 		inputText = append(inputText, ebiten.AppendInputChars(nil)...)
 		if inpututil.IsKeyJustPressed(ebiten.KeyArrowUp) {

--- a/settings.go
+++ b/settings.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Distortions81/EUI/eui"
 	"github.com/hajimehoshi/ebiten/v2"
@@ -115,7 +116,10 @@ type settings struct {
 	ChatWindow      WindowState
 }
 
-var settingsDirty bool
+var (
+	settingsDirty    bool
+	lastSettingsSave = time.Now()
+)
 
 type WindowPoint struct {
 	X float64


### PR DESCRIPTION
## Summary
- mark windows as dirty on move/resize and periodically persist settings
- save settings every 5 seconds whenever updates are pending

## Testing
- `go vet ./...` *(fails: github.com/Distortions81/EUI replacement directory does not exist)*
- `go test ./...` *(fails: missing EUI replacement and X11 header)*

------
https://chatgpt.com/codex/tasks/task_e_68994b4c0768832a9e0011eb991ac602