### PR TITLE
Reset inventory state on startup

### DIFF
--- a/game.go
+++ b/game.go
@@ -1387,6 +1387,8 @@ func initGame() {
 	ebiten.SetTPS(ebiten.SyncWithFPS)
 	ebiten.SetCursorShape(ebiten.CursorShapeDefault)
 
+	resetInventory()
+
 	loadSettings()
 	theme := gs.Theme
 	if theme == "" {

--- a/inventory.go
+++ b/inventory.go
@@ -22,6 +22,7 @@ var (
 func resetInventory() {
 	inventoryMu.Lock()
 	inventoryItems = inventoryItems[:0]
+	inventoryNames = make(map[uint16]string)
 	inventoryMu.Unlock()
 	inventoryDirty = true
 }


### PR DESCRIPTION
## Summary
- Reinitialize inventory map when clearing items
- Reset inventory during game initialization for a clean starting state

## Testing
- `gofmt -w inventory.go game.go`
- `go vet ./...` *(fails: X11 extensions, ALSA, GTK pkg-config files missing)*

------
https://chatgpt.com/codex/tasks/task_e_689db325a70c832a8104b2f1e8a6c185