### PR TITLE
Handle unshare messages more flexibly

### DIFF
--- a/text_parsers.go
+++ b/text_parsers.go
@@ -127,7 +127,7 @@ func parseShareText(raw []byte, s string) bool {
 			playersDirty = true
 		}
 		return true
-	case strings.HasSuffix(s, " is no longer sharing experiences with you."):
+	case strings.Contains(s, " is no longer sharing experiences with you"):
 		name := firstTagContent(raw, 'p', 'n')
 		if name != "" {
 			playersMu.Lock()


### PR DESCRIPTION
## Summary
- Handle "no longer sharing experiences with you" messages even if extra text follows

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a264959544832aaf0823013d764815