### PR TITLE
Load settings before UI and lay out windows after render

### DIFF
--- a/game.go
+++ b/game.go
@@ -1121,6 +1121,7 @@ func drawEquippedItems(screen *ebiten.Image, ox, oy int) {
 // drawInputOverlay renders the text entry box when chatting.
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 	eui.RenderSize(outsideWidth, outsideHeight)
+	layoutOnce.Do(layoutWindows)
 	return outsideWidth, outsideHeight
 }
 
@@ -1154,8 +1155,8 @@ func initGame() {
 	eui.LoadTheme("AccentDark")
 	eui.LoadStyle("RoundHybrid")
 
-	initUI()
 	loadSettings()
+	initUI()
 	updateCharacterButtons()
 
 	close(gameStarted)

--- a/ui.go
+++ b/ui.go
@@ -39,6 +39,7 @@ var addCharPass string
 var addCharRemember bool
 var windowsWin *eui.WindowData
 var toolbarWin *eui.WindowData
+var layoutOnce sync.Once
 
 var (
 	sheetCacheLabel  *eui.ItemData
@@ -93,6 +94,22 @@ func initUI() {
 		downloadWin.Open()
 	} else {
 		loginWin.Open()
+	}
+}
+
+func layoutWindows() {
+	sx, sy := eui.ScreenSize()
+	if chatWin != nil {
+		chatWin.Position = eui.Point{X: float32(sx) - chatWin.Size.X, Y: float32(sy) - chatWin.Size.Y}
+	}
+	if messagesWin != nil {
+		messagesWin.Position = eui.Point{X: 0, Y: float32(sy) - messagesWin.Size.Y}
+	}
+	if inventoryWin != nil {
+		inventoryWin.Position = eui.Point{X: 0, Y: 0}
+	}
+	if playersWin != nil {
+		playersWin.Position = eui.Point{X: float32(sx) - playersWin.Size.X, Y: 0}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Load saved settings before initializing UI so window states are restored correctly.
- Add layout logic using actual screen size to position chat, messages, inventory, and players windows at corners.
- Ensure window layout runs once after the first render size update.

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b024431a0832abe68436da55bbc27