### PR TITLE
Handle BEPP think markers

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -151,6 +151,21 @@ func stripBEPPTags(b []byte) []byte {
 }
 
 func parseThinkText(raw []byte, text string) (name string, target thinkTarget, msg string) {
+	colon := bytes.IndexByte(raw, ':')
+	for i := 0; i < len(raw) && (colon < 0 || i < colon); i++ {
+		if raw[i] == 0xC2 && i+4 < len(raw) && raw[i+1] == 't' && raw[i+2] == '_' && raw[i+3] == 't' {
+			switch raw[i+4] {
+			case 't':
+				target = thinkToYou
+			case 'c':
+				target = thinkToClan
+			case 'g':
+				target = thinkToGroup
+			}
+			break
+		}
+	}
+
 	idx := strings.IndexByte(text, ':')
 	if idx >= 0 {
 		name = strings.TrimSpace(text[:idx])
@@ -160,31 +175,29 @@ func parseThinkText(raw []byte, text string) (name string, target thinkTarget, m
 		msg = strings.TrimSpace(text)
 	}
 
-	if i := bytes.Index(raw, []byte{0xC2, 't', '_', 't'}); i >= 0 && i+4 < len(raw) {
-		switch raw[i+4] {
-		case 't':
-			target = thinkToYou
-		case 'c':
-			target = thinkToClan
-		case 'g':
-			target = thinkToGroup
+	switch target {
+	case thinkToYou:
+		name = strings.TrimSuffix(name, " to you")
+	case thinkToClan:
+		name = strings.TrimSuffix(name, " to your clan")
+	case thinkToGroup:
+		name = strings.TrimSuffix(name, " to a group")
+	default:
+		if name != "" && name != ThinkUnknownName {
+			switch {
+			case strings.HasSuffix(name, " to you"):
+				target = thinkToYou
+				name = strings.TrimSuffix(name, " to you")
+			case strings.HasSuffix(name, " to your clan"):
+				target = thinkToClan
+				name = strings.TrimSuffix(name, " to your clan")
+			case strings.HasSuffix(name, " to a group"):
+				target = thinkToGroup
+				name = strings.TrimSuffix(name, " to a group")
+			}
 		}
 	}
-
-	if target == thinkNone && name != "" && name != ThinkUnknownName {
-		switch {
-		case strings.HasSuffix(name, " to you"):
-			target = thinkToYou
-			name = strings.TrimSuffix(name, " to you")
-		case strings.HasSuffix(name, " to your clan"):
-			target = thinkToClan
-			name = strings.TrimSuffix(name, " to your clan")
-		case strings.HasSuffix(name, " to a group"):
-			target = thinkToGroup
-			name = strings.TrimSuffix(name, " to a group")
-		}
-		name = strings.TrimSpace(name)
-	}
+	name = strings.TrimSpace(name)
 	return
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseThinkTextTargets(t *testing.T) {
+	cases := []struct {
+		raw    string
+		target thinkTarget
+	}{
+		{"Torx\xC2t_th: hello", thinkNone},
+		{"Torx\xC2t_tt to you: hello", thinkToYou},
+		{"Torx\xC2t_tc to your clan: hello", thinkToClan},
+		{"Torx\xC2t_tg to a group: hello", thinkToGroup},
+	}
+	for _, tc := range cases {
+		raw := []byte(tc.raw)
+		text := strings.TrimSpace(decodeMacRoman(stripBEPPTags(raw)))
+		name, target, msg := parseThinkText(raw, text)
+		if name != "Torx" {
+			t.Errorf("name = %q, want Torx", name)
+		}
+		if msg != "hello" {
+			t.Errorf("msg = %q, want hello", msg)
+		}
+		if target != tc.target {
+			t.Errorf("target = %v, want %v", target, tc.target)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Detect BEPP think markers before the colon and assign the correct think target
- Strip think target phrases from the speaker name
- Cover think target parsing for none, you, clan, and group in tests

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: github.com/Distortions81/EUI@v0.0.31: replacement directory ../EUI/ does not exist)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a8fddd1b0832a8f1dd21acf5a8723