### PR TITLE
Normalize window geometry

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -47,8 +47,9 @@ func makeChatWindow() {
 	}
 	chatWin = eui.NewWindow()
 	chatWin.Title = "Chat"
+	sx, sy := eui.ScreenSize()
 	if gs.ChatWindow.Size.X > 0 && gs.ChatWindow.Size.Y > 0 {
-		chatWin.Size = eui.Point{X: float32(gs.ChatWindow.Size.X), Y: float32(gs.ChatWindow.Size.Y)}
+		chatWin.Size = eui.Point{X: float32(gs.ChatWindow.Size.X) * float32(sx), Y: float32(gs.ChatWindow.Size.Y) * float32(sy)}
 	} else {
 		chatWin.Size = eui.Point{X: 425, Y: 350}
 	}
@@ -57,7 +58,7 @@ func makeChatWindow() {
 	chatWin.Movable = true
 	chatWin.Position = BOTTOM_RIGHT
 	if gs.ChatWindow.Position.X != 0 || gs.ChatWindow.Position.Y != 0 {
-		chatWin.Position = eui.Point{X: float32(gs.ChatWindow.Position.X), Y: float32(gs.ChatWindow.Position.Y)}
+		chatWin.Position = eui.Point{X: float32(gs.ChatWindow.Position.X) * float32(sx), Y: float32(gs.ChatWindow.Position.Y) * float32(sy)}
 	}
 
 	chatList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}

--- a/console_ui.go
+++ b/console_ui.go
@@ -64,8 +64,9 @@ func makeConsoleWindow() {
 		return
 	}
 	messagesWin = eui.NewWindow()
+	sx, sy := eui.ScreenSize()
 	if gs.MessagesWindow.Size.X > 0 && gs.MessagesWindow.Size.Y > 0 {
-		messagesWin.Size = eui.Point{X: float32(gs.MessagesWindow.Size.X), Y: float32(gs.MessagesWindow.Size.Y)}
+		messagesWin.Size = eui.Point{X: float32(gs.MessagesWindow.Size.X) * float32(sx), Y: float32(gs.MessagesWindow.Size.Y) * float32(sy)}
 	} else {
 		messagesWin.Size = eui.Point{X: 425, Y: 350}
 	}
@@ -75,7 +76,7 @@ func makeConsoleWindow() {
 	messagesWin.Movable = true
 	messagesWin.Position = BOTTOM_LEFT
 	if gs.MessagesWindow.Position.X != 0 || gs.MessagesWindow.Position.Y != 0 {
-		messagesWin.Position = eui.Point{X: float32(gs.MessagesWindow.Position.X), Y: float32(gs.MessagesWindow.Position.Y)}
+		messagesWin.Position = eui.Point{X: float32(gs.MessagesWindow.Position.X) * float32(sx), Y: float32(gs.MessagesWindow.Position.Y) * float32(sy)}
 	}
 
 	messagesList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}

--- a/game.go
+++ b/game.go
@@ -1153,14 +1153,14 @@ func initGame() {
 }
 
 func makeGameWindow() {
-	ssx, _ := eui.ScreenSize()
+	ssx, ssy := eui.ScreenSize()
 
 	gameWin = eui.NewWindow()
 	gameWin.Title = ""
 
 	if gs.AnyGameWindowSize {
 		if gs.GameWindow.Size.X > 0 && gs.GameWindow.Size.Y > 0 {
-			gameWin.Size = eui.Point{X: float32(gs.GameWindow.Size.X) * eui.UIScale(), Y: float32(gs.GameWindow.Size.Y) * eui.UIScale()}
+			gameWin.Size = eui.Point{X: float32(gs.GameWindow.Size.X) * float32(ssx), Y: float32(gs.GameWindow.Size.Y) * float32(ssy)}
 		} else {
 			gameWin.Size = eui.Point{X: float32(gameAreaSizeX) * float32(gs.GameScale), Y: float32(gameAreaSizeY) * float32(gs.GameScale)}
 		}
@@ -1174,9 +1174,9 @@ func makeGameWindow() {
 	}
 
 	if gs.GameWindow.Position.X != 0 || gs.GameWindow.Position.Y != 0 {
-		gameWin.Position = eui.Point{X: float32(gs.GameWindow.Position.X), Y: float32(gs.GameWindow.Position.Y)}
+		gameWin.Position = eui.Point{X: float32(gs.GameWindow.Position.X) * float32(ssx), Y: float32(gs.GameWindow.Position.Y) * float32(ssy)}
 	} else {
-		gameWin.Position = eui.Point{X: float32(ssx/2) - gameWin.Size.X/2, Y: 50}
+		gameWin.Position = eui.Point{X: float32(ssx)/2 - gameWin.Size.X/2, Y: 50}
 	}
 
 	gameWin.Closable = false

--- a/settings.go
+++ b/settings.go
@@ -126,15 +126,21 @@ var (
 	lastSettingsSave = time.Now()
 )
 
+// WindowPoint represents a normalized point on the screen where 0 and 1
+// correspond to the minimum and maximum screen extents respectively.
 type WindowPoint struct {
 	X float64
 	Y float64
 }
 
+// WindowState stores window visibility and geometry using normalized values in
+// the range [0,1].
 type WindowState struct {
-	Open     bool
+	Open bool
+	// Position holds the normalized top-left corner of the window.
 	Position WindowPoint
-	Size     WindowPoint
+	// Size represents the normalized width and height of the window.
+	Size WindowPoint
 }
 
 const settingsFile = "settings.json"
@@ -230,12 +236,13 @@ func syncWindow(win *eui.WindowData, state *WindowState) bool {
 		state.Open = win.IsOpen()
 		changed = true
 	}
-	pos := WindowPoint{X: float64(win.Position.X), Y: float64(win.Position.Y)}
+	sx, sy := eui.ScreenSize()
+	pos := WindowPoint{X: float64(win.Position.X) / float64(sx), Y: float64(win.Position.Y) / float64(sy)}
 	if state.Position != pos {
 		state.Position = pos
 		changed = true
 	}
-	size := WindowPoint{X: float64(win.Size.X), Y: float64(win.Size.Y)}
+	size := WindowPoint{X: float64(win.Size.X) / float64(sx), Y: float64(win.Size.Y) / float64(sy)}
 	if state.Size != size {
 		state.Size = size
 		changed = true
@@ -244,36 +251,27 @@ func syncWindow(win *eui.WindowData, state *WindowState) bool {
 }
 
 func clampWindowSettings() {
-	sx, sy := eui.ScreenSize()
 	states := []*WindowState{&gs.GameWindow, &gs.InventoryWindow, &gs.PlayersWindow, &gs.MessagesWindow, &gs.ChatWindow}
 	for _, st := range states {
-		clampWindowState(st, float64(sx), float64(sy))
+		clampWindowState(st)
 	}
 }
 
-func clampWindowState(st *WindowState, sx, sy float64) {
-	if st.Size.X < 100 || st.Size.Y < 100 {
+func clampWindowState(st *WindowState) {
+	if st.Size.X <= 0 || st.Size.X > 1 || st.Size.Y <= 0 || st.Size.Y > 1 {
 		st.Position = WindowPoint{}
 		st.Size = WindowPoint{}
 		return
 	}
-	if st.Size.X > sx {
-		st.Size.X = sx
-	}
-	if st.Size.Y > sy {
-		st.Size.Y = sy
-	}
-	maxX := sx - st.Size.X
-	maxY := sy - st.Size.Y
 	if st.Position.X < 0 {
 		st.Position.X = 0
-	} else if st.Position.X > maxX {
-		st.Position.X = maxX
+	} else if st.Position.X > 1 {
+		st.Position.X = 1
 	}
 	if st.Position.Y < 0 {
 		st.Position.Y = 0
-	} else if st.Position.Y > maxY {
-		st.Position.Y = maxY
+	} else if st.Position.Y > 1 {
+		st.Position.Y = 1
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -1566,11 +1566,12 @@ func makeInventoryWindow() {
 	inventoryWin.Movable = true
 	inventoryWin.Size = eui.Point{X: 425, Y: 600}
 
+	sx, sy := eui.ScreenSize()
 	if gs.InventoryWindow.Size.X > 0 && gs.InventoryWindow.Size.Y > 0 {
-		inventoryWin.Size = eui.Point{X: float32(gs.InventoryWindow.Size.X), Y: float32(gs.InventoryWindow.Size.Y)}
+		inventoryWin.Size = eui.Point{X: float32(gs.InventoryWindow.Size.X) * float32(sx), Y: float32(gs.InventoryWindow.Size.Y) * float32(sy)}
 	}
 	if gs.InventoryWindow.Position.X != 0 || gs.InventoryWindow.Position.Y != 0 {
-		inventoryWin.Position = eui.Point{X: float32(gs.InventoryWindow.Position.X), Y: float32(gs.InventoryWindow.Position.Y)}
+		inventoryWin.Position = eui.Point{X: float32(gs.InventoryWindow.Position.X) * float32(sx), Y: float32(gs.InventoryWindow.Position.Y) * float32(sy)}
 	} else {
 		inventoryWin.Position = eui.Point{X: 0, Y: 0}
 	}
@@ -1590,8 +1591,9 @@ func makePlayersWindow() {
 	}
 	playersWin = eui.NewWindow()
 	playersWin.Title = "Players"
+	sx, sy := eui.ScreenSize()
 	if gs.PlayersWindow.Size.X > 0 && gs.PlayersWindow.Size.Y > 0 {
-		playersWin.Size = eui.Point{X: float32(gs.PlayersWindow.Size.X), Y: float32(gs.PlayersWindow.Size.Y)}
+		playersWin.Size = eui.Point{X: float32(gs.PlayersWindow.Size.X) * float32(sx), Y: float32(gs.PlayersWindow.Size.Y) * float32(sy)}
 	} else {
 		playersWin.Size = eui.Point{X: 425, Y: 600}
 	}
@@ -1600,7 +1602,7 @@ func makePlayersWindow() {
 	playersWin.Movable = true
 	playersWin.Position = TOP_RIGHT
 	if gs.PlayersWindow.Position.X != 0 || gs.PlayersWindow.Position.Y != 0 {
-		playersWin.Position = eui.Point{X: float32(gs.PlayersWindow.Position.X), Y: float32(gs.PlayersWindow.Position.Y)}
+		playersWin.Position = eui.Point{X: float32(gs.PlayersWindow.Position.X) * float32(sx), Y: float32(gs.PlayersWindow.Position.Y) * float32(sy)}
 	}
 
 	playersList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}


### PR DESCRIPTION
## Summary
- document WindowState positions and sizes as normalized 0-1 values
- store window geometry normalized to screen size and clamp within [0,1]
- scale normalized settings when constructing windows

## Testing
- `go fmt settings.go chat_messages_ui.go console_ui.go ui.go game.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a640f47d4832aa3ff6e0096928817