### PR TITLE
Avoid cancel after PCAP replay

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,8 +155,9 @@ func main() {
 		go func() {
 			if err := replayPCAP(ctx, pcapPath); err != nil {
 				log.Printf("replay PCAP: %v", err)
+			} else {
+				log.Print("PCAP replay complete")
 			}
-			cancel()
 		}()
 		<-ctx.Done()
 		return


### PR DESCRIPTION
## Summary
- remove unconditional cancel after `replayPCAP`
- log PCAP replay completion

## Testing
- `gofmt -w main.go`
- `go vet ./...` *(fails: Package alsa was not found; X11 and gtk+-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e1414a54c832a9f2e0422359cf300