### PR TITLE
Remove legacy render mode options

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -112,12 +112,6 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 		return
 	}
 	tailX, tailY := x, y
-	ox, oy := 0, 0
-	if !gs.AnyGameWindowSize {
-		ox, oy = gameContentOrigin()
-		x -= ox
-		y -= oy
-	}
 
 	sw := int(float64(gameAreaSizeX) * gs.GameScale)
 	sh := int(float64(gameAreaSizeY) * gs.GameScale)
@@ -133,12 +127,6 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	height := lineHeight*len(lines) + 2*pad
 
 	left, top, right, bottom := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, far)
-	if !gs.AnyGameWindowSize {
-		left += ox
-		right += ox
-		top += oy
-		bottom += oy
-	}
 	baseX := left + width/2
 
 	bgR, bgG, bgB, bgA := bgCol.RGBA()

--- a/settings.go
+++ b/settings.go
@@ -79,8 +79,6 @@ var gsdef settings = settings{
 	ChatTTSVolume:     1.0,
 	WindowTiling:      false,
 	WindowSnapping:    false,
-	AnyGameWindowSize: true,
-	IntegerScaling:    false,
 	NoCaching:         false,
 	PotatoComputer:    false,
 
@@ -156,7 +154,6 @@ type settings struct {
 	Fullscreen        bool
 	Volume            float64
 	Mute              bool
-	AnyGameWindowSize bool // allow arbitrary game window sizes
 	GameScale         float64
 	BarPlacement      BarPlacement
 	Theme             string
@@ -165,7 +162,6 @@ type settings struct {
 	ChatTTSVolume     float64
 	WindowTiling      bool
 	WindowSnapping    bool
-	IntegerScaling    bool
 
 	GameWindow      WindowState
 	InventoryWindow WindowState
@@ -246,8 +242,6 @@ func loadSettings() bool {
 }
 
 func applySettings() {
-	// Fixed-size mode is deprecated; force any-size mode on.
-	gs.AnyGameWindowSize = true
 	updateBubbleVisibility()
 	eui.SetWindowTiling(gs.WindowTiling)
 	eui.SetWindowSnapping(gs.WindowSnapping)

--- a/ui.go
+++ b/ui.go
@@ -1739,9 +1739,8 @@ func makeGraphicsWindow() {
 	if graphicsWin != nil {
 		return
 	}
-	// Column widths
+	// Column width
 	var leftW float32 = 260
-	var rightW float32 = 260
 
 	graphicsWin = eui.NewWindow()
 	graphicsWin.Title = "Screen Size Settings"
@@ -1751,14 +1750,11 @@ func makeGraphicsWindow() {
 	graphicsWin.Movable = true
 	graphicsWin.SetZone(eui.HZoneCenterLeft, eui.VZoneMiddleTop)
 
-	// Outer horizontal flow with two vertical columns
+	// Outer container
 	outer := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL}
 
 	simple := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	simple.Size = eui.Point{X: leftW, Y: 10}
-
-	advanced := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
-	advanced.Size = eui.Point{X: rightW, Y: 10}
 
 	// Simple (left) controls
 	uiScaleSlider, uiScaleEvents := eui.NewSlider()
@@ -1821,7 +1817,7 @@ func makeGraphicsWindow() {
 	}
 	renderScale.Value = float32(math.Round(gs.GameScale))
 	renderScale.Size = eui.Point{X: leftW - 10, Y: 24}
-	renderScale.Tooltip = "Game render zoom (1x–10x). In Integer mode uses nearest filtering."
+	renderScale.Tooltip = "Game render zoom (1x–10x)."
 	renderScaleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			// Round to integer steps and clamp
@@ -1843,25 +1839,7 @@ func makeGraphicsWindow() {
 	}
 	simple.AddItem(renderScale)
 
-	// Advanced (right) controls
-	intCB, intEvents := eui.NewCheckbox()
-	intCB.Text = "Integer scale (sharper, faster)"
-	intCB.Size = eui.Point{X: rightW, Y: 24}
-	intCB.Checked = gs.IntegerScaling
-	intEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventCheckboxChanged {
-			gs.IntegerScaling = ev.Checked
-			initFont()
-			if gameWin != nil {
-				gameWin.Refresh()
-			}
-			settingsDirty = true
-		}
-	}
-	advanced.AddItem(intCB)
-
 	outer.AddItem(simple)
-	outer.AddItem(advanced)
 	graphicsWin.AddItem(outer)
 	graphicsWin.AddWindow(false)
 }


### PR DESCRIPTION
## Summary
- drop AnyGameWindowSize and IntegerScaling settings
- simplify render scaling logic to always fit the window
- remove integer scaling UI option and related bubble offsets

## Testing
- `gofmt -w bubble.go game.go settings.go ui.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a38b536018832a9aeb460135826769