### PR TITLE
Guard descriptor side effects in movie playback

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -674,11 +674,15 @@ func parseDrawState(data []byte) error {
 		if clImages != nil {
 			d.Plane = clImages.Plane(uint32(d.PictID))
 		}
-		// Skip NPCs entirely for player list scanning.
+		// Skip NPCs entirely for player list scanning. Only update
+		// appearance and queue info requests when not in movie mode to
+		// avoid side effects during playback.
 		if d.Type != kDescNPC && d.Name != "" {
-			updatePlayerAppearance(d.Name, d.PictID, d.Colors, false)
-			// Opportunistically request full info for visible players.
-			queueInfoRequest(d.Name)
+			if !movieMode {
+				updatePlayerAppearance(d.Name, d.PictID, d.Colors, false)
+				// Opportunistically request full info for visible players.
+				queueInfoRequest(d.Name)
+			}
 		}
 		descs = append(descs, d)
 	}

--- a/movie_player.go
+++ b/movie_player.go
@@ -15,6 +15,7 @@ import (
 var (
 	shortUnits, _ = durafmt.DefaultUnitsCoder.Decode("y:yrs,wk:wks,d:d,h:h,m:m,s:s,ms:ms,us:us")
 	playingMovie  bool
+	movieMode     bool
 	movieWin      *eui.WindowData
 )
 
@@ -53,6 +54,7 @@ func newMoviePlayer(frames [][]byte, fps int, cancel context.CancelFunc) *movieP
 	serverFPS = float64(fps)
 	frameInterval = time.Second / time.Duration(fps)
 	playingMovie = true
+	movieMode = true
 	return &moviePlayer{
 		frames:      frames,
 		fps:         fps,
@@ -294,6 +296,7 @@ func (p *moviePlayer) makePlaybackWindow() {
 			p.cancel()
 		}
 		playingMovie = false
+		movieMode = false
 		// Clear the selected movie path and reopen the login window.
 		clmov = ""
 		pcapPath = ""
@@ -320,6 +323,7 @@ func (p *moviePlayer) run(ctx context.Context) {
 		case <-ctx.Done():
 			p.ticker.Stop()
 			playingMovie = false
+			movieMode = false
 			return
 		case <-p.ticker.C:
 			if p.playing {


### PR DESCRIPTION
## Summary
- Avoid updating player appearance or queueing info requests while parsing draw state in movie playback
- Track movie playback state with a dedicated `movieMode` flag

## Testing
- `go test ./...` *(fails: missing X11/ALSA/GTK development libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a76add44832ab0256c54a154bbe0