### PR TITLE
Normalize UI hit test coordinates

### DIFF
--- a/input_ui_test.go
+++ b/input_ui_test.go
@@ -6,6 +6,18 @@ import (
 	"github.com/Distortions81/EUI/eui"
 )
 
+// screenToNormal converts screen pixel coordinates to normalized EUI coordinates.
+func screenToNormal(x, y int) eui.Point {
+	w, h := eui.ScreenSize()
+	return eui.Point{X: float32(x) / float32(w), Y: float32(y) / float32(h)}
+}
+
+// normalToScreen converts normalized EUI coordinates back to screen pixels.
+func normalToScreen(p eui.Point) (int, int) {
+	w, h := eui.ScreenSize()
+	return int(p.X * float32(w)), int(p.Y * float32(h))
+}
+
 // TestPointInUISkipsMainPortal ensures that the base game window does not block
 // interaction with other UI windows.
 func TestPointInUISkipsMainPortal(t *testing.T) {
@@ -16,23 +28,25 @@ func TestPointInUISkipsMainPortal(t *testing.T) {
 
 	// Main portal window covering 100x100 at origin.
 	mainWin := eui.NewWindow()
-	mainWin.Size = eui.Point{X: 100, Y: 100}
+	mainWin.Size = screenToNormal(100, 100)
 	mainWin.MainPortal = true
 	mainWin.AddWindow(false)
 	mainWin.Open()
 
 	// With only the main portal, the point should not be considered over UI.
-	if pointInUI(10, 10) {
+	pt := screenToNormal(10, 10)
+	px, py := normalToScreen(pt)
+	if pointInUI(px, py) {
 		t.Fatalf("pointInUI should ignore MainPortal window")
 	}
 
 	// Add a regular window at the same position.
 	frontWin := eui.NewWindow()
-	frontWin.Size = eui.Point{X: 20, Y: 20}
+	frontWin.Size = screenToNormal(20, 20)
 	frontWin.AddWindow(false)
 	frontWin.Open()
 
-	if !pointInUI(10, 10) {
+	if !pointInUI(px, py) {
 		t.Fatalf("pointInUI should detect top window")
 	}
 
@@ -49,7 +63,7 @@ func TestPointInUICoversTitleBar(t *testing.T) {
 	}
 
 	win := eui.NewWindow()
-	win.Size = eui.Point{X: 50, Y: 50}
+	win.Size = screenToNormal(50, 50)
 	win.AddWindow(false)
 	win.Open()
 
@@ -58,8 +72,11 @@ func TestPointInUICoversTitleBar(t *testing.T) {
 	s := eui.UIScale()
 	frame := (win.Margin + win.Border + win.BorderPad + win.Padding) * s
 	title := win.GetTitleSize()
-	x := int(pos.X + frame + 1)
-	y := int(pos.Y + size.Y + frame*2 + title/2)
+	w, h := eui.ScreenSize()
+	offset := screenToNormal(1, 0).X
+	xNorm := (pos.X+frame)/float32(w) + offset
+	yNorm := (pos.Y + size.Y + frame*2 + title/2) / float32(h)
+	x, y := normalToScreen(eui.Point{X: xNorm, Y: yNorm})
 	if !pointInUI(x, y) {
 		t.Fatalf("pointInUI should include title bar region")
 	}


### PR DESCRIPTION
## Summary
- replace pixel literals in `input_ui_test.go` with normalized conversions
- add helpers to convert between screen pixels and normalized coordinates

## Testing
- `go vet`


------
https://chatgpt.com/codex/tasks/task_e_689a64133cc8832aac298b1df73920fe