### PR TITLE
Handle BEPP unshare messages

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -110,7 +110,7 @@ func decodeBEPP(data []byte) string {
 		if text != "" {
 			return "info: " + text
 		}
-	case "sh":
+	case "sh", "su":
 		parseShareText(raw, text)
 		if text != "" {
 			return text

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -127,7 +127,7 @@ func parseShareText(raw []byte, s string) bool {
 			playersDirty = true
 		}
 		return true
-	case strings.HasSuffix(s, " is no longer sharing experiences with you."):
+	case strings.Contains(s, " is no longer sharing experiences with you"):
 		name := firstTagContent(raw, 'p', 'n')
 		if name != "" {
 			playersMu.Lock()


### PR DESCRIPTION
## Summary
- Process BEPP `su` messages so we detect when someone stops sharing experiences with you

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a264959544832aaf0823013d764815