### PR TITLE
docs: tidy and expand project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,67 +1,42 @@
 # AGENTS
 
-This repo includes a minimal Go client under `go_client/`. To build or run the Go program you need Go version 1.24 or later.
-Do not compile/test unless explicitly instructed to do so. go vet, go fmt is sufficient. 
+This repository contains the Go-based ThoomSpeak client for the Clan Lord MMORPG.
 
+Do not compile or run tests unless explicitly instructed. After modifying Go code, run:
+
+```bash
+go fmt ./...
+go vet ./...
+```
 
 ## Installing dependencies
 
-1. Install Go 1.24 or later. On Debian/Ubuntu you can run:
-   ```bash
-   sudo apt-get update
-   sudo apt-get install -y golang-go build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev
-   ```
-   `libgl1-mesa-dev`, `libglu1-mesa-dev`, and `xorg-dev` provide the OpenGL and X11 libraries required by Ebiten.
-   On other distributions install the equivalent development packages.
-2. Fetch Go module dependencies:
-   ```bash
-   cd go_client
-   go mod download
-   ```
-
-For convenience the `scripts` directory contains small helper scripts:
-`scripts/build_go_client.sh` fetches dependencies, formats the sources and
-compiles the client. `scripts/run_go_client.sh` launches the program.
-
-Both scripts expect to be executed from the repository root.
-
-## Build steps
-1. Navigate to the `go_client` directory if not already there:
-   ```bash
-   cd go_client
-   ```
-2. Compile the program:
-   ```bash
-   go build
-   ```
-   This produces the executable `go_client` in the current directory.
-   You can also run `../scripts/build_go_client.sh` from the repo root which
-   runs `go mod download` and `go build ./...` in one step.
-3. You can also run the program directly with:
-   ```bash
-   go run .
-   ```
-   Alternatively run `../scripts/run_go_client.sh` from the repo root.
-
-The module path is `go_client` and the main package is located in this directory.
-
-The `mac_client` directory contains a reference implementation written in C and should *never* be modified. It is only for reference!
-
-## Session notes
-The following dependencies were installed when building the Go client
-in this session:
+Install Go 1.24 or later. On Debian/Ubuntu you can run:
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y golang-go build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev
 ```
 
-Example build and run commands used:
+`libgl1-mesa-dev`, `libglu1-mesa-dev`, and `xorg-dev` provide the OpenGL and X11 libraries required by Ebiten. On other distributions install the equivalent development packages.
+
+## Build and run
+
+To build the client from the repository root:
 
 ```bash
-go build ./...
+go build
+```
+
+To run directly:
+
+```bash
 go run .
 ```
 
-Running the client without a display (i.e. no `$DISPLAY` variable) will exit
-with an X11 initialization error.
+The `scripts` directory contains helper scripts such as `scripts/build_binaries.sh` for building release binaries.
+
+The `old_mac_client/` directory contains a historical C implementation for reference only and should not be modified.
+
+Running the client without a display (i.e. no `$DISPLAY` variable) will exit with an X11 initialization error.
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ClanLord Client
+# ThoomSpeak
 
-A pre-alpha open source (MIT) client for the Clan Lord MMORPG.
+ThoomSpeak is a pre-alpha, MIT-licensed Go client for the Clan Lord MMORPG.
 
-This repository hosts the Go implementation of the client. The
-`old_mac_client/` directory contains a historical C implementation provided
-for reference only (do not modify).
+This repository hosts the Go implementation of the client. The `old_mac_client/`
+directory contains a historical C implementation provided for reference only
+and should not be modified.
 
 ## Quick Start
 
@@ -61,6 +61,7 @@ The Go client accepts the following flags:
 ## Data and Logging
 
 - The default server is `server.deltatao.com:5010`; override it with `-host`.
-- Missing `CL_Images` or `CL_Sounds` archives in `data` are fetched automatically from `https://www.deltatao.com/downloads/clanlord`.
-  They are saved as `CL_Images` and `CL_Sounds`.
+- Missing `CL_Images` or `CL_Sounds` archives in `data` are fetched automatically from
+  `https://www.deltatao.com/downloads/clanlord`. They are saved as `CL_Images` and
+  `CL_Sounds`.
 


### PR DESCRIPTION
## Summary
- clarify AGENTS instructions for building and running the Go client
- refresh README with project name and streamlined setup guidance

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: github.com/Distortions81/EUI replacement directory ../EUI/ does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689a7595555c832aa784f8a687c176f8