### PR TITLE
feat: add game window size settings

### DIFF
--- a/game.go
+++ b/game.go
@@ -1150,25 +1150,33 @@ func initGame() {
 
 func makeGameWindow() {
 	ssx, _ := eui.ScreenSize()
-	size := eui.Point{X: gameAreaSizeX, Y: gameAreaSizeY}
 
 	gameWin = eui.NewWindow()
 	gameWin.Title = ""
 
-	if gs.GameWindow.Size.X > 0 && gs.GameWindow.Size.Y > 0 {
-		gameWin.Size = eui.Point{X: float32(gs.GameWindow.Size.X) * eui.UIScale(), Y: float32(gs.GameWindow.Size.Y) * eui.UIScale()}
+	if gs.AnyGameWindowSize {
+		if gs.GameWindow.Size.X > 0 && gs.GameWindow.Size.Y > 0 {
+			gameWin.Size = eui.Point{X: float32(gs.GameWindow.Size.X) * eui.UIScale(), Y: float32(gs.GameWindow.Size.Y) * eui.UIScale()}
+		} else {
+			gameWin.Size = eui.Point{X: float32(gameAreaSizeX) * float32(gs.scale), Y: float32(gameAreaSizeY) * float32(gs.scale)}
+		}
 	} else {
+		if gs.scale < 1 {
+			gs.scale = 1
+		} else if gs.scale > 5 {
+			gs.scale = 5
+		}
 		gameWin.Size = eui.Point{X: float32(gameAreaSizeX) * float32(gs.scale), Y: float32(gameAreaSizeY) * float32(gs.scale)}
 	}
 
 	if gs.GameWindow.Position.X != 0 || gs.GameWindow.Position.Y != 0 {
 		gameWin.Position = eui.Point{X: float32(gs.GameWindow.Position.X), Y: float32(gs.GameWindow.Position.Y)}
 	} else {
-		gameWin.Position = eui.Point{X: float32(ssx/2) - (size.X/2)*float32(gs.scale), Y: 0}
+		gameWin.Position = eui.Point{X: float32(ssx/2) - gameWin.Size.X/2, Y: 0}
 	}
 
 	gameWin.Closable = false
-	gameWin.Resizable = true
+	gameWin.Resizable = gs.AnyGameWindowSize
 	gameWin.Movable = true
 	gameWin.MainPortal = true
 	gameWin.FixedRatio = true

--- a/settings.go
+++ b/settings.go
@@ -37,25 +37,26 @@ var gs settings = settings{
 	UIScale:           1.0,
 	Fullscreen:        false,
 
-	imgPlanesDebug:   false,
-	smoothingDebug:   false,
-	hideMoving:       false,
-	hideMobiles:      false,
-	vsync:            true,
-	fastSound:        true,
-	nightEffect:      true,
-	precacheSounds:   false,
-	precacheImages:   false,
-	textureFiltering: false,
-	lateInputUpdates: true,
-	cacheWholeSheet:  true,
-	smoothMoving:     true,
-	fastBars:         true,
-	bubbleMessages:   false,
-	Volume:           0.5,
-	Mute:             false,
-	recordAssetStats: true,
-	scale:            2,
+	imgPlanesDebug:    false,
+	smoothingDebug:    false,
+	hideMoving:        false,
+	hideMobiles:       false,
+	vsync:             true,
+	fastSound:         true,
+	nightEffect:       true,
+	precacheSounds:    false,
+	precacheImages:    false,
+	textureFiltering:  false,
+	lateInputUpdates:  true,
+	cacheWholeSheet:   true,
+	smoothMoving:      true,
+	fastBars:          true,
+	bubbleMessages:    false,
+	Volume:            0.5,
+	Mute:              false,
+	recordAssetStats:  true,
+	scale:             2,
+	AnyGameWindowSize: false,
 
 	GameWindow:      WindowState{Open: true},
 	InventoryWindow: WindowState{Open: true},
@@ -90,25 +91,26 @@ type settings struct {
 	UIScale           float64
 	Fullscreen        bool
 
-	imgPlanesDebug   bool
-	smoothingDebug   bool
-	hideMoving       bool
-	hideMobiles      bool
-	vsync            bool
-	fastSound        bool
-	nightEffect      bool
-	precacheSounds   bool
-	precacheImages   bool
-	textureFiltering bool
-	lateInputUpdates bool
-	cacheWholeSheet  bool
-	smoothMoving     bool
-	fastBars         bool
-	bubbleMessages   bool
-	Volume           float64
-	Mute             bool
-	recordAssetStats bool
-	scale            float64
+	imgPlanesDebug    bool
+	smoothingDebug    bool
+	hideMoving        bool
+	hideMobiles       bool
+	vsync             bool
+	fastSound         bool
+	nightEffect       bool
+	precacheSounds    bool
+	precacheImages    bool
+	textureFiltering  bool
+	lateInputUpdates  bool
+	cacheWholeSheet   bool
+	smoothMoving      bool
+	fastBars          bool
+	bubbleMessages    bool
+	Volume            float64
+	Mute              bool
+	recordAssetStats  bool
+	scale             float64
+	AnyGameWindowSize bool
 
 	GameWindow      WindowState
 	InventoryWindow WindowState


### PR DESCRIPTION
## Summary
- add slider to set game window scale 1–5x and show desktop max
- toggle for allowing any game window size and adjust window behavior
- persist new any-game-window-size setting

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68999c0a3258832aa8dcf4bfe26c0b8f