### PR TITLE
Handle legacy padding in inventory stream

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -518,10 +518,12 @@ func parseInventory(data []byte) ([]byte, bool) {
 			return nil, false
 		}
 		data = data[1:]
+	case kInvCmdLegacyPadding:
+		// ignore legacy padding byte
 	default:
 		logError("inventory: unexpected trailing cmd %d", cmd)
 	}
-	for len(data) > 0 && data[0] == 0 {
+	for len(data) > 0 && (data[0] == 0 || data[0] == kInvCmdLegacyPadding) {
 		data = data[1:]
 	}
 	inventoryDirty = true

--- a/inventory_packets_test.go
+++ b/inventory_packets_test.go
@@ -56,3 +56,22 @@ func TestParseInventoryOther(t *testing.T) {
 		t.Fatalf("inventoryDirty not set")
 	}
 }
+
+func TestParseInventoryTrailingB1(t *testing.T) {
+	resetInventory()
+	inventoryDirty = false
+	data := []byte{
+		byte(kInvCmdFull), 1, 0x00, 0x00, 0x64,
+		kInvCmdLegacyPadding, byte(kInvCmdNone), 0x55,
+	}
+	rest, ok := parseInventory(data)
+	if !ok {
+		t.Fatalf("parse failed")
+	}
+	if len(rest) != 1 || rest[0] != 0x55 {
+		t.Fatalf("unexpected rest %v", rest)
+	}
+	if !inventoryDirty {
+		t.Fatalf("inventoryDirty not set")
+	}
+}

--- a/util.go
+++ b/util.go
@@ -182,7 +182,8 @@ const (
 	kInvCmdMultiple
 	kInvCmdName
 
-	kInvCmdIndex = 0x80
+	kInvCmdIndex         = 0x80
+	kInvCmdLegacyPadding = 0xB1 // trailing byte in legacy inventory streams
 )
 
 // item slots from Public_cl.h


### PR DESCRIPTION
## Summary
- Define `kInvCmdLegacyPadding` for stray 0xB1 bytes in inventory packets
- Ignore legacy padding when parsing inventory commands
- Add test covering a packet with a trailing 0xB1 byte

## Testing
- `gofmt -w util.go draw.go inventory_packets_test.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689dd66e613c832a822a25438743866f