### PR TITLE
Handle MacRoman encoding

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -82,8 +82,6 @@ var languageYellVerb = []string{
 	"yelps",           // Lepori
 }
 
-func decodeMacRoman(b []byte) string { return string(b) }
-
 func decodeBEPP(data []byte) string {
 	if len(data) < 3 || data[0] != 0xC2 {
 		return ""

--- a/draw.go
+++ b/draw.go
@@ -459,7 +459,7 @@ func parseInventory(data []byte) ([]byte, bool) {
 					logError("inventory: cmd %x missing name", cmd)
 					return nil, false
 				}
-				name = string(data[:nidx])
+				name = decodeMacRoman(data[:nidx])
 				data = data[nidx+1:]
 			}
 			switch base {
@@ -537,7 +537,7 @@ func parseDrawState(data []byte) error {
 		d.PictID = binary.BigEndian.Uint16(data[p+2:])
 		p += 4
 		if idx := bytes.IndexByte(data[p:], 0); idx >= 0 {
-			d.Name = string(data[p : p+idx])
+			d.Name = decodeMacRoman(data[p : p+idx])
 			p += idx + 1
 			if d.Name == playerName {
 				playerIndex = d.Index

--- a/macroman.go
+++ b/macroman.go
@@ -1,0 +1,21 @@
+//go:build !nomac
+
+package main
+
+import "golang.org/x/text/encoding/charmap"
+
+func decodeMacRoman(b []byte) string {
+	s, err := charmap.Macintosh.NewDecoder().Bytes(b)
+	if err != nil {
+		return string(b)
+	}
+	return string(s)
+}
+
+func encodeMacRoman(s string) []byte {
+	b, err := charmap.Macintosh.NewEncoder().Bytes([]byte(s))
+	if err != nil {
+		return []byte(s)
+	}
+	return b
+}

--- a/macroman_nomac.go
+++ b/macroman_nomac.go
@@ -1,0 +1,7 @@
+//go:build nomac
+
+package main
+
+func decodeMacRoman(b []byte) string { return string(b) }
+
+func encodeMacRoman(s string) []byte { return []byte(s) }

--- a/util.go
+++ b/util.go
@@ -28,8 +28,6 @@ func simpleEncrypt(data []byte) {
 	}
 }
 
-func encodeMacRoman(s string) []byte { return []byte(s) }
-
 func encodeFullVersion(v int) uint32 { return uint32(v) << 8 }
 
 const (


### PR DESCRIPTION
## Summary
- decode mobile and inventory names from MacRoman to UTF-8
- encode outgoing player commands as MacRoman
- add `nomac` build tag to bypass MacRoman conversion when desired

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: github.com/Distortions81/EUI@v0.0.31 replacement directory ../EUI/ does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689a90de96ec832a8a44063194ad3647