### PR TITLE
Remove HiddenCharOpacity setting

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -40,7 +40,6 @@ var gsdef settings = settings{
 	BubbleOpacity:      0.7,
 	NameBgOpacity:      0.7,
 	BarOpacity:         0.5,
-	HiddenCharOpacity:  0.5,
 	SpeechBubbles:      true,
 	BubbleNormal:       true,
 	BubbleWhisper:      true,
@@ -123,7 +122,6 @@ type settings struct {
 	BubbleOpacity      float64
 	NameBgOpacity      float64
 	BarOpacity         float64
-	HiddenCharOpacity  float64
 	SpeechBubbles      bool
 	BubbleNormal       bool
 	BubbleWhisper      bool


### PR DESCRIPTION
## Summary
- remove unused HiddenCharOpacity from default settings and struct

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a58aee98832aa64b3858245c55fc