### PR TITLE
Add quality preset dropdown

### DIFF
--- a/game.go
+++ b/game.go
@@ -325,6 +325,9 @@ func (g *Game) Update() error {
 	if syncWindowSettings() {
 		settingsDirty = true
 	}
+	if settingsDirty && qualityPresetDD != nil {
+		qualityPresetDD.Selected = detectQualityPreset()
+	}
 	if time.Since(lastSettingsSave) >= 5*time.Second {
 		if settingsDirty {
 			saveSettings()

--- a/settings.go
+++ b/settings.go
@@ -276,3 +276,118 @@ func clampWindowState(st *WindowState, sx, sy float64) {
 		st.Position.Y = maxY
 	}
 }
+
+type qualityPreset struct {
+	DenoiseImages    bool
+	MotionSmoothing  bool
+	BlendMobiles     bool
+	BlendPicts       bool
+	textureFiltering bool
+	fastSound        bool
+	precacheSounds   bool
+	precacheImages   bool
+}
+
+var (
+	lowPreset = qualityPreset{
+		DenoiseImages:    false,
+		MotionSmoothing:  false,
+		BlendMobiles:     false,
+		BlendPicts:       false,
+		textureFiltering: false,
+		fastSound:        true,
+		precacheSounds:   false,
+		precacheImages:   false,
+	}
+	standardPreset = qualityPreset{
+		DenoiseImages:    true,
+		MotionSmoothing:  true,
+		BlendMobiles:     false,
+		BlendPicts:       true,
+		textureFiltering: false,
+		fastSound:        true,
+		precacheSounds:   false,
+		precacheImages:   false,
+	}
+	highPreset = qualityPreset{
+		DenoiseImages:    true,
+		MotionSmoothing:  true,
+		BlendMobiles:     true,
+		BlendPicts:       true,
+		textureFiltering: true,
+		fastSound:        false,
+		precacheSounds:   false,
+		precacheImages:   false,
+	}
+	ultimatePreset = qualityPreset{
+		DenoiseImages:    true,
+		MotionSmoothing:  true,
+		BlendMobiles:     true,
+		BlendPicts:       true,
+		textureFiltering: true,
+		fastSound:        false,
+		precacheSounds:   true,
+		precacheImages:   true,
+	}
+)
+
+func applyQualityPreset(name string) {
+	var p qualityPreset
+	switch name {
+	case "Low":
+		p = lowPreset
+	case "Standard":
+		p = standardPreset
+	case "High":
+		p = highPreset
+	case "Ultimate":
+		p = ultimatePreset
+	default:
+		return
+	}
+
+	gs.DenoiseImages = p.DenoiseImages
+	gs.MotionSmoothing = p.MotionSmoothing
+	gs.BlendMobiles = p.BlendMobiles
+	gs.BlendPicts = p.BlendPicts
+	gs.textureFiltering = p.textureFiltering
+	gs.fastSound = p.fastSound
+	gs.precacheSounds = p.precacheSounds
+	gs.precacheImages = p.precacheImages
+
+	applySettings()
+	if gs.fastSound {
+		resample = resampleLinear
+	} else {
+		initSinc()
+		resample = resampleSincHQ
+	}
+	clearCaches()
+	settingsDirty = true
+}
+
+func matchesPreset(p qualityPreset) bool {
+	return gs.DenoiseImages == p.DenoiseImages &&
+		gs.MotionSmoothing == p.MotionSmoothing &&
+		gs.BlendMobiles == p.BlendMobiles &&
+		gs.BlendPicts == p.BlendPicts &&
+		gs.textureFiltering == p.textureFiltering &&
+		gs.fastSound == p.fastSound &&
+		gs.precacheSounds == p.precacheSounds &&
+		gs.precacheImages == p.precacheImages
+}
+
+func detectQualityPreset() int {
+	switch {
+	case matchesPreset(lowPreset):
+		return 0
+	case matchesPreset(standardPreset):
+		return 1
+	case matchesPreset(highPreset):
+		return 2
+	case matchesPreset(ultimatePreset):
+		return 3
+	default:
+		return 4
+	}
+}

--- a/ui.go
+++ b/ui.go
@@ -49,10 +49,11 @@ var (
 	pictBlendLabel   *eui.ItemData
 	totalCacheLabel  *eui.ItemData
 
-	soundTestLabel *eui.ItemData
-	soundTestID    int
-	recordBtn      *eui.ItemData
-	recordStatus   *eui.ItemData
+	soundTestLabel  *eui.ItemData
+	soundTestID     int
+	recordBtn       *eui.ItemData
+	recordStatus    *eui.ItemData
+	qualityPresetDD *eui.ItemData
 )
 
 func initUI() {
@@ -858,6 +859,27 @@ func makeSettingsWindow() {
 		}
 	}
 	mainFlow.AddItem(fullscreenCB)
+
+	qualityPresetDD, qpEvents := eui.NewDropdown()
+	qualityPresetDD.Options = []string{"Low", "Standard", "High", "Ultimate", "Custom"}
+	qualityPresetDD.Size = eui.Point{X: width, Y: 24}
+	qualityPresetDD.Selected = detectQualityPreset()
+	qpEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventDropdownSelected {
+			switch ev.Index {
+			case 0:
+				applyQualityPreset("Low")
+			case 1:
+				applyQualityPreset("Standard")
+			case 2:
+				applyQualityPreset("High")
+			case 3:
+				applyQualityPreset("Ultimate")
+			}
+			qualityPresetDD.Selected = detectQualityPreset()
+		}
+	}
+	mainFlow.AddItem(qualityPresetDD)
 
 	qualityBtn, qualityEvents := eui.NewButton()
 	qualityBtn.Text = "Quality Options"


### PR DESCRIPTION
## Summary
- Add quality preset dropdown to settings menu
- Implement preset application and detection for Low, Standard, High and Ultimate options
- Sync preset selection when settings change

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899a8d4a6c4832a8ab4dd752c920c2e