### PR TITLE
Restore settings.json saving on window changes

### DIFF
--- a/game.go
+++ b/game.go
@@ -1196,6 +1196,8 @@ func runGame(ctx context.Context) {
 	if err := ebiten.RunGameWithOptions(&Game{}, op); err != nil {
 		log.Printf("ebiten: %v", err)
 	}
+	syncWindowSettings()
+	saveSettings()
 }
 
 func initGame() {

--- a/settings.go
+++ b/settings.go
@@ -181,8 +181,15 @@ func applySettings() {
 }
 
 func saveSettings() {
-	// Saving settings is currently disabled.
-	return
+	data, err := json.MarshalIndent(gs, "", "  ")
+	if err != nil {
+		logError("save settings: %v", err)
+		return
+	}
+	path := filepath.Join(dataDirPath, settingsFile)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		logError("save settings: %v", err)
+	}
 }
 
 func syncWindowSettings() bool {


### PR DESCRIPTION
## Summary
- Implement saving settings.json with JSON encoding
- Persist window positions and sizes on exit

## Testing
- `go fmt game.go settings.go`
- `go fmt settings.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689becb1ff60832a8704f776ab9c96cf