### PR TITLE
Fix speech bubble position

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -103,7 +103,9 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 		return
 	}
 	tailX, tailY := x, y
-	y -= int(35 * gs.scale)
+	ox, oy := gameContentOrigin()
+	x -= ox
+	y -= oy
 
 	sw := int(float64(gameAreaSizeX) * gs.scale)
 	sh := int(float64(gameAreaSizeY) * gs.scale)
@@ -119,6 +121,10 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	height := lineHeight*len(lines) + 2*pad
 
 	left, top, right, bottom := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, far)
+	left += ox
+	right += ox
+	top += oy
+	bottom += oy
 	baseX := left + width/2
 
 	bgR, bgG, bgB, bgA := bgCol.RGBA()


### PR DESCRIPTION
## Summary
- account for game window origin when clamping speech bubbles so they can travel across the full width

## Testing
- `gofmt -w bubble.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689967c1cd98832aa82a3729c929ecec