### PR TITLE
Use frame-based expiration for speech bubbles

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -925,7 +925,11 @@ func parseDrawState(data []byte) error {
 				stateMu.Unlock()
 			}
 			if gs.SpeechBubbles && txt != "" && !blockBubbles {
-				b := bubble{Index: idx, Text: txt, Type: typ, Expire: time.Now().Add(4 * time.Second)}
+				frameMu.Lock()
+				interval := frameInterval
+				frameMu.Unlock()
+				frames := int((4*time.Second + interval - 1) / interval)
+				b := bubble{Index: idx, Text: txt, Type: typ, ExpireFrame: frameCounter + frames}
 				switch typ & kBubbleTypeMask {
 				case kBubbleRealAction, kBubblePlayerAction, kBubbleNarrate:
 					b.NoArrow = true

--- a/game.go
+++ b/game.go
@@ -157,13 +157,13 @@ var (
 
 // bubble stores temporary bubble debug information.
 type bubble struct {
-	Index   uint8
-	H, V    int16
-	Far     bool
-	NoArrow bool
-	Text    string
-	Type    int
-	Expire  time.Time
+	Index       uint8
+	H, V        int16
+	Far         bool
+	NoArrow     bool
+	Text        string
+	Type        int
+	ExpireFrame int
 }
 
 // drawSnapshot is a read-only copy of the current draw state.
@@ -224,10 +224,10 @@ func captureDrawSnapshot() drawSnapshot {
 		snap.mobiles = append(snap.mobiles, m)
 	}
 	if len(state.bubbles) > 0 {
-		now := time.Now()
+		curFrame := frameCounter
 		kept := state.bubbles[:0]
 		for _, b := range state.bubbles {
-			if b.Expire.After(now) {
+			if b.ExpireFrame > curFrame {
 				if !b.Far {
 					if m, ok := state.mobiles[b.Index]; ok {
 						b.H, b.V = m.H, m.V


### PR DESCRIPTION
## Summary
- track speech bubble expiration using frame counts rather than wall clock time

## Testing
- `go vet ./...` *(fails: github.com/Distortions81/EUI@v0.0.24: replacement directory /home/dist/github/EUI/ does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68996c11b004832a97d12f0531b32ad2