### PR TITLE
Handle BEPP prefixes and tests

### DIFF
--- a/console_ui_stub_test.go
+++ b/console_ui_stub_test.go
@@ -1,0 +1,5 @@
+//go:build test
+
+package main
+
+func updateMessagesWindow() {}

--- a/decode.go
+++ b/decode.go
@@ -112,9 +112,103 @@ func decodeBEPP(data []byte) string {
 		if text != "" {
 			return "share: " + text
 		}
+	case "hp":
+		if text != "" {
+			return "help: " + text
+		}
+	case "er":
+		if text != "" {
+			return "error: " + text
+		}
+	case "gm":
+		if text != "" {
+			return "gm: " + text
+		}
+	case "lg":
+		if text != "" {
+			return "logon: " + text
+		}
+	case "lf":
+		if text != "" {
+			return "logoff: " + text
+		}
+	case "dp":
+		if text != "" {
+			return "depart: " + text
+		}
+	case "ka":
+		if text != "" {
+			return "karma: " + text
+		}
+	case "kr":
+		if text != "" {
+			return "karma received: " + text
+		}
+	case "wh":
+		if text != "" {
+			return "who: " + text
+		}
+	case "hf":
+		if text != "" {
+			return "fallen: " + text
+		}
+	case "nf":
+		if text != "" {
+			return "no longer fallen: " + text
+		}
+	case "lo":
+		if text != "" {
+			return "location: " + text
+		}
+	case "de":
+		if text != "" {
+			return "demo: " + text
+		}
+	case "iv":
+		if text != "" {
+			return "inventory: " + text
+		}
+	case "nw":
+		if text != "" {
+			return "news: " + text
+		}
+	case "ba":
+		if text != "" {
+			return "bard: " + text
+		}
+	case "su":
+		if text != "" {
+			return "unshare: " + text
+		}
+	case "cn", "pn", "mn", "tt", "ml":
+		if text != "" {
+			return text
+		}
+	case "yk":
+		if text != "" {
+			return text
+		}
+	case "mu":
+		if text != "" {
+			consoleMessage("music: " + text)
+		}
+	case "dl":
+		if text != "" {
+			consoleMessage("download: " + text)
+		}
+	case "cf":
+		if text != "" {
+			consoleMessage("config: " + text)
+		}
+	case "tl":
+		if text != "" {
+			consoleMessage(text)
+		}
 	case "be":
 		parseBackend(textBytes)
-	case "yk":
+	case "dd":
+		// suppress
+	default:
 		if text != "" {
 			return text
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+func resetConsole() {
+	messageMu.Lock()
+	messages = nil
+	messageMu.Unlock()
+}
+
+func makeBEPP(prefix, text string) []byte {
+	b := []byte{0xC2, prefix[0], prefix[1]}
+	b = append(b, []byte(text)...)
+	return b
+}
+
+func TestDecodeBEPPPrefixes(t *testing.T) {
+	cases := []struct {
+		prefix string
+		text   string
+		want   string
+		log    string
+	}{
+		{"ba", "bard", "bard: bard", ""},
+		{"be", "payload", "", ""},
+		{"cn", "clan", "clan", ""},
+		{"cf", "cfg", "", "config: cfg"},
+		{"dd", "hidden", "", ""},
+		{"de", "demo", "demo: demo", ""},
+		{"dp", "depart", "depart: depart", ""},
+		{"dl", "file", "", "download: file"},
+		{"er", "oops", "error: oops", ""},
+		{"gm", "msg", "gm: msg", ""},
+		{"hf", "fallen text", "fallen: fallen text", ""},
+		{"nf", "recover", "no longer fallen: recover", ""},
+		{"hp", "help me", "help: help me", ""},
+		{"in", "info", "info: info", ""},
+		{"iv", "inventory item", "inventory: inventory item", ""},
+		{"ka", "karma", "karma: karma", ""},
+		{"kr", "krec", "karma received: krec", ""},
+		{"lf", "bye", "logoff: bye", ""},
+		{"lg", "hi", "logon: hi", ""},
+		{"lo", "here", "location: here", ""},
+		{"mn", "monster", "monster", ""},
+		{"ml", "multi", "multi", ""},
+		{"mu", "song", "", "music: song"},
+		{"nw", "news", "news: news", ""},
+		{"pn", "player", "player", ""},
+		{"sh", "share text", "share: share text", ""},
+		{"su", "unshare text", "unshare: unshare text", ""},
+		{"tl", "log only", "", "log only"},
+		{"th", "thought", "think: thought", ""},
+		{"tt", "mono", "mono", ""},
+		{"wh", "who text", "who: who text", ""},
+		{"yk", "you killed", "you killed", ""},
+	}
+
+	for _, tc := range cases {
+		resetConsole()
+		data := makeBEPP(tc.prefix, tc.text)
+		got := decodeBEPP(data)
+		if got != tc.want {
+			t.Errorf("prefix %s got %q want %q", tc.prefix, got, tc.want)
+		}
+		msgs := getConsoleMessages()
+		last := ""
+		if len(msgs) > 0 {
+			last = msgs[len(msgs)-1]
+		}
+		if last != tc.log {
+			t.Errorf("prefix %s log %q want %q", tc.prefix, last, tc.log)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- map all BEPP message prefixes to display/log/suppress behaviors
- add unit tests for BEPP prefix handling
- provide test-time stub for console message updates

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a8fcb2748832a8f87d4052a47a4d5