### PR TITLE
Recalculate window zones on size change

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -21,6 +21,8 @@ var (
 // Update processes input and updates window state.
 // Programs embedding the UI can call this from their Ebiten Update handler.
 func Update() error {
+	w, h := ebiten.WindowSize()
+	Layout(w, h)
 
 	checkThemeStyleMods()
 


### PR DESCRIPTION
## Summary
- Ensure UI layout recalculates when the Ebiten window size changes to keep zoned windows in place

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ba48c93ec832aa1e6a5eda211946c