### PR TITLE
fix: remove undefined sincSums reference

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -237,7 +237,7 @@ func resampleSincHQ(src []int16, srcRate, dstRate int) []int16 {
 			phase = sincPhases - 1
 		}
 		coeffs := sincTable[phase]
-		wsum := float64(sincSums[phase]) // float64 to reduce rounding error
+		wsum := 1.0 // coefficients pre-normalized to sum to 1
 		var sum float64
 
 		for k := -sincTaps + 1; k <= sincTaps; k++ {


### PR DESCRIPTION
## Summary
- fix resampleSincHQ using missing sincSums variable by using normalized coefficient sum

## Testing
- `go vet ./...` *(fails: github.com/Distortions81/EUI@v0.0.24: replacement directory /home/dist/github/EUI/ does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68995c39adc4832ab48e842ce795f32c