### PR TITLE
Add potato computer performance option

### DIFF
--- a/game.go
+++ b/game.go
@@ -1136,7 +1136,17 @@ func runGame(ctx context.Context) {
 
 func initGame() {
 	ebiten.SetWindowTitle("goThoom Client")
-	ebiten.SetVsyncEnabled(gs.vsync)
+	if gs.PotatoMode {
+		ebiten.SetFPSMode(ebiten.FPSModeVsyncOffMinimum)
+		ebiten.SetVsyncEnabled(false)
+	} else {
+		ebiten.SetVsyncEnabled(gs.vsync)
+		if gs.vsync {
+			ebiten.SetFPSMode(ebiten.FPSModeVsyncOn)
+		} else {
+			ebiten.SetFPSMode(ebiten.FPSModeVsyncOffMaximum)
+		}
+	}
 	ebiten.SetTPS(ebiten.SyncWithFPS)
 	ebiten.SetCursorShape(ebiten.CursorShapeDefault)
 

--- a/settings.go
+++ b/settings.go
@@ -38,6 +38,7 @@ var gsdef settings = settings{
 	ShowFPS:           true,
 	UIScale:           1.0,
 	Fullscreen:        false,
+	PotatoMode:        false,
 
 	imgPlanesDebug:    false,
 	smoothingDebug:    false,
@@ -92,6 +93,7 @@ type settings struct {
 	ShowFPS           bool
 	UIScale           float64
 	Fullscreen        bool
+	PotatoMode        bool
 
 	imgPlanesDebug    bool
 	smoothingDebug    bool
@@ -178,10 +180,41 @@ func applySettings() {
 	if !gs.fastSound {
 		initSinc()
 	}
-	ebiten.SetVsyncEnabled(gs.vsync)
+	if gs.PotatoMode {
+		ebiten.SetFPSMode(ebiten.FPSModeVsyncOffMinimum)
+		ebiten.SetVsyncEnabled(false)
+	} else {
+		ebiten.SetVsyncEnabled(gs.vsync)
+		if gs.vsync {
+			ebiten.SetFPSMode(ebiten.FPSModeVsyncOn)
+		} else {
+			ebiten.SetFPSMode(ebiten.FPSModeVsyncOffMaximum)
+		}
+	}
 	ebiten.SetFullscreen(gs.Fullscreen)
 	initFont()
 	updateSoundVolume()
+}
+
+func enablePotatoMode() {
+	gs.PotatoMode = true
+	gs.MotionSmoothing = false
+	gs.BlendMobiles = false
+	gs.BlendPicts = false
+	gs.DenoiseImages = false
+	gs.ShowFPS = false
+	gs.vsync = false
+	gs.precacheSounds = false
+	gs.precacheImages = false
+	gs.textureFiltering = false
+	gs.lateInputUpdates = false
+	gs.cacheWholeSheet = false
+	gs.smoothMoving = false
+	gs.fastBars = false
+	gs.bubbleMessages = false
+	gs.SpeechBubbles = true
+	gs.nightEffect = true
+	applySettings()
 }
 
 func saveSettings() {

--- a/ui.go
+++ b/ui.go
@@ -859,6 +859,23 @@ func makeSettingsWindow() {
 	}
 	mainFlow.AddItem(fullscreenCB)
 
+	potatoCB, potatoEvents := eui.NewCheckbox()
+	potatoCB.Text = "Potato Computer (requires relaunch)"
+	potatoCB.Size = eui.Point{X: width, Y: 24}
+	potatoCB.Checked = gs.PotatoMode
+	potatoEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			if ev.Checked {
+				enablePotatoMode()
+			} else {
+				gs.PotatoMode = false
+				applySettings()
+			}
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(potatoCB)
+
 	qualityBtn, qualityEvents := eui.NewButton()
 	qualityBtn.Text = "Quality Options"
 	qualityBtn.Size = eui.Point{X: width, Y: 24}
@@ -1129,7 +1146,7 @@ func makeQualityWindow() {
 	vsyncEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.vsync = ev.Checked
-			ebiten.SetVsyncEnabled(gs.vsync)
+			applySettings()
 			settingsDirty = true
 		}
 	}


### PR DESCRIPTION
## Summary
- add "Potato Computer" setting to disable expensive rendering features and sync FPS to game updates
- honor potato mode during startup and expose toggle in settings UI

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899a32a2c34832a941929f39cdd3ac0