### PR TITLE
Preserve backgrounds after picture shift

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -752,6 +752,27 @@ func parseDrawState(data []byte) error {
 		state.picShiftX = 0
 		state.picShiftY = 0
 	}
+	if ok {
+		type picKey struct {
+			id   uint16
+			h, v int16
+		}
+		lookup := make(map[picKey]struct{}, len(newPics))
+		for _, p := range newPics {
+			lookup[picKey{p.PictID, p.H, p.V}] = struct{}{}
+		}
+		for _, p := range prevPics {
+			if p.Background {
+				key := picKey{p.PictID, p.H, p.V}
+				if _, found := lookup[key]; !found {
+					p.Again = true
+					newPics = append(newPics, p)
+					bgIdxs = append(bgIdxs, len(newPics)-1)
+					lookup[key] = struct{}{}
+				}
+			}
+		}
+	}
 	if !ok {
 		if pictCount+pictAgain == 0 {
 			prevPics = nil


### PR DESCRIPTION
## Summary
- After successful pictureShift, retain prior background sprites not present in the new frame by appending them and tracking indices.
- Background indices now ensure appended sprites are flagged as static backgrounds during rendering.

## Testing
- `go fmt draw.go`
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d6628680c832abf0289cab365826d