### PR TITLE
Remove integer scaling and render overlays post-scale

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -107,17 +107,13 @@ func bubbleColors(typ int) (border, bg, text color.Color) {
 // parameter is currently unused but retained for future compatibility with the
 // original bubble images. The colors of the border, background, and text can be
 // customized via borderCol, bgCol, and textCol respectively.
-func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, noArrow bool, borderCol, bgCol, textCol color.Color) {
+func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, noArrow bool, ox, oy int, borderCol, bgCol, textCol color.Color) {
 	if txt == "" {
 		return
 	}
 	tailX, tailY := x, y
-	ox, oy := 0, 0
-	if !gs.AnyGameWindowSize {
-		ox, oy = gameContentOrigin()
-		x -= ox
-		y -= oy
-	}
+	x -= ox
+	y -= oy
 
 	sw := int(float64(gameAreaSizeX) * gs.GameScale)
 	sh := int(float64(gameAreaSizeY) * gs.GameScale)
@@ -133,12 +129,10 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	height := lineHeight*len(lines) + 2*pad
 
 	left, top, right, bottom := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, far)
-	if !gs.AnyGameWindowSize {
-		left += ox
-		right += ox
-		top += oy
-		bottom += oy
-	}
+	left += ox
+	right += ox
+	top += oy
+	bottom += oy
 	baseX := left + width/2
 
 	bgR, bgG, bgB, bgA := bgCol.RGBA()

--- a/settings.go
+++ b/settings.go
@@ -79,8 +79,6 @@ var gsdef settings = settings{
 	ChatTTSVolume:     1.0,
 	WindowTiling:      false,
 	WindowSnapping:    false,
-	AnyGameWindowSize: true,
-	IntegerScaling:    false,
 	NoCaching:         false,
 	PotatoComputer:    false,
 
@@ -156,7 +154,6 @@ type settings struct {
 	Fullscreen        bool
 	Volume            float64
 	Mute              bool
-	AnyGameWindowSize bool // allow arbitrary game window sizes
 	GameScale         float64
 	BarPlacement      BarPlacement
 	Theme             string
@@ -165,7 +162,6 @@ type settings struct {
 	ChatTTSVolume     float64
 	WindowTiling      bool
 	WindowSnapping    bool
-	IntegerScaling    bool
 
 	GameWindow      WindowState
 	InventoryWindow WindowState
@@ -246,8 +242,6 @@ func loadSettings() bool {
 }
 
 func applySettings() {
-	// Fixed-size mode is deprecated; force any-size mode on.
-	gs.AnyGameWindowSize = true
 	updateBubbleVisibility()
 	eui.SetWindowTiling(gs.WindowTiling)
 	eui.SetWindowSnapping(gs.WindowSnapping)

--- a/ui.go
+++ b/ui.go
@@ -1741,7 +1741,6 @@ func makeGraphicsWindow() {
 	}
 	// Column widths
 	var leftW float32 = 260
-	var rightW float32 = 260
 
 	graphicsWin = eui.NewWindow()
 	graphicsWin.Title = "Screen Size Settings"
@@ -1756,9 +1755,6 @@ func makeGraphicsWindow() {
 
 	simple := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	simple.Size = eui.Point{X: leftW, Y: 10}
-
-	advanced := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
-	advanced.Size = eui.Point{X: rightW, Y: 10}
 
 	// Simple (left) controls
 	uiScaleSlider, uiScaleEvents := eui.NewSlider()
@@ -1821,7 +1817,7 @@ func makeGraphicsWindow() {
 	}
 	renderScale.Value = float32(math.Round(gs.GameScale))
 	renderScale.Size = eui.Point{X: leftW - 10, Y: 24}
-	renderScale.Tooltip = "Game render zoom (1x–10x). In Integer mode uses nearest filtering."
+	renderScale.Tooltip = "Game render zoom (1x–10x)."
 	renderScaleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			// Round to integer steps and clamp
@@ -1843,25 +1839,7 @@ func makeGraphicsWindow() {
 	}
 	simple.AddItem(renderScale)
 
-	// Advanced (right) controls
-	intCB, intEvents := eui.NewCheckbox()
-	intCB.Text = "Integer scale (sharper, faster)"
-	intCB.Size = eui.Point{X: rightW, Y: 24}
-	intCB.Checked = gs.IntegerScaling
-	intEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventCheckboxChanged {
-			gs.IntegerScaling = ev.Checked
-			initFont()
-			if gameWin != nil {
-				gameWin.Refresh()
-			}
-			settingsDirty = true
-		}
-	}
-	advanced.AddItem(intCB)
-
 	outer.AddItem(simple)
-	outer.AddItem(advanced)
 	graphicsWin.AddItem(outer)
 	graphicsWin.AddWindow(false)
 }


### PR DESCRIPTION
## Summary
- drop obsolete IntegerScaling and AnyGameWindowSize settings; arbitrary window sizes are now default
- render speech bubbles and name tags after scaling so they draw directly on the final game image

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68a392b77d84832a9ff0a36b1e3e47f3