### PR TITLE
Use atomic flag for inventory dirtiness

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -516,7 +516,7 @@ func parseInventory(data []byte) ([]byte, bool) {
 	for len(data) > 0 && data[0] == 0 {
 		data = data[1:]
 	}
-	inventoryDirty = true
+	inventoryDirty.Store(true)
 	return data, true
 }
 

--- a/game.go
+++ b/game.go
@@ -371,10 +371,10 @@ func (g *Game) Update() error {
 		initGame()
 	})
 
-	if inventoryDirty {
+	if inventoryDirty.Load() {
 		updateInventoryWindow()
 		if inventoryList != nil {
-			inventoryDirty = false
+			inventoryDirty.CompareAndSwap(true, false)
 		}
 	}
 

--- a/inventory.go
+++ b/inventory.go
@@ -23,7 +23,7 @@ func resetInventory() {
 	inventoryMu.Lock()
 	inventoryItems = inventoryItems[:0]
 	inventoryMu.Unlock()
-	inventoryDirty = true
+	inventoryDirty.Store(true)
 }
 
 func addInventoryItem(id uint16, idx int, name string, equip bool) {
@@ -42,7 +42,7 @@ func addInventoryItem(id uint16, idx int, name string, equip bool) {
 		inventoryNames[id] = name
 	}
 	inventoryMu.Unlock()
-	inventoryDirty = true
+	inventoryDirty.Store(true)
 }
 
 func removeInventoryItem(id uint16, idx int) {
@@ -61,7 +61,7 @@ func removeInventoryItem(id uint16, idx int) {
 		inventoryItems[i].Index = i
 	}
 	inventoryMu.Unlock()
-	inventoryDirty = true
+	inventoryDirty.Store(true)
 }
 
 func equipInventoryItem(id uint16, idx int, equip bool) {
@@ -77,7 +77,7 @@ func equipInventoryItem(id uint16, idx int, equip bool) {
 		}
 	}
 	inventoryMu.Unlock()
-	inventoryDirty = true
+	inventoryDirty.Store(true)
 }
 
 func renameInventoryItem(id uint16, idx int, name string) {
@@ -96,7 +96,7 @@ func renameInventoryItem(id uint16, idx int, name string) {
 		inventoryNames[id] = name
 	}
 	inventoryMu.Unlock()
-	inventoryDirty = true
+	inventoryDirty.Store(true)
 }
 
 func getInventory() []inventoryItem {
@@ -134,5 +134,5 @@ func setFullInventory(ids []uint16, equipped []bool) {
 	}
 	inventoryItems = items
 	inventoryMu.Unlock()
-	inventoryDirty = true
+	inventoryDirty.Store(true)
 }

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -4,11 +4,12 @@ package main
 
 import (
 	"gothoom/eui"
+	"sync/atomic"
 )
 
 var inventoryWin *eui.WindowData
 var inventoryList *eui.ItemData
-var inventoryDirty bool
+var inventoryDirty atomic.Bool
 
 func updateInventoryWindow() {
 	if inventoryList == nil {


### PR DESCRIPTION
## Summary
- replace global `inventoryDirty` boolean with `atomic.Bool`
- use atomic operations for reads and writes across game and inventory updates

## Testing
- `gofmt -w inventory_ui.go game.go inventory.go draw.go`
- `go vet ./...` *(fails: undefined identifiers in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689db32897e8832aaa5b0c520b70ef48