### PR TITLE
Use dB conversion for tune playback volume

### DIFF
--- a/tune.go
+++ b/tune.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+func dbToGain(db float64) float64 {
+	return math.Pow(10, db/20)
+}
+
 // playTuneSimple parses a space-separated list of note names and plays them as a
 // sequence of sine waves. Each note is assumed to be a quarter note at a
 // fixed tempo and octave if not specified (default octave 4).
@@ -31,7 +35,7 @@ func playTuneSimple(tune string) {
 		}
 	}
 	p := audioContext.NewPlayerFromBytes(buf)
-	p.SetVolume(0.2)
+	p.SetVolume(dbToGain(-14))
 	p.Play()
 }
 


### PR DESCRIPTION
## Summary
- Add `dbToGain` helper for decibel conversion
- Use decibel-based gain when playing simple tunes

## Testing
- `gofmt -w tune.go`
- `go vet ./...` *(fails: Package alsa not found; Xrandr.h not found; gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a329050924832a9b52ef4c9c2d4306