### PR TITLE
Add scroll wheel zoom debug mode

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -723,6 +723,21 @@ func parseDrawState(data []byte) error {
 		newPics[i].Again = false
 	}
 	dx, dy, bgIdxs, ok := pictureShift(prevPics, newPics)
+	if ok && gs.scrollWheelZoom {
+		for i := again; i < len(prevPics); i++ {
+			p := prevPics[i]
+			if !p.Background {
+				continue
+			}
+			p.H = int16(int(p.H) + dx)
+			p.V = int16(int(p.V) + dy)
+			p.Again = true
+			p.Moving = false
+			idx := len(newPics)
+			newPics = append(newPics, p)
+			bgIdxs = append(bgIdxs, idx)
+		}
+	}
 	if gs.MotionSmoothing {
 		if gs.smoothMoving {
 			logDebug("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, ok)

--- a/game.go
+++ b/game.go
@@ -518,6 +518,20 @@ func (g *Game) Update() error {
 	}
 
 	mx, my := ebiten.CursorPosition()
+	if gs.scrollWheelZoom && !pointInUI(mx, my) {
+		_, wy := ebiten.Wheel()
+		if wy != 0 {
+			gs.GameScale += wy * 0.25
+			if gs.GameScale < 1 {
+				gs.GameScale = 1
+			} else if gs.GameScale > 5 {
+				gs.GameScale = 5
+			}
+			updateGameWindowSize()
+			initFont()
+			settingsDirty = true
+		}
+	}
 	gx, gy := gameWindowOrigin()
 	baseX := int16(float64(mx-gx)/gs.GameScale - float64(fieldCenterX))
 	baseY := int16(float64(my-gy)/gs.GameScale - float64(fieldCenterY))

--- a/settings.go
+++ b/settings.go
@@ -71,6 +71,7 @@ var gsdef settings = settings{
 	cacheWholeSheet:     true,
 	smoothMoving:        false,
 	dontShiftNewSprites: false,
+	scrollWheelZoom:     false,
 	fastBars:            true,
 	recordAssetStats:    false,
 }
@@ -130,6 +131,7 @@ type settings struct {
 	cacheWholeSheet     bool
 	smoothMoving        bool
 	dontShiftNewSprites bool
+	scrollWheelZoom     bool
 	fastBars            bool
 	recordAssetStats    bool
 	NoCaching           bool

--- a/ui.go
+++ b/ui.go
@@ -1567,6 +1567,19 @@ func makeDebugWindow() {
 		}
 	}
 	debugFlow.AddItem(shiftSpriteCB)
+
+	zoomWheelCB, zoomWheelEvents := eui.NewCheckbox()
+	zoomWheelCB.Text = "Scroll Wheel Zoom"
+	zoomWheelCB.Size = eui.Point{X: width, Y: 24}
+	zoomWheelCB.Checked = gs.scrollWheelZoom
+	zoomWheelCB.Tooltip = "Zoom game with scroll wheel and persist backgrounds"
+	zoomWheelEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.scrollWheelZoom = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(zoomWheelCB)
 	cacheLabel, _ := eui.NewText()
 	cacheLabel.Text = "Caches:"
 	cacheLabel.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- allow zooming the game view with the mouse wheel while in debug mode
- persist background pictures by shifting them with pictureShift when wheel zoom is enabled
- expose a Scroll Wheel Zoom toggle in debug settings

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run -a go test ./...` *(fails: width snapped to 64; want 50)*

------
https://chatgpt.com/codex/tasks/task_e_689d1f509360832abd780fd0140fc032