### PR TITLE
Center playfield content in game window

### DIFF
--- a/game.go
+++ b/game.go
@@ -519,7 +519,7 @@ func updateGameWindowSize() {
 	gameWin.Size = eui.Point{X: float32(gameAreaSizeX) * scale, Y: float32(gameAreaSizeY) * scale}
 }
 
-func gameContentOrigin() (int, int) {
+func gameWindowOrigin() (int, int) {
 	if gameWin == nil {
 		return 0, 0
 	}
@@ -530,15 +530,35 @@ func gameContentOrigin() (int, int) {
 	return int(math.Round(float64(x))), int(math.Round(float64(y)))
 }
 
+func gameContentOrigin() (int, int) {
+	x, y := gameWindowOrigin()
+	if gameWin == nil {
+		return x, y
+	}
+	size := gameWin.GetSize()
+	w := float64(int(size.X) &^ 1)
+	h := float64(int(size.Y) &^ 1)
+	fw := float64(gameAreaSizeX) * gs.GameScale
+	fh := float64(gameAreaSizeY) * gs.GameScale
+	if w > fw {
+		x += int(math.Round((w - fw) / 2))
+	}
+	if h > fh {
+		y += int(math.Round((h - fh) / 2))
+	}
+	return x, y
+}
+
 func (g *Game) Draw(screen *ebiten.Image) {
 
+	wx, wy := gameWindowOrigin()
 	ox, oy := gameContentOrigin()
 	if gameWin != nil {
 		size := gameWin.GetSize()
 		w := float32(int(size.X) &^ 1)
 		h := float32(int(size.Y) &^ 1)
 		bg := color.RGBA(gameWin.Theme.Window.BGColor)
-		vector.DrawFilledRect(screen, float32(ox), float32(oy), w, h, bg, false)
+		vector.DrawFilledRect(screen, float32(wx), float32(wy), w, h, bg, false)
 	}
 	if clmov == "" && tcpConn == nil {
 		drawSplash(screen, ox, oy)
@@ -565,11 +585,21 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		fw := float32(float64(gameAreaSizeX) * gs.GameScale)
 		fh := float32(float64(gameAreaSizeY) * gs.GameScale)
 		dark := color.RGBA{0x40, 0x40, 0x40, 0xff}
-		if fw < w {
-			vector.DrawFilledRect(screen, float32(ox)+fw, float32(oy), w-fw, fh, dark, false)
+		left := float32(ox - wx)
+		top := float32(oy - wy)
+		right := w - left - fw
+		bottom := h - top - fh
+		if left > 0 {
+			vector.DrawFilledRect(screen, float32(wx), float32(oy), left, fh, dark, false)
 		}
-		if fh < h {
-			vector.DrawFilledRect(screen, float32(ox), float32(oy)+fh, w, h-fh, dark, false)
+		if right > 0 {
+			vector.DrawFilledRect(screen, float32(ox)+fw, float32(oy), right, fh, dark, false)
+		}
+		if top > 0 {
+			vector.DrawFilledRect(screen, float32(wx), float32(wy), w, top, dark, false)
+		}
+		if bottom > 0 {
+			vector.DrawFilledRect(screen, float32(wx), float32(oy)+fh, w, bottom, dark, false)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- factor out gameWindowOrigin to get window content origin
- center game content using window size and scale
- update Draw to render background and fillers based on centered offsets

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bb27dd088832ab95ea6e4fe6bdc34