### PR TITLE
Normalize UI corner constants

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -20,14 +20,12 @@ import (
 	"go_client/clsnd"
 )
 
-const cval = 8000
-
 var (
-	TOP_RIGHT = eui.Point{X: cval, Y: 0}
+	TOP_RIGHT = eui.Point{X: 1, Y: 0}
 	TOP_LEFT  = eui.Point{X: 0, Y: 0}
 
-	BOTTOM_LEFT  = eui.Point{X: 0, Y: cval}
-	BOTTOM_RIGHT = eui.Point{X: cval, Y: cval}
+	BOTTOM_LEFT  = eui.Point{X: 0, Y: 1}
+	BOTTOM_RIGHT = eui.Point{X: 1, Y: 1}
 )
 
 var loginWin *eui.WindowData


### PR DESCRIPTION
## Summary
- use normalized eui.Point values for TOP_RIGHT, TOP_LEFT, BOTTOM_LEFT, and BOTTOM_RIGHT
- remove obsolete cval constant

## Testing
- `go fmt ui.go`
- `go vet .`


------
https://chatgpt.com/codex/tasks/task_e_689a6403cb4c832aa9cb2c7e27233393