### PR TITLE
Ensure chat list scrolls and stays visible with input bar

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -8,10 +8,17 @@ import (
 
 var chatWin *eui.WindowData
 var chatList *eui.ItemData
+var inputBar *eui.ItemData
 
 func updateChatWindow() {
 	if chatList == nil {
 		return
+	}
+	if chatWin != nil {
+		chatList.Size.Y = chatWin.GetSize().Y
+		if inputBar != nil {
+			chatList.Size.Y -= inputBar.Size.Y
+		}
 	}
 	msgs := getChatMessages()
 	changed := false
@@ -59,7 +66,7 @@ func makeChatWindow() error {
 	chatWin.Movable = true
 	chatWin.SetZone(eui.HZoneRight, eui.VZoneBottom)
 
-	chatList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
+	chatList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true}
 	chatWin.AddItem(chatList)
 	chatWin.AddWindow(false)
 	return nil


### PR DESCRIPTION
## Summary
- Make chat message list scrollable
- Resize message list to keep space for an optional input bar

## Testing
- `go fmt chat_messages_ui.go`
- `go vet`


------
https://chatgpt.com/codex/tasks/task_e_689c386ea108832a84ed4bda0fc43255