### PR TITLE
Normalize game window size and position calculations

### DIFF
--- a/game.go
+++ b/game.go
@@ -1154,18 +1154,14 @@ func initGame() {
 }
 
 func makeGameWindow() {
-	ssx, ssy := eui.ScreenSize()
+	ssx, _ := eui.ScreenSize()
 
 	gameWin = eui.NewWindow()
 	gameWin.Title = ""
 
 	var size eui.Point
-	if gs.AnyGameWindowSize {
-		if gs.GameWindow.Size.X > 0 && gs.GameWindow.Size.Y > 0 {
-			gameWin.Size = eui.Point{X: float32(gs.GameWindow.Size.X) * float32(ssx), Y: float32(gs.GameWindow.Size.Y) * float32(ssy)}
-		} else {
-			size = eui.Point{X: float32(gameAreaSizeX) * float32(gs.GameScale), Y: float32(gameAreaSizeY) * float32(gs.GameScale)}
-		}
+	if gs.AnyGameWindowSize && gs.GameWindow.Size.X > 0 && gs.GameWindow.Size.Y > 0 {
+		size = eui.NormToScreen(eui.Point{X: float32(gs.GameWindow.Size.X), Y: float32(gs.GameWindow.Size.Y)})
 	} else {
 		if gs.GameScale < 1 {
 			gs.GameScale = 1
@@ -1177,9 +1173,10 @@ func makeGameWindow() {
 	gameWin.Size = eui.ScreenToNorm(size)
 
 	if gs.GameWindow.Position.X != 0 || gs.GameWindow.Position.Y != 0 {
-		gameWin.Position = eui.Point{X: float32(gs.GameWindow.Position.X) * float32(ssx), Y: float32(gs.GameWindow.Position.Y) * float32(ssy)}
+		gameWin.Position = eui.Point{X: float32(gs.GameWindow.Position.X), Y: float32(gs.GameWindow.Position.Y)}
 	} else {
-		gameWin.Position = eui.Point{X: float32(ssx)/2 - gameWin.Size.X/2, Y: 50}
+		pos := eui.Point{X: float32(ssx)/2 - size.X/2, Y: 50}
+		gameWin.Position = eui.ScreenToNorm(pos)
 	}
 
 	gameWin.Closable = false


### PR DESCRIPTION
## Summary
- Remove screen size scaling when restoring game window size and position
- Compute default window geometry in pixels then convert to normalized units
- Center game window when no saved position is available

## Testing
- `go fmt ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a90505518832a99daf110f627c424