### PR TITLE
Allow interpolation for stationary objects when smoothing is off

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -726,11 +726,13 @@ func parseDrawState(data []byte) error {
 		newPics[i].Again = false
 	}
 	dx, dy, bgIdxs, ok := pictureShift(prevPics, newPics)
-	if gs.MotionSmoothing && gs.smoothMoving {
-		logDebug("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, ok)
-		if !ok {
-			logDebug("prev pics: %v", picturesSummary(prevPics))
-			logDebug("new  pics: %v", picturesSummary(newPics))
+	if gs.MotionSmoothing {
+		if gs.smoothMoving {
+			logDebug("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, ok)
+			if !ok {
+				logDebug("prev pics: %v", picturesSummary(prevPics))
+				logDebug("new  pics: %v", picturesSummary(newPics))
+			}
 		}
 		if ok {
 			state.picShiftX = dx


### PR DESCRIPTION
## Summary
- compute camera shift even when `smoothMoving` is disabled so stationary pictures still interpolate

## Testing
- `go vet ./...`
- `xvfb-run -a go test ./...` *(fails: TestSnapResizeToWindow, TestSnapResizeToScreenScaled)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c62d2c100832aab7b9732cd6f8c91