### PR TITLE
Implement auto volume normalisation

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -56,33 +56,35 @@ var gsdef settings = settings{
 	BubbleMonsters:     true,
 	BubbleNarration:    true,
 
-	MotionSmoothing:   true,
-	BlendMobiles:      false,
-	BlendPicts:        false,
-	BlendAmount:       1.0,
-	MobileBlendAmount: 0.33,
-	MobileBlendFrames: 10,
-	PictBlendFrames:   10,
-	DenoiseImages:     false,
-	DenoiseSharpness:  4.0,
-	DenoiseAmount:     0.2,
-	ShowFPS:           true,
-	UIScale:           1.0,
-	Fullscreen:        false,
-	Volume:            0.10,
-	Mute:              false,
-	GameScale:         2,
-	BarPlacement:      BarPlacementBottom,
-	Theme:             "",
-	MessagesToConsole: false,
-	ChatTTS:           false,
-	ChatTTSVolume:     1.0,
-	WindowTiling:      false,
-	WindowSnapping:    false,
-	AnyGameWindowSize: true,
-	IntegerScaling:    false,
-	NoCaching:         false,
-	PotatoComputer:    false,
+	MotionSmoothing:    true,
+	BlendMobiles:       false,
+	BlendPicts:         false,
+	BlendAmount:        1.0,
+	MobileBlendAmount:  0.33,
+	MobileBlendFrames:  10,
+	PictBlendFrames:    10,
+	DenoiseImages:      false,
+	DenoiseSharpness:   4.0,
+	DenoiseAmount:      0.2,
+	ShowFPS:            true,
+	UIScale:            1.0,
+	Fullscreen:         false,
+	Volume:             0.10,
+	Mute:               false,
+	AutoVolume:         false,
+	AutoVolumeStrength: 1.0,
+	GameScale:          2,
+	BarPlacement:       BarPlacementBottom,
+	Theme:              "",
+	MessagesToConsole:  false,
+	ChatTTS:            false,
+	ChatTTSVolume:      1.0,
+	WindowTiling:       false,
+	WindowSnapping:     false,
+	AnyGameWindowSize:  true,
+	IntegerScaling:     false,
+	NoCaching:          false,
+	PotatoComputer:     false,
 
 	GameWindow:      WindowState{Open: true},
 	InventoryWindow: WindowState{Open: true},
@@ -140,31 +142,33 @@ type settings struct {
 	BubbleMonsters     bool
 	BubbleNarration    bool
 
-	MotionSmoothing   bool
-	BlendMobiles      bool
-	BlendPicts        bool
-	BlendAmount       float64
-	MobileBlendAmount float64
-	MobileBlendFrames int
-	PictBlendFrames   int
-	DenoiseImages     bool
-	DenoiseSharpness  float64
-	DenoiseAmount     float64
-	ShowFPS           bool
-	UIScale           float64
-	Fullscreen        bool
-	Volume            float64
-	Mute              bool
-	AnyGameWindowSize bool // allow arbitrary game window sizes
-	GameScale         float64
-	BarPlacement      BarPlacement
-	Theme             string
-	MessagesToConsole bool
-	ChatTTS           bool
-	ChatTTSVolume     float64
-	WindowTiling      bool
-	WindowSnapping    bool
-	IntegerScaling    bool
+	MotionSmoothing    bool
+	BlendMobiles       bool
+	BlendPicts         bool
+	BlendAmount        float64
+	MobileBlendAmount  float64
+	MobileBlendFrames  int
+	PictBlendFrames    int
+	DenoiseImages      bool
+	DenoiseSharpness   float64
+	DenoiseAmount      float64
+	ShowFPS            bool
+	UIScale            float64
+	Fullscreen         bool
+	Volume             float64
+	Mute               bool
+	AutoVolume         bool
+	AutoVolumeStrength float64
+	AnyGameWindowSize  bool // allow arbitrary game window sizes
+	GameScale          float64
+	BarPlacement       BarPlacement
+	Theme              string
+	MessagesToConsole  bool
+	ChatTTS            bool
+	ChatTTSVolume      float64
+	WindowTiling       bool
+	WindowSnapping     bool
+	IntegerScaling     bool
 
 	GameWindow      WindowState
 	InventoryWindow WindowState

--- a/sound.go
+++ b/sound.go
@@ -22,7 +22,10 @@ var (
 	pcmCache = make(map[uint16][]byte)
 
 	audioContext *audio.Context
-	soundPlayers = make(map[*audio.Player]struct{})
+	// soundPlayers tracks active audio players and their individual
+	// auto-volume gains so that volume changes can be reapplied
+	// correctly when settings change.
+	soundPlayers = make(map[*audio.Player]float64)
 )
 
 // stopAllSounds halts and disposes all currently playing audio players.
@@ -98,6 +101,7 @@ func playSound(ids ...uint16) {
 
 		var wg sync.WaitGroup
 		maxCh := make(chan int32, chunks)
+		rmsCh := make(chan float64, chunks)
 
 		for start := 0; start < maxSamples; start += chunkSize {
 			end := start + chunkSize
@@ -108,6 +112,7 @@ func playSound(ids ...uint16) {
 			go func(start, end int) {
 				defer wg.Done()
 				localMax := int32(0)
+				var localSum float64
 				for i := start; i < end; i++ {
 					var sum int32
 					for _, pcm := range sounds {
@@ -123,12 +128,15 @@ func playSound(ids ...uint16) {
 					if sum > localMax {
 						localMax = sum
 					}
+					localSum += float64(sum) * float64(sum)
 				}
 				maxCh <- localMax
+				rmsCh <- localSum
 			}(start, end)
 		}
 		wg.Wait()
 		close(maxCh)
+		close(rmsCh)
 
 		maxVal := int32(0)
 		for v := range maxCh {
@@ -136,11 +144,31 @@ func playSound(ids ...uint16) {
 				maxVal = v
 			}
 		}
+		var sumSquares float64
+		for v := range rmsCh {
+			sumSquares += v
+		}
 
 		// Apply peak normalization and reduce volume for overlapping sounds
 		scale := 1 / float64(len(sounds))
 		if maxVal > 0 {
 			scale *= math.Min(1.0, 32767.0/float64(maxVal))
+		}
+
+		// Calculate RMS of the mixed samples after scaling
+		rms := 0.0
+		if maxSamples > 0 {
+			rms = math.Sqrt(sumSquares/float64(maxSamples)) * scale
+		}
+		autoGain := 1.0
+		if gs.AutoVolume && rms > 0 {
+			// target RMS as a fraction of full scale (approx 25%)
+			target := 0.25 * 32767.0
+			g := target / rms
+			autoGain = 1 + (g-1)*gs.AutoVolumeStrength
+			if autoGain > 8 {
+				autoGain = 8
+			}
 		}
 
 		out := make([]byte, len(mixed)*2)
@@ -168,7 +196,7 @@ func playSound(ids ...uint16) {
 		wg.Wait()
 
 		p := audioContext.NewPlayerFromBytes(out)
-		vol := gs.Volume
+		vol := gs.Volume * autoGain
 		if gs.Mute {
 			vol = 0
 		}
@@ -187,7 +215,7 @@ func playSound(ids ...uint16) {
 			p.Close()
 			return
 		}
-		soundPlayers[p] = struct{}{}
+		soundPlayers[p] = autoGain
 		soundMu.Unlock()
 
 		//logDebug("playSound playing")
@@ -208,18 +236,22 @@ func updateSoundVolume() {
 	}
 
 	soundMu.Lock()
-	players := make([]*audio.Player, 0, len(soundPlayers))
-	for sp := range soundPlayers {
-		players = append(players, sp)
+	type playerGain struct {
+		p *audio.Player
+		g float64
+	}
+	players := make([]playerGain, 0, len(soundPlayers))
+	for sp, g := range soundPlayers {
+		players = append(players, playerGain{sp, g})
 	}
 	soundMu.Unlock()
 
 	stopped := make([]*audio.Player, 0)
-	for _, sp := range players {
-		if sp.IsPlaying() {
-			sp.SetVolume(vol)
+	for _, pg := range players {
+		if pg.p.IsPlaying() {
+			pg.p.SetVolume(vol * pg.g)
 		} else {
-			stopped = append(stopped, sp)
+			stopped = append(stopped, pg.p)
 		}
 	}
 

--- a/sound_test.go
+++ b/sound_test.go
@@ -69,7 +69,7 @@ func TestPlaySoundIDs(t *testing.T) {
 
 	messages = nil
 	soundMu.Lock()
-	soundPlayers = make(map[*audio.Player]struct{})
+	soundPlayers = make(map[*audio.Player]float64)
 	soundMu.Unlock()
 
 	playSound(1)


### PR DESCRIPTION
## Summary
- add auto-volume settings fields
- compute RMS-based gain and apply to sound playback
- track per-player gain so volume updates respect auto normalisation

## Testing
- `go fmt sound.go settings.go sound_test.go`
- `go vet ./...` *(fails: Package alsa was not found, X11/Xrandr.h missing, gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a31c7458f4832abae9965b2edf8c47