### PR TITLE
Normalize console window geometry

### DIFF
--- a/console_ui.go
+++ b/console_ui.go
@@ -55,9 +55,9 @@ func makeConsoleWindow() {
 		return
 	}
 	messagesWin = eui.NewWindow()
-	sx, sy := eui.ScreenSize()
 	if gs.MessagesWindow.Size.X > 0 && gs.MessagesWindow.Size.Y > 0 {
-		messagesWin.Size = eui.Point{X: float32(gs.MessagesWindow.Size.X) * float32(sx), Y: float32(gs.MessagesWindow.Size.Y) * float32(sy)}
+		size := eui.NormToScreen(eui.Point{X: float32(gs.MessagesWindow.Size.X), Y: float32(gs.MessagesWindow.Size.Y)})
+		messagesWin.Size = eui.ScreenToNorm(size)
 	} else {
 		messagesWin.Size = eui.ScreenToNorm(eui.Point{X: 425, Y: 350})
 	}
@@ -67,7 +67,8 @@ func makeConsoleWindow() {
 	messagesWin.Movable = true
 	messagesWin.Position = BOTTOM_LEFT
 	if gs.MessagesWindow.Position.X != 0 || gs.MessagesWindow.Position.Y != 0 {
-		messagesWin.Position = eui.Point{X: float32(gs.MessagesWindow.Position.X) * float32(sx), Y: float32(gs.MessagesWindow.Position.Y) * float32(sy)}
+		pos := eui.NormToScreen(eui.Point{X: float32(gs.MessagesWindow.Position.X), Y: float32(gs.MessagesWindow.Position.Y)})
+		messagesWin.Position = eui.ScreenToNorm(pos)
 	}
 
 	messagesList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}

--- a/settings.go
+++ b/settings.go
@@ -233,14 +233,14 @@ func syncWindow(win *eui.WindowData, state *WindowState) bool {
 		state.Open = win.IsOpen()
 		changed = true
 	}
-	pos := WindowPoint{X: float64(win.Position.X), Y: float64(win.Position.Y)}
-	if state.Position != pos {
-		state.Position = pos
+	pos := eui.ScreenToNorm(win.GetPos())
+	if state.Position != (WindowPoint{X: float64(pos.X), Y: float64(pos.Y)}) {
+		state.Position = WindowPoint{X: float64(pos.X), Y: float64(pos.Y)}
 		changed = true
 	}
-	size := WindowPoint{X: float64(win.Size.X), Y: float64(win.Size.Y)}
-	if state.Size != size {
-		state.Size = size
+	size := eui.ScreenToNorm(win.GetSize())
+	if state.Size != (WindowPoint{X: float64(size.X), Y: float64(size.Y)}) {
+		state.Size = WindowPoint{X: float64(size.X), Y: float64(size.Y)}
 		changed = true
 	}
 	return changed


### PR DESCRIPTION
## Summary
- use EUI helpers to convert persisted console window geometry
- store window position and size in normalized coordinates

## Testing
- `go fmt ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689aa240deb4832a8861c6f056fffb47