### PR TITLE
Apply high-pass filter to resampled audio

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -434,6 +434,8 @@ func loadSound(id uint16) []byte {
 		samples = resample(samples, srcRate, dstRate)
 	}
 
+	highpassIIR16(samples, 0.995)
+
 	applyFadeInOut(samples, dstRate)
 
 	pcm := make([]byte, len(samples)*2)


### PR DESCRIPTION
## Summary
- Remove DC bias from audio samples by inserting a one-pole high-pass filter after resampling.

## Testing
- `go fmt sound.go`
- `go vet ./...` *(fails: github.com/Distortions81/EUI replacement directory does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68996e0775fc832aa904533eb996bc67