### PR TITLE
Use precomputed sinc sums in HQ resampler

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -165,9 +165,6 @@ func initSinc() {
 		if wsum != 0 {
 			inv = 1 / wsum
 		}
-		for i := range coeffs {
-			coeffs[i] *= inv
-		}
 		sincTable[p] = coeffs
 		sincInvSums[p] = inv
 	}
@@ -238,24 +235,18 @@ func resampleSincHQ(src []int16, srcRate, dstRate int) []int16 {
 		}
 		coeffs := sincTable[phase]
 		var sum float64
-		var wsum float64
 
 		for k := -sincTaps + 1; k <= sincTaps; k++ {
 			j := idx + k
 			idxk := k + sincTaps - 1
 			coeff := float64(coeffs[idxk])
-			if j < 0 || j >= len(src) {
-				continue
+			var s float64
+			if j >= 0 && j < len(src) {
+				s = float64(src[j])
 			}
-			sum += float64(src[j]) * coeff
-			wsum += coeff
+			sum += s * coeff
 		}
-		if wsum < 1e-6 {
-			dst[i] = 0
-			pos += ratio
-			continue
-		}
-		sum /= wsum
+		sum *= float64(sincInvSums[phase])
 		if sum > float64(math.MaxInt16) {
 			sum = float64(math.MaxInt16)
 		} else if sum < float64(math.MinInt16) {

--- a/sound_test.go
+++ b/sound_test.go
@@ -13,8 +13,9 @@ func TestSincNormalization(t *testing.T) {
 		for _, c := range coeffs {
 			sum += c
 		}
-		if math.Abs(float64(sum-1)) > 1e-6 {
-			t.Fatalf("phase %d sum %f out of range", phase, sum)
+		norm := sum * sincInvSums[phase]
+		if math.Abs(float64(norm-1)) > 1e-6 {
+			t.Fatalf("phase %d normalized sum %f out of range", phase, norm)
 		}
 		if sincInvSums[phase] <= 0 {
 			t.Fatalf("phase %d inverse sum %f invalid", phase, sincInvSums[phase])


### PR DESCRIPTION
## Summary
- Use precomputed sinc coefficient sums for high quality resampling
- Zero-pad out-of-range samples instead of reweighting near clip edges
- Adjust sinc table test to verify normalization via inverse sums

## Testing
- `go vet ./...` *(fails: github.com/Distortions81/EUI@v0.0.24: replacement directory /home/dist/github/EUI/ does not exist)*
- `go vet sound.go sound_test.go` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68996e009008832a8c74ba0129637b39