### PR TITLE
Sort name tags deterministically

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -102,6 +102,15 @@ func sortMobiles(mobs []frameMobile) {
 	})
 }
 
+func sortMobilesNameTags(mobs []frameMobile) {
+	sort.Slice(mobs, func(i, j int) bool {
+		if mobs[i].H == mobs[j].H {
+			return mobs[i].V < mobs[j].V
+		}
+		return mobs[i].H > mobs[j].H
+	})
+}
+
 func sortDescriptors(descs []frameDescriptor) {
 	sort.Slice(descs, func(i, j int) bool {
 		return descs[i].Index < descs[j].Index


### PR DESCRIPTION
## Summary
- precompute mobile slice sorted right-to-left/top-to-bottom for name tag rendering
- use the pre-sorted slice when capturing draw snapshots to avoid map flicker

## Testing
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a34137b0832a9f34cbd8716236dc