### PR TITLE
Use dB for chat TTS volume

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"io"
+	"math"
 	"sync"
 	"time"
 
@@ -16,6 +17,10 @@ var (
 	ttsPlayers   = make(map[*audio.Player]struct{})
 	ttsPlayersMu sync.Mutex
 )
+
+func dbToGain(db float64) float64 {
+	return math.Pow(10, db/20)
+}
 
 func stopAllTTS() {
 	ttsPlayersMu.Lock()
@@ -63,9 +68,9 @@ func speakChatMessage(msg string) {
 		ttsPlayers[p] = struct{}{}
 		ttsPlayersMu.Unlock()
 
-		vol := gs.ChatTTSVolume * gs.Volume
-		if gs.Mute {
-			vol = 0
+		vol := 0.0
+		if !gs.Mute {
+			vol = dbToGain(gs.ChatTTSVolumeDB + gs.VolumeDB)
 		}
 		p.SetVolume(vol)
 		p.Play()

--- a/settings.go
+++ b/settings.go
@@ -70,13 +70,14 @@ var gsdef settings = settings{
 	UIScale:           1.0,
 	Fullscreen:        false,
 	Volume:            0.10,
+	VolumeDB:          -20,
 	Mute:              false,
 	GameScale:         2,
 	BarPlacement:      BarPlacementBottom,
 	Theme:             "",
 	MessagesToConsole: false,
 	ChatTTS:           false,
-	ChatTTSVolume:     1.0,
+	ChatTTSVolumeDB:   0,
 	WindowTiling:      false,
 	WindowSnapping:    false,
 	AnyGameWindowSize: true,
@@ -154,6 +155,7 @@ type settings struct {
 	UIScale           float64
 	Fullscreen        bool
 	Volume            float64
+	VolumeDB          float64
 	Mute              bool
 	AnyGameWindowSize bool // allow arbitrary game window sizes
 	GameScale         float64
@@ -161,7 +163,7 @@ type settings struct {
 	Theme             string
 	MessagesToConsole bool
 	ChatTTS           bool
-	ChatTTSVolume     float64
+	ChatTTSVolumeDB   float64
 	WindowTiling      bool
 	WindowSnapping    bool
 	IntegerScaling    bool
@@ -239,6 +241,7 @@ func loadSettings() bool {
 		applyQualityPreset("High")
 	}
 
+	gs.Volume = dbToGain(gs.VolumeDB)
 	clampWindowSettings()
 	return true
 }

--- a/ui.go
+++ b/ui.go
@@ -231,14 +231,15 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 	row1.AddItem(exitSessBtn)
 
 	volumeSlider, volumeEvents := eui.NewSlider()
-	volumeSlider.MinValue = 0
-	volumeSlider.MaxValue = 1
-	volumeSlider.Value = float32(gs.Volume)
+	volumeSlider.MinValue = -60
+	volumeSlider.MaxValue = 0
+	volumeSlider.Value = float32(gs.VolumeDB)
 	volumeSlider.Size = eui.Point{X: 150, Y: buttonHeight}
 	volumeSlider.FontSize = 9
 	volumeEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
-			gs.Volume = float64(ev.Value)
+			gs.VolumeDB = float64(ev.Value)
+			gs.Volume = dbToGain(gs.VolumeDB)
 			settingsDirty = true
 			updateSoundVolume()
 		}
@@ -1257,9 +1258,9 @@ func makeSettingsWindow() {
 	chatTTSRow.AddItem(chatTTSCB)
 
 	chatTTSSlider, chatTTSSliderEvents := eui.NewSlider()
-	chatTTSSlider.MinValue = 0
-	chatTTSSlider.MaxValue = 1
-	chatTTSSlider.Value = float32(gs.ChatTTSVolume)
+	chatTTSSlider.MinValue = -60
+	chatTTSSlider.MaxValue = 0
+	chatTTSSlider.Value = float32(gs.ChatTTSVolumeDB)
 	chatTTSSlider.Size = eui.Point{X: 100, Y: 24}
 	chatTTSSlider.FontSize = 9
 	chatTTSSliderEvents.Handle = func(ev eui.UIEvent) {
@@ -1267,7 +1268,7 @@ func makeSettingsWindow() {
 			SettingsLock.Lock()
 			defer SettingsLock.Unlock()
 
-			gs.ChatTTSVolume = float64(ev.Value)
+			gs.ChatTTSVolumeDB = float64(ev.Value)
 			settingsDirty = true
 		}
 	}


### PR DESCRIPTION
## Summary
- track chat text-to-speech volume in dB
- expose master and chat TTS volume sliders with dB ranges
- mix chat TTS gain from chat and master volume dB values

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; X11/extensions/Xrandr.h missing; Package gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a329025514832a8283d21260fc8263