### PR TITLE
Guard item.Render before SubImage

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -937,6 +937,9 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 
 		src := image.Rect(int(item.DrawRect.X0-offset.X), int(item.DrawRect.Y0-offset.Y), int(item.DrawRect.X1-offset.X), int(item.DrawRect.Y1-offset.Y))
+		if item.Render == nil {
+			return // optionally log missing render
+		}
 		sub := item.Render.SubImage(src).(*ebiten.Image)
 		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Translate(float64(item.DrawRect.X0), float64(item.DrawRect.Y0))


### PR DESCRIPTION
## Summary
- Avoid nil dereference in drawItem by checking item.Render before calling SubImage

## Testing
- `go vet ./...` *(fails: settings.go:190:2: unreachable code)*

------
https://chatgpt.com/codex/tasks/task_e_689b6c87c814832a8375e435a3f1324d