### PR TITLE
Remove fastBars setting and simplify bar interpolation

### DIFF
--- a/game.go
+++ b/game.go
@@ -1502,10 +1502,10 @@ func drawSpeechBubbles(screen *ebiten.Image, snap drawSnapshot, alpha float64) {
 	}
 }
 
-// lerpBar interpolates status bar values, skipping interpolation when
-// fastBars is enabled and the value decreases.
+// lerpBar interpolates status bar values, skipping interpolation when the
+// current value is lower than the previous.
 func lerpBar(prev, cur int, alpha float64) int {
-	if gs.fastBars && cur < prev {
+	if cur < prev {
 		return cur
 	}
 	return int(math.Round(float64(prev) + alpha*float64(cur-prev)))

--- a/settings.go
+++ b/settings.go
@@ -102,7 +102,6 @@ var gsdef settings = settings{
 	cacheWholeSheet:     true,
 	smoothMoving:        false,
 	dontShiftNewSprites: false,
-	fastBars:            true,
 	BarColorByValue:     false,
 	recordAssetStats:    false,
 }
@@ -182,7 +181,6 @@ type settings struct {
 	cacheWholeSheet     bool
 	smoothMoving        bool
 	dontShiftNewSprites bool
-	fastBars            bool
 	BarColorByValue     bool
 	recordAssetStats    bool
 	NoCaching           bool


### PR DESCRIPTION
## Summary
- drop unused fastBars configuration from settings and default values
- simplify status bar interpolation to skip only when current value drops

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3aa734e8c832a846b23868a2a88f5