### PR TITLE
Skip origin adjustment when bubble coordinates already offscreen

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -103,9 +103,12 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 		return
 	}
 	tailX, tailY := x, y
-	ox, oy := gameContentOrigin()
-	x -= ox
-	y -= oy
+	ox, oy := 0, 0
+	if !gs.AnyGameWindowSize {
+		ox, oy = gameContentOrigin()
+		x -= ox
+		y -= oy
+	}
 
 	sw := int(float64(gameAreaSizeX) * gs.GameScale)
 	sh := int(float64(gameAreaSizeY) * gs.GameScale)
@@ -121,10 +124,12 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	height := lineHeight*len(lines) + 2*pad
 
 	left, top, right, bottom := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, far)
-	left += ox
-	right += ox
-	top += oy
-	bottom += oy
+	if !gs.AnyGameWindowSize {
+		left += ox
+		right += ox
+		top += oy
+		bottom += oy
+	}
 	baseX := left + width/2
 
 	bgR, bgG, bgB, bgA := bgCol.RGBA()


### PR DESCRIPTION
## Summary
- Avoid redundant origin adjustment in `drawBubble` when off-screen coordinates are provided
- Keep bubble bounds clamped and tail anchored in both fixed and any-size window modes

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c3363acb8832aa6f8e7f0d9a5a7c2