### PR TITLE
Normalize window geometry persistence

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -126,19 +126,20 @@ var (
 	lastSettingsSave = time.Now()
 )
 
-// WindowPoint represents a point on the screen using pixel coordinates.
+// WindowPoint represents a point on the screen using normalized coordinates
+// in the range 0-1.
 type WindowPoint struct {
 	X float64
 	Y float64
 }
 
-// WindowState stores window visibility and geometry using absolute pixel
-// values.
+// WindowState stores window visibility and geometry using normalized
+// coordinates so layouts remain consistent across resolutions.
 type WindowState struct {
 	Open bool
-	// Position holds the top-left corner of the window in pixels.
+	// Position holds the top-left corner of the window as normalized values.
 	Position WindowPoint
-	// Size represents the width and height of the window in pixels.
+	// Size represents the width and height of the window as normalized values.
 	Size WindowPoint
 }
 
@@ -233,12 +234,16 @@ func syncWindow(win *eui.WindowData, state *WindowState) bool {
 		state.Open = win.IsOpen()
 		changed = true
 	}
-	pos := WindowPoint{X: float64(win.Position.X), Y: float64(win.Position.Y)}
+
+	posN := eui.ScreenToNorm(win.GetPos())
+	pos := WindowPoint{X: float64(posN.X), Y: float64(posN.Y)}
 	if state.Position != pos {
 		state.Position = pos
 		changed = true
 	}
-	size := WindowPoint{X: float64(win.Size.X), Y: float64(win.Size.Y)}
+
+	sizeN := eui.ScreenToNorm(win.GetSize())
+	size := WindowPoint{X: float64(sizeN.X), Y: float64(sizeN.Y)}
 	if state.Size != size {
 		state.Size = size
 		changed = true

--- a/ui.go
+++ b/ui.go
@@ -1572,12 +1572,11 @@ func makeInventoryWindow() {
 	inventoryWin.Movable = true
 	inventoryWin.Size = eui.ScreenToNorm(eui.Point{X: 425, Y: 600})
 
-	sx, sy := eui.ScreenSize()
 	if gs.InventoryWindow.Size.X > 0 && gs.InventoryWindow.Size.Y > 0 {
-		inventoryWin.Size = eui.Point{X: float32(gs.InventoryWindow.Size.X) * float32(sx), Y: float32(gs.InventoryWindow.Size.Y) * float32(sy)}
+		inventoryWin.Size = eui.Point{X: float32(gs.InventoryWindow.Size.X), Y: float32(gs.InventoryWindow.Size.Y)}
 	}
 	if gs.InventoryWindow.Position.X != 0 || gs.InventoryWindow.Position.Y != 0 {
-		inventoryWin.Position = eui.Point{X: float32(gs.InventoryWindow.Position.X) * float32(sx), Y: float32(gs.InventoryWindow.Position.Y) * float32(sy)}
+		inventoryWin.Position = eui.Point{X: float32(gs.InventoryWindow.Position.X), Y: float32(gs.InventoryWindow.Position.Y)}
 	} else {
 		inventoryWin.Position = eui.ScreenToNorm(eui.Point{X: 0, Y: 0})
 	}
@@ -1597,9 +1596,8 @@ func makePlayersWindow() {
 	}
 	playersWin = eui.NewWindow()
 	playersWin.Title = "Players"
-	sx, sy := eui.ScreenSize()
 	if gs.PlayersWindow.Size.X > 0 && gs.PlayersWindow.Size.Y > 0 {
-		playersWin.Size = eui.Point{X: float32(gs.PlayersWindow.Size.X) * float32(sx), Y: float32(gs.PlayersWindow.Size.Y) * float32(sy)}
+		playersWin.Size = eui.Point{X: float32(gs.PlayersWindow.Size.X), Y: float32(gs.PlayersWindow.Size.Y)}
 	} else {
 		playersWin.Size = eui.ScreenToNorm(eui.Point{X: 425, Y: 600})
 	}
@@ -1608,7 +1606,7 @@ func makePlayersWindow() {
 	playersWin.Movable = true
 	playersWin.Position = TOP_RIGHT
 	if gs.PlayersWindow.Position.X != 0 || gs.PlayersWindow.Position.Y != 0 {
-		playersWin.Position = eui.Point{X: float32(gs.PlayersWindow.Position.X) * float32(sx), Y: float32(gs.PlayersWindow.Position.Y) * float32(sy)}
+		playersWin.Position = eui.Point{X: float32(gs.PlayersWindow.Position.X), Y: float32(gs.PlayersWindow.Position.Y)}
 	}
 
 	playersList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}


### PR DESCRIPTION
## Summary
- Restore inventory and player windows using stored normalized sizes and positions instead of screen-size multipliers.
- Save window geometry in normalized coordinates to remain resolution-independent.

## Testing
- `go fmt ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689aa244fbc0832aafbff915f705f3a2