### PR TITLE
Fix Blackman window indexing

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -130,7 +130,7 @@ func updateSoundVolume() {
 func initSinc() {
 	for k := -sincTaps + 1; k <= sincTaps; k++ {
 		idx := k + sincTaps - 1
-		t := float64(k)/float64(sincTaps) + 0.5
+		t := float64(idx) / float64(2*sincTaps-1)
 		a := 2 * math.Pi * t
 		blackmanCosA[idx] = float32(math.Cos(a))
 		blackmanSinA[idx] = float32(math.Sin(a))
@@ -143,7 +143,7 @@ func initSinc() {
 	sincSums = make([]float32, sincPhases)
 	for p := 0; p < sincPhases; p++ {
 		frac := float32(p) / float32(sincPhases)
-		b := (2 * math.Pi / float64(sincTaps)) * float64(frac)
+		b := (2 * math.Pi / float64(2*sincTaps-1)) * float64(frac)
 		cosB, sinB := float32(math.Cos(b)), float32(math.Sin(b))
 		cosB2, sinB2 := float32(math.Cos(2*b)), float32(math.Sin(2*b))
 


### PR DESCRIPTION
## Summary
- compute Blackman window coefficients using direct index-based t
- adjust phase scaling to align with standard Blackman window

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899566c9bd4832a9c102de46e2d22bc