### PR TITLE
Sync Ebiten window with game window for any-size setting

### DIFF
--- a/game.go
+++ b/game.go
@@ -510,6 +510,7 @@ func updateGameScale() {
 			gs.GameScale = newScale
 			initFont()
 		}
+		updateGameWindowSize()
 		return
 	}
 
@@ -529,6 +530,13 @@ func updateGameWindowSize() {
 		return
 	}
 	if gs.AnyGameWindowSize {
+		size := gameWin.GetRawSize()
+		desiredW := int(math.Round(float64(size.X)))
+		desiredH := int(math.Round(float64(size.Y)))
+		curW, curH := ebiten.WindowSize()
+		if curW != desiredW || curH != desiredH {
+			ebiten.SetWindowSize(desiredW, desiredH)
+		}
 		return
 	}
 	scale := float32(gs.GameScale)


### PR DESCRIPTION
## Summary
- keep the Ebiten window in sync when arbitrary game window sizes are allowed
- resize the Ebiten window even when "Any size game window" is enabled

## Testing
- `gofmt -w game.go`
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c28e4e9ac832a862e32bb7099398b