### PR TITLE
Rewrite sinc filter for faster resampling

### DIFF
--- a/sound_test.go
+++ b/sound_test.go
@@ -13,12 +13,8 @@ func TestSincNormalization(t *testing.T) {
 		for _, c := range coeffs {
 			sum += c
 		}
-		norm := sum * sincInvSums[phase]
-		if math.Abs(float64(norm-1)) > 1e-6 {
-			t.Fatalf("phase %d normalized sum %f out of range", phase, norm)
-		}
-		if sincInvSums[phase] <= 0 {
-			t.Fatalf("phase %d inverse sum %f invalid", phase, sincInvSums[phase])
+		if math.Abs(float64(sum-1)) > 1e-6 {
+			t.Fatalf("phase %d normalized sum %f out of range", phase, sum)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- streamline sinc initialization with normalized Blackman-windowed coefficients
- simplify high-quality resampler to drop phase interpolation for better performance
- update normalization test for new table format

## Testing
- `go fmt sound.go sound_test.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68997f6c83ec832aa230d349830684c1