### PR TITLE
Handle BEPP tags without dropping MacRoman characters

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -125,8 +125,7 @@ func decodeBEPP(data []byte) string {
 func stripBEPPTags(b []byte) []byte {
 	out := b[:0]
 	for i := 0; i < len(b); {
-		c := b[i]
-		if c == 0xC2 {
+		if b[i] == 0xC2 {
 			if i+4 < len(b) && b[i+1] == 't' && b[i+2] == '_' && b[i+3] == 't' {
 				switch b[i+4] {
 				case 'h', 't', 'c', 'g':
@@ -134,17 +133,12 @@ func stripBEPPTags(b []byte) []byte {
 					continue
 				}
 			}
-			if i+2 < len(b) {
-				i += 3
+			if i+3 < len(b) && b[i+3] == ' ' && b[i+1] >= 'a' && b[i+1] <= 'z' && b[i+2] >= 'a' && b[i+2] <= 'z' {
+				i += 4
 				continue
 			}
-			break
 		}
-		if c >= 0x80 || c < 0x20 {
-			i++
-			continue
-		}
-		out = append(out, c)
+		out = append(out, b[i])
 		i++
 	}
 	return out

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStripBEPPTags(t *testing.T) {
+	in := []byte{'h', 'i', ' ', 0xC2, 'b', 'e', ' ', 'w', 'o', 'r', 'l', 'd'}
+	got := stripBEPPTags(in)
+	want := []byte("hi world")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestStripBEPPTagsHighBit(t *testing.T) {
+	in := []byte{'h', 0x8E, 0xC2, 't', '_', 't', 'g', 0x8F}
+	got := stripBEPPTags(in)
+	want := []byte{'h', 0x8E, 0x8F}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- Parse BEPP markers using Mac client logic instead of blanket high-bit removal
- Keep valid high-bit MacRoman bytes and strip only recognized BEPP tags
- Add tests to ensure BEPP tags are removed while high-bit characters remain

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: Xrandr.h, ALSA, and GTK+ headers not found)*
- `go test ./...` *(fails: Xrandr.h, ALSA, and GTK+ headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a8fd15964832abfb885156175bcf5