### PR TITLE
Draw uncached items

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -936,14 +936,20 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			return
 		}
 
-		src := image.Rect(int(item.DrawRect.X0-offset.X), int(item.DrawRect.Y0-offset.Y), int(item.DrawRect.X1-offset.X), int(item.DrawRect.Y1-offset.Y))
-		if item.Render == nil {
-			return // optionally log missing render
+		if item.Render != nil {
+			src := image.Rect(
+				int(item.DrawRect.X0-offset.X),
+				int(item.DrawRect.Y0-offset.Y),
+				int(item.DrawRect.X1-offset.X),
+				int(item.DrawRect.Y1-offset.Y),
+			)
+			sub := item.Render.SubImage(src).(*ebiten.Image)
+			op := &ebiten.DrawImageOptions{}
+			op.GeoM.Translate(float64(item.DrawRect.X0), float64(item.DrawRect.Y0))
+			screen.DrawImage(sub, op)
+		} else {
+			item.drawItemInternal(parent, offset, clip, screen)
 		}
-		sub := item.Render.SubImage(src).(*ebiten.Image)
-		op := &ebiten.DrawImageOptions{}
-		op.GeoM.Translate(float64(item.DrawRect.X0), float64(item.DrawRect.Y0))
-		screen.DrawImage(sub, op)
 
 		if item.ItemType == ITEM_DROPDOWN && item.Open {
 			dropOff := offset


### PR DESCRIPTION
## Summary
- Render items directly when no cached image exists to keep UI drawing functional
- Preserve cached image usage when available and maintain dropdown/debug handling

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- `EBITENGINE_HEADLESS=1 timeout 5 go run .` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b7108f274832a90fe5fc89124680e