### PR TITLE
Clamp zoned windows to screen bounds

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -226,9 +226,6 @@ func (win *windowData) adjustScrollForResize() {
 }
 
 func (win *windowData) clampToScreen() {
-	if win.zone != nil {
-		return
-	}
 	pos := win.getPosition()
 	size := win.GetSize()
 	old := win.Position

--- a/eui/zones.go
+++ b/eui/zones.go
@@ -50,6 +50,26 @@ func (win *windowData) updateZonePosition() {
 	size := win.GetSize()
 	win.Position.X = (cx - size.X/2) / uiScale
 	win.Position.Y = (cy - size.Y/2) / uiScale
+
+	maxX := (float32(screenWidth) - size.X) / uiScale
+	maxY := (float32(screenHeight) - size.Y) / uiScale
+	if maxX < 0 {
+		maxX = 0
+	}
+	if maxY < 0 {
+		maxY = 0
+	}
+	if win.Position.X < 0 {
+		win.Position.X = 0
+	} else if win.Position.X > maxX {
+		win.Position.X = maxX
+	}
+	if win.Position.Y < 0 {
+		win.Position.Y = 0
+	} else if win.Position.Y > maxY {
+		win.Position.Y = maxY
+	}
+	win.clampToScreen()
 }
 
 func hZoneCoord(z HZone, width int) float32 {


### PR DESCRIPTION
## Summary
- Ensure zoned windows stay within display bounds by clamping their positions
- Allow `clampToScreen` to handle zoned windows and invoke it after zone positioning

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ba499a648832a908e3c0420d36adf