### PR TITLE
Expand fake mode for share detection and extra bubble types

### DIFF
--- a/fake.go
+++ b/fake.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+// mobile pose helpers for orienting characters in fake mode.
+const (
+	poseStand uint8 = iota
+	poseWalk1
+	poseWalk2
+	posePunch
+	poseMax
+)
+
+const (
+	facingEast uint8 = iota
+	facingSE
+	facingSouth
+	facingSW
+	facingWest
+	facingNW
+	facingNorth
+	facingNE
+)
+
+func mobilePose(action, facing uint8) uint8 {
+	return facing*poseMax + action
+}
+
+// pnTag wraps a name with -pn markers for name parsing.
+func pnTag(name string) []byte {
+	b := []byte{0xC2, 'p', 'n'}
+	b = append(b, []byte(name)...)
+	b = append(b, 0xC2, 'p', 'n')
+	return b
+}
+
+// bepp wraps plain text with a BEPP prefix and NUL terminator.
+func bepp(prefix string, msg []byte) []byte {
+	b := []byte{0xC2}
+	b = append(b, prefix[0], prefix[1])
+	b = append(b, msg...)
+	b = append(b, 0)
+	return b
+}
+
+// runFakeMode injects sample share and fallen messages using real server
+// formats captured from PCAP data. It allows testing client behavior without
+// connecting to the live server.
+func runFakeMode(ctx context.Context) {
+	go func() {
+		select {
+		case <-gameStarted:
+		case <-ctx.Done():
+			return
+		}
+
+		playerName = "Hero"
+
+		// Populate simple player descriptors and mobiles so Hero and Bob
+		// appear in the player list and on screen without a server
+		// connection.
+		updatePlayerAppearance("Hero", 447, nil, false)
+		updatePlayerAppearance("Bob", 447, nil, false)
+		stateMu.Lock()
+		playerIndex = 0
+		state.descriptors[0] = frameDescriptor{Index: 0, Type: kDescPlayer, PictID: 447, Name: "Hero"}
+		state.descriptors[1] = frameDescriptor{Index: 1, Type: kDescPlayer, PictID: 447, Name: "Bob"}
+		state.mobiles[0] = frameMobile{Index: 0, State: mobilePose(poseStand, facingEast), H: -16, V: 0}
+		state.mobiles[1] = frameMobile{Index: 1, State: mobilePose(poseStand, facingWest), H: 16, V: 0}
+
+		// Lay out a tiny square room for the pair to inhabit.
+		state.pictures = []framePicture{
+			{PictID: 3038, H: -32, V: -32, Plane: -1},
+			{PictID: 3038, H: 0, V: -32, Plane: -1},
+			{PictID: 3038, H: -32, V: 0, Plane: -1},
+			{PictID: 3038, H: 0, V: 0, Plane: -1},
+			{PictID: 3039, H: -32, V: -64, Plane: 0}, // north wall
+			{PictID: 3039, H: 0, V: -64, Plane: 0},
+			{PictID: 3039, H: -64, V: -32, Plane: 0}, // west wall
+			{PictID: 3039, H: -64, V: 0, Plane: 0},
+			{PictID: 3039, H: 32, V: -32, Plane: 0}, // east wall
+			{PictID: 3039, H: 32, V: 0, Plane: 0},
+			{PictID: 3039, H: -32, V: 32, Plane: 0}, // south wall
+			{PictID: 3039, H: 0, V: 32, Plane: 0},
+			{PictID: 3040, H: -16, V: -16, Plane: 1}, // decorative rug
+		}
+
+		prepareRenderCacheLocked()
+		stateMu.Unlock()
+		playersDirty = true
+
+		// Helper to append a bubble and show corresponding chat message.
+		emitBubble := func(idx uint8, typ int, name, verb, txt string) {
+			stateMu.Lock()
+			state.bubbles = append(state.bubbles, bubble{Index: idx, Text: txt, Type: typ, CreatedFrame: frameCounter})
+			stateMu.Unlock()
+			switch verb {
+			case "", bubbleVerbVerbatim:
+				chatMessage(txt)
+			case bubbleVerbParentheses:
+				chatMessage(name + " " + txt)
+			default:
+				chatMessage(name + " " + verb + ", " + txt)
+			}
+		}
+
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		step := 0
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			switch step {
+			case 0: // You share Bob
+				msg := append([]byte("You are sharing experiences with "), pnTag("Bob")...)
+				msg = append(msg, '.')
+				handleInfoText(append(bepp("sh", msg), '\r'))
+			case 1: // Bob shares you
+				msg := append(pnTag("Bob"), []byte(" is sharing experiences with you.")...)
+				handleInfoText(append(bepp("sh", msg), '\r'))
+			case 2: // Hero speaks
+				emitBubble(0, kBubbleNormal, "Hero", "says", "Hello there!")
+			case 3: // Bob whispers
+				emitBubble(1, kBubbleWhisper, "Bob", "whispers", "psst...")
+			case 4: // Hero yells
+				emitBubble(0, kBubbleYell, "Hero", "yells", "Watch out!")
+			case 5: // Bob thinks
+				emitBubble(1, kBubbleThought, "Bob", "thinks", "I wonder...")
+			case 6: // Bob thinks to you
+				emitBubble(1, kBubbleThought, "Bob", "thinks to you", "Hello Hero")
+			case 7: // Bob acts
+				emitBubble(1, kBubblePlayerAction, "Bob", bubbleVerbParentheses, "waves excitedly")
+			case 8: // Bob falls
+				msg := append(pnTag("Bob"), []byte(" has fallen")...)
+				handleInfoText(append(msg, '\r'))
+			case 9: // Bob recovers
+				msg := append(pnTag("Bob"), []byte(" is no longer fallen")...)
+				handleInfoText(append(msg, '\r'))
+			case 10: // You unshare Bob
+				msg := append([]byte("You are no longer sharing experiences with "), pnTag("Bob")...)
+				msg = append(msg, '.')
+				handleInfoText(append(bepp("su", msg), '\r'))
+			case 11: // Bob unshares you
+				msg := append(pnTag("Bob"), []byte(" is no longer sharing experiences with you.")...)
+				handleInfoText(append(bepp("su", msg), '\r'))
+			}
+			step = (step + 1) % 12
+		}
+	}()
+}

--- a/game.go
+++ b/game.go
@@ -972,7 +972,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	worldRT.Clear()
 
 	// Render splash or live frame into worldRT using offscreen integer scale
-	if clmov == "" && tcpConn == nil && pcapPath == "" {
+	if clmov == "" && tcpConn == nil && pcapPath == "" && !fake {
 		prev := gs.GameScale
 		gs.GameScale = float64(offIntScale)
 		drawSplash(worldRT, 0, 0)

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 	demo          bool
 	clmov         string
 	pcapPath      string
+	fake          bool
 	blockSound    bool
 	blockBubbles  bool
 	blockTTS      bool
@@ -42,6 +43,7 @@ var (
 func main() {
 	flag.StringVar(&clmov, "clmov", "", "play back a .clMov file")
 	flag.StringVar(&pcapPath, "pcap", "", "replay network frames from a .pcap/.pcapng file")
+	flag.BoolVar(&fake, "fake", false, "simulate server messages without connecting")
 	clientVer := flag.Int("client-version", 1445, "client version number (for testing)")
 	flag.BoolVar(&doDebug, "debug", false, "verbose/debug logging")
 	flag.BoolVar(&eui.CacheCheck, "cacheCheck", false, "display window and item render counts")
@@ -157,6 +159,18 @@ func main() {
 					log.Print("PCAP replay complete")
 				}
 			}()
+			<-ctx.Done()
+			return
+		}
+
+		if fake {
+			drawStateEncrypted = false
+			if (gs.precacheSounds || gs.precacheImages) && !assetsPrecached {
+				for !assetsPrecached {
+					time.Sleep(time.Millisecond * 100)
+				}
+			}
+			runFakeMode(ctx)
 			<-ctx.Done()
 			return
 		}

--- a/ui.go
+++ b/ui.go
@@ -163,7 +163,7 @@ func initUI() {
 
 	if status.NeedImages || status.NeedSounds {
 		downloadWin.MarkOpen()
-	} else if clmov == "" && pcapPath == "" {
+	} else if clmov == "" && pcapPath == "" && !fake {
 		loginWin.MarkOpen()
 	}
 }


### PR DESCRIPTION
## Summary
- add BEPP-wrapped share/unshare messages so fake mode updates share state
- handle action-style verbs and add a sample player action bubble in the cycle
- extend fake message loop to keep exercising think and action bubbles continuously
- seed fake mode with pose helpers and a tiny room so Hero and Bob face one another

## Testing
- `gofmt -w fake.go`
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68a2927bbfa8832aab2e761ed7441718