### PR TITLE
Handle inventory updates when window closed

### DIFF
--- a/game.go
+++ b/game.go
@@ -373,7 +373,9 @@ func (g *Game) Update() error {
 
 	if inventoryDirty {
 		updateInventoryWindow()
-		inventoryDirty = false
+		if inventoryList != nil {
+			inventoryDirty = false
+		}
 	}
 
 	if syncWindowSettings() {

--- a/ui.go
+++ b/ui.go
@@ -1798,6 +1798,7 @@ func makeInventoryWindow() {
 	inventoryWin.AddItem(title)
 	inventoryWin.AddItem(inventoryList)
 	inventoryWin.AddWindow(false)
+	updateInventoryWindow()
 }
 
 func makePlayersWindow() {


### PR DESCRIPTION
## Summary
- Avoid clearing `inventoryDirty` while the inventory window is closed
- Refresh inventory window immediately after creation to show existing items

## Testing
- `go fmt game.go ui.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689da6681c54832a857019706556e52a