### PR TITLE
Use embedded help file for help window

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -1,0 +1,35 @@
+Welcome to GoThoom!
+
+MOVEMENT
+  - Use the WASD or arrow keys to walk.
+  - Hold Shift while moving to run.
+  - Left click anywhere on the ground to walk toward that spot.
+  - Right click on objects or NPCs to interact with them.
+  - Press Space to stop moving immediately.
+
+COMMUNICATION
+  - Press Enter to begin chatting or enter commands.
+  - Prefix a line with / to issue commands like /who or /tell.
+  - /tell <name> <message> whispers privately to another player.
+  - /emote <action> describes your actions in third person.
+
+INTERFACE
+  - Use the players window to see who is online.
+  - The inventory window lets you manage gear and items.
+  - Drag items between slots or to the world to drop them.
+  - Hold Ctrl while dragging to split stacks.
+  - Scroll the mouse wheel to zoom the game view.
+
+GAMEPLAY
+  - Talk to NPCs for quests and information.
+  - Combat initiates automatically when you target a hostile creature.
+  - Keep an eye on your health and stamina bars.
+  - Rest near a campfire to recover more quickly.
+
+MISCELLANEOUS
+  - Adjust volume and graphics options in the settings window.
+  - Press F1 or click the Help button to toggle this help.
+  - Use the Logout button in the toolbar to exit safely.
+  - Be respectful of other players and have fun exploring!
+
+For more tips and community guides, ask around in game or visit the forums.

--- a/help_ui.go
+++ b/help_ui.go
@@ -3,7 +3,64 @@
 package main
 
 import (
+	_ "embed"
+	"strings"
+
 	"go_client/eui"
 )
 
 var helpWin *eui.WindowData
+var helpFlow *eui.ItemData
+
+//go:embed data/help.txt
+var helpText string
+
+func updateHelpWindow() {
+	if helpFlow == nil || helpWin == nil {
+		return
+	}
+	// Clear existing contents
+	for i := range helpFlow.Contents {
+		helpFlow.Contents[i] = nil
+	}
+	helpFlow.Contents = helpFlow.Contents[:0]
+
+	maxWidth := int(helpWin.Size.X) - 20
+	if maxWidth <= 0 {
+		maxWidth = 300
+	}
+
+	for _, para := range strings.Split(helpText, "\n") {
+		var lines []string
+		if mainFont != nil {
+			_, lines = wrapText(para, mainFont, float64(maxWidth))
+		} else {
+			lines = []string{para}
+		}
+		for _, line := range lines {
+			t, _ := eui.NewText()
+			t.Text = line
+			t.Size = eui.Point{X: float32(maxWidth), Y: 24}
+			t.FontSize = float32(gs.MainFontSize)
+			helpFlow.AddItem(t)
+		}
+	}
+}
+
+func makeHelpWindow() {
+	if helpWin != nil {
+		return
+	}
+	helpWin = eui.NewWindow()
+	helpWin.Title = "Help"
+	helpWin.Size = eui.Point{X: 410, Y: 450}
+	helpWin.Closable = true
+	helpWin.Resizable = true
+	helpWin.Movable = true
+	helpWin.SetZone(eui.HZoneCenterLeft, eui.VZoneMiddleTop)
+
+	helpFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true}
+	helpWin.AddItem(helpFlow)
+	helpWin.AddWindow(false)
+	updateHelpWindow()
+}

--- a/ui.go
+++ b/ui.go
@@ -1758,34 +1758,3 @@ func makePlayersWindow() {
 	playersWin.AddItem(playersList)
 	playersWin.AddWindow(false)
 }
-
-func makeHelpWindow() {
-	if helpWin != nil {
-		return
-	}
-	helpWin = eui.NewWindow()
-	helpWin.Title = "Help"
-	helpWin.Closable = true
-	helpWin.Resizable = false
-	helpWin.AutoSize = true
-	helpWin.Movable = true
-	helpWin.SetZone(eui.HZoneCenterLeft, eui.VZoneMiddleTop)
-	helpFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
-	helpTexts := []string{
-		"WASD or Arrow Keys - Walk",
-		"Shift + Movement - Run",
-		"Left Click - Walk toward cursor",
-		"Click-to-Toggle Walk - Left click toggles walking",
-		"Enter - Start typing / send command",
-		"Escape - Cancel typing",
-	}
-	for _, line := range helpTexts {
-		t, _ := eui.NewText()
-		t.Text = line
-		t.Size = eui.Point{X: 300, Y: 24}
-		t.FontSize = 15
-		helpFlow.AddItem(t)
-	}
-	helpWin.AddItem(helpFlow)
-	helpWin.AddWindow(false)
-}


### PR DESCRIPTION
## Summary
- load help window text from embedded `data/help.txt`
- auto-wrap help contents and display them in a scrollable window
- add comprehensive in-game help text file

## Testing
- `gofmt -w help_ui.go ui.go`
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c214e0d70832a8c38fba08c68593f