### PR TITLE
Parse hero share events

### DIFF
--- a/text_parsers_share_test.go
+++ b/text_parsers_share_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestParseShareTextHeroShareUnshareOthers(t *testing.T) {
+	playerName = "Hero"
+	players = make(map[string]*Player)
+
+	// Hero shares Bob
+	shareRaw := append(pn("Hero"), []byte(" is sharing experiences with ")...)
+	shareRaw = append(shareRaw, pn("Bob")...)
+	shareRaw = append(shareRaw, '.')
+	parseShareText(shareRaw, "Hero is sharing experiences with Bob.")
+	if p, ok := players["Bob"]; !ok || !p.Sharee {
+		t.Fatalf("Bob not marked sharee after share: %+v", p)
+	}
+
+	// Hero unshares Bob
+	unshareRaw := append(pn("Hero"), []byte(" is no longer sharing experiences with ")...)
+	unshareRaw = append(unshareRaw, pn("Bob")...)
+	unshareRaw = append(unshareRaw, '.')
+	parseShareText(unshareRaw, "Hero is no longer sharing experiences with Bob.")
+	if p, ok := players["Bob"]; ok && p.Sharee {
+		t.Fatalf("Bob still marked sharee after unshare: %+v", p)
+	}
+}


### PR DESCRIPTION
## Summary
- parse third-person messages when your hero shares or unshares others
- track share targets so italics/bold-italics update correctly
- add tests for hero share and unshare handling

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a273bd8acc832a9961d7be8a78ad98