### PR TITLE
Normalize sinc resampler weights and guard wsum underflow

### DIFF
--- a/sound_test.go
+++ b/sound_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+// TestSincNormalization ensures sinc table coefficients sum to approximately 1.
+func TestSincNormalization(t *testing.T) {
+	initSinc()
+	for phase, coeffs := range sincTable {
+		var sum float32
+		for _, c := range coeffs {
+			sum += c
+		}
+		if math.Abs(float64(sum-1)) > 1e-6 {
+			t.Fatalf("phase %d sum %f out of range", phase, sum)
+		}
+		if sincInvSums[phase] <= 0 {
+			t.Fatalf("phase %d inverse sum %f invalid", phase, sincInvSums[phase])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize precomputed sinc coefficients and store inverse sums for reuse
- Guard resampleSincHQ against tiny or negative weight sums before dividing
- Add unit test verifying sinc phases remain normalized

## Testing
- `go vet ./...`
- `go test ./...` *(fails: "glfw: X11: The DISPLAY environment variable is missing")*


------
https://chatgpt.com/codex/tasks/task_e_689956755c10832a842c777137756199