### PR TITLE
Scale title bar button padding with UI scale

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -108,7 +108,7 @@ func (win *windowData) xRect() rect {
 		return rect{}
 	}
 
-	var xpad float32 = win.Border
+	var xpad float32 = win.Border * win.scale()
 	pos := win.GetPos()
 	return rect{
 		X0: pos.X + win.GetSize().X - (win.GetTitleSize()) + xpad,
@@ -124,7 +124,7 @@ func (win *windowData) pinRect() rect {
 		return rect{}
 	}
 
-	var xpad float32 = win.Border
+	var xpad float32 = win.Border * win.scale()
 	size := win.GetTitleSize()
 	pos := win.GetPos()
 	x1 := pos.X + win.GetSize().X - xpad


### PR DESCRIPTION
## Summary
- scale hit areas for close and pin buttons by UI scale

## Testing
- `gofmt -w eui/util.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bfa85d538832a9280d4349e98cc6a