### PR TITLE
Reset state when seeking movies

### DIFF
--- a/movie_player.go
+++ b/movie_player.go
@@ -339,8 +339,9 @@ func (p *moviePlayer) seek(idx int) {
 	}
 	wasPlaying := p.playing
 	p.playing = false
+	resetDrawState()
+	frameCounter = 0
 
-	//resetDrawState()
 	for i := 0; i < idx; i++ {
 		m := p.frames[i]
 		if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {


### PR DESCRIPTION
## Summary
- Reset draw state and frame counter prior to processing frames when seeking in movies

## Testing
- `go vet ./...`
- `xvfb-run -a go test ./...` *(fails: TestSnapResizeToWindow width snapped to 64; want 50)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c57216878832aa67ad8358cbaa396