### PR TITLE
Avoid rerendering on steady hover

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -166,8 +166,13 @@ func Update() error {
 			}
 		}
 
-		//Window items
+		// Window items
+		prevWinHovered := win.Hovered
+		win.Hovered = false
 		win.clickWindowItems(mpos, click)
+		if win.Hovered != prevWinHovered {
+			win.markDirty()
+		}
 
 		// Bring window forward on click if the cursor is over it or an
 		// expanded dropdown. Break so windows behind don't receive the

--- a/eui/render.go
+++ b/eui/render.go
@@ -222,7 +222,6 @@ func (win *windowData) drawBorder(screen *ebiten.Image) {
 			FrameColor = win.Theme.Window.ActiveColor
 		} else if win.Hovered {
 			FrameColor = win.Theme.Window.HoverColor
-			win.Hovered = false
 		}
 		drawRoundRect(screen, &roundRect{
 			Size:     win.GetSize(),
@@ -347,7 +346,6 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 			} else if tab.Hovered {
 				col = style.HoverColor
 			}
-			tab.Hovered = false
 			if item.Filled {
 				drawTabShape(subImg,
 					point{X: x, Y: offset.Y},
@@ -562,7 +560,6 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 			itemColor = style.ClickColor
 			bColor = style.Color
 		} else if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 		auxSize := pointScaleMul(item.AuxSize)
@@ -620,7 +617,6 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 			itemColor = style.ClickColor
 			bColor = style.OutlineColor
 		} else if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 		auxSize := pointScaleMul(item.AuxSize)
@@ -681,7 +677,6 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 			if time.Since(item.Clicked) < clickFlash {
 				itemColor = style.ClickColor
 			} else if item.Hovered {
-				item.Hovered = false
 				itemColor = style.HoverColor
 			}
 			if item.Filled {
@@ -717,7 +712,6 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		if item.Focused {
 			itemColor = style.ClickColor
 		} else if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 
@@ -760,7 +754,6 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 
 		itemColor := style.Color
 		if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 
@@ -840,7 +833,6 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		if item.Open {
 			itemColor = style.SelectedColor
 		} else if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 


### PR DESCRIPTION
## Summary
- Track window hover state and only redraw when it changes
- Preserve item hover flags during rendering

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b90932d34832ab17072df92921dbb