### PR TITLE
Add window zone save/load helpers

### DIFF
--- a/eui/zone_state.go
+++ b/eui/zone_state.go
@@ -1,0 +1,40 @@
+package eui
+
+// WindowZone represents a saved window zone.
+type WindowZone struct {
+	H HZone
+	V VZone
+}
+
+// WindowZoneState captures whether a window is zoned and its zone.
+type WindowZoneState struct {
+	Zoned bool
+	Zone  WindowZone
+}
+
+// SaveWindowZones returns a table of window titles to their zone state.
+func SaveWindowZones() map[string]WindowZoneState {
+	table := make(map[string]WindowZoneState, len(windows))
+	for _, win := range windows {
+		st := WindowZoneState{}
+		if win.zone != nil {
+			st.Zoned = true
+			st.Zone = WindowZone{H: win.zone.h, V: win.zone.v}
+		}
+		table[win.Title] = st
+	}
+	return table
+}
+
+// LoadWindowZones restores window zone states from the provided table.
+func LoadWindowZones(table map[string]WindowZoneState) {
+	for _, win := range windows {
+		if st, ok := table[win.Title]; ok {
+			if st.Zoned {
+				win.SetZone(st.Zone.H, st.Zone.V)
+			} else {
+				win.ClearZone()
+			}
+		}
+	}
+}

--- a/eui/zone_state_test.go
+++ b/eui/zone_state_test.go
@@ -1,0 +1,38 @@
+package eui
+
+import "testing"
+
+func TestSaveLoadWindowZones(t *testing.T) {
+	screenWidth = 100
+	screenHeight = 100
+	uiScale = 1
+
+	a := &windowData{Title: "a"}
+	b := &windowData{Title: "b"}
+	windows = []*windowData{a, b}
+
+	a.SetZone(HZoneLeft, VZoneTop)
+
+	saved := SaveWindowZones()
+	if len(saved) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(saved))
+	}
+	if st := saved["a"]; !st.Zoned || st.Zone.H != HZoneLeft || st.Zone.V != VZoneTop {
+		t.Fatalf("unexpected saved state for a: %+v", st)
+	}
+	if st := saved["b"]; st.Zoned {
+		t.Fatalf("expected b to be unzoned")
+	}
+
+	a.ClearZone()
+	b.SetZone(HZoneRight, VZoneBottom)
+	LoadWindowZones(saved)
+
+	if a.zone == nil || a.zone.h != HZoneLeft || a.zone.v != VZoneTop {
+		t.Fatalf("a zone not restored: %+v", a.zone)
+	}
+	if b.zone != nil {
+		t.Fatalf("b zone should be cleared: %+v", b.zone)
+	}
+	windows = nil
+}


### PR DESCRIPTION
## Summary
- add `SaveWindowZones` and `LoadWindowZones` to capture window zone state in a name table
- cover zone save/load cycle with unit test

## Testing
- `go vet ./...`
- `go test ./...` *(fails: GLFW library is not initialized)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bfa1a1754832ab308571ec7a09e50