### PR TITLE
Consume pin clicks to avoid activating windows underneath

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -139,7 +139,7 @@ func Update() error {
 						win.PinToClosestZone()
 					}
 					win.markDirty()
-					continue
+					break
 				}
 				dragPart = part
 				dragWin = win


### PR DESCRIPTION
## Summary
- avoid propagating pin icon clicks to other windows by exiting the window loop

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bfc663f74832a8a3e1f990dcbe550