### PR TITLE
Add option for arbitrary game window sizes

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -46,7 +46,7 @@ var gsdef settings = settings{
 	Theme:             "",
 	MessagesToConsole: false,
 	WindowTiling:      true,
-	AnyGameWindowSize: false,
+	AnyGameWindowSize: false, // allow arbitrary game window sizes
 
 	GameWindow:      WindowState{Open: true},
 	InventoryWindow: WindowState{Open: true},
@@ -99,7 +99,7 @@ type settings struct {
 	Fullscreen        bool
 	Volume            float64
 	Mute              bool
-	AnyGameWindowSize bool
+	AnyGameWindowSize bool // allow arbitrary game window sizes
 	GameScale         float64
 	Theme             string
 	MessagesToConsole bool

--- a/ui.go
+++ b/ui.go
@@ -961,6 +961,29 @@ func makeGraphicsWindow() {
 	hint.Size = eui.Point{X: width, Y: 16}
 	flow.AddItem(hint)
 
+	anySizeWarn, _ := eui.NewText()
+	anySizeWarn.Text = "Warning: arbitrary sizes may produce blurrier graphics"
+	anySizeWarn.FontSize = 10
+	anySizeWarn.Color = eui.ColorRed
+	anySizeWarn.Size = eui.Point{X: width, Y: 16}
+	anySizeWarn.Invisible = !gs.AnyGameWindowSize
+
+	anySizeCB, anySizeEvents := eui.NewCheckbox()
+	anySizeCB.Text = "Any size game window"
+	anySizeCB.Size = eui.Point{X: width, Y: 24}
+	anySizeCB.Checked = gs.AnyGameWindowSize
+	anySizeEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.AnyGameWindowSize = ev.Checked
+			gameSizeSlider.Disabled = ev.Checked
+			anySizeWarn.Invisible = !ev.Checked
+			updateGameWindowSize()
+			settingsDirty = true
+		}
+	}
+	flow.AddItem(anySizeCB)
+	flow.AddItem(anySizeWarn)
+
 	fullscreenCB, fullscreenEvents := eui.NewCheckbox()
 	fullscreenCB.Text = "Fullscreen"
 	fullscreenCB.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- add graphics setting checkbox "Any size game window" with warning and slider disabling
- persist any-size game window flag in settings

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run -a go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c1cff737c832a8e0e395b250cc74f