### PR TITLE
Add cache check flag and render counters

### DIFF
--- a/eui/glob.go
+++ b/eui/glob.go
@@ -36,6 +36,9 @@ var (
 	// before exiting when enabled.
 	TreeMode bool
 
+	// CacheCheck shows render counts for windows and items when enabled.
+	CacheCheck bool
+
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 

--- a/eui/render.go
+++ b/eui/render.go
@@ -63,6 +63,9 @@ func Draw(screen *ebiten.Image) {
 }
 
 func (win *windowData) Draw(screen *ebiten.Image) {
+	if CacheCheck {
+		win.RenderCount++
+	}
 	win.drawBG(screen)
 	win.drawItems(screen)
 	win.drawScrollbars(screen)
@@ -71,6 +74,9 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 	windowArea := screen.SubImage(win.getWinRect().getRectangle()).(*ebiten.Image)
 	win.drawBorder(windowArea)
 	win.drawDebug(screen)
+	if CacheCheck {
+		ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%d", win.RenderCount), int(win.getPosition().X), int(win.getPosition().Y))
+	}
 }
 
 func (win *windowData) drawBG(screen *ebiten.Image) {
@@ -275,6 +281,9 @@ func (win *windowData) drawItems(screen *ebiten.Image) {
 }
 
 func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point, clip rect, screen *ebiten.Image) {
+	if CacheCheck {
+		item.RenderCount++
+	}
 	// Store the drawn rectangle for input handling
 	itemRect := rect{
 		X0: offset.X,
@@ -475,6 +484,9 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 		case FLOW_VERTICAL_REV:
 			drawArrow(subImg, midX, item.DrawRect.Y1-margin, midX, item.DrawRect.Y0+margin, 1, col)
 		}
+	}
+	if CacheCheck {
+		ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%d", item.RenderCount), int(item.DrawRect.X0), int(item.DrawRect.Y0))
 	}
 }
 
@@ -917,6 +929,9 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 }
 
 func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen *ebiten.Image) {
+	if CacheCheck {
+		item.RenderCount++
+	}
 	if item.ItemType != ITEM_FLOW {
 
 		if parent == nil {
@@ -964,10 +979,16 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		if DebugMode {
 			strokeRect(screen, item.DrawRect.X0, item.DrawRect.Y0, item.DrawRect.X1-item.DrawRect.X0, item.DrawRect.Y1-item.DrawRect.Y0, 1, color.RGBA{R: 128}, false)
 		}
+		if CacheCheck {
+			ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%d", item.RenderCount), int(item.DrawRect.X0), int(item.DrawRect.Y0))
+		}
 		return
 	}
 
 	item.drawItemInternal(parent, offset, clip, screen)
+	if CacheCheck {
+		ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%d", item.RenderCount), int(item.DrawRect.X0), int(item.DrawRect.Y0))
+	}
 }
 
 func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten.Image) {

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -56,6 +56,9 @@ type windowData struct {
 	// Drop shadow styling
 	ShadowSize  float32
 	ShadowColor Color
+
+	// RenderCount tracks how often the window has been drawn.
+	RenderCount int
 }
 
 type itemData struct {
@@ -138,6 +141,9 @@ type itemData struct {
 	// Drop shadow styling
 	ShadowSize  float32
 	ShadowColor Color
+
+	// RenderCount tracks how often the item has been drawn.
+	RenderCount int
 }
 
 type roundRect struct {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 
 	"go_client/climg"
 	"go_client/clsnd"
+	"go_client/eui"
 )
 
 var (
@@ -38,6 +39,7 @@ func main() {
 	flag.StringVar(&clmov, "clmov", "", "play back a .clMov file")
 	clientVer := flag.Int("client-version", 1445, "client version number (for testing)")
 	flag.BoolVar(&doDebug, "debug", false, "verbose/debug logging")
+	flag.BoolVar(&eui.CacheCheck, "cacheCheck", false, "display window and item render counts")
 	genPGO := flag.Bool("pgo", false, "create default.pgo using test.clMov at 30 fps for 30s")
 	flag.Parse()
 	clientVersion = *clientVer


### PR DESCRIPTION
## Summary
- add `-cacheCheck` launch parameter to toggle window and item render counts
- overlay re-render counters in top-left of windows and UI elements for cache debugging

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b7c88d264832aa6349c57ed1e1d19