### PR TITLE
Remove obsolete cacheWholeSheet setting

### DIFF
--- a/images.go
+++ b/images.go
@@ -177,7 +177,7 @@ func loadImageFrame(id uint16, frame int) *ebiten.Image {
 	innerWidth := sheet.Bounds().Dx() - 2
 	h := innerHeight / frames
 
-	if gs.cacheWholeSheet && !gs.NoCaching {
+	if !gs.NoCaching {
 		imageMu.Lock()
 		for f := 0; f < frames; f++ {
 			k := makeImageKey(id, f)
@@ -240,7 +240,7 @@ func loadMobileFrame(id uint16, state uint8, colors []byte) *ebiten.Image {
 		return nil
 	}
 
-	if gs.cacheWholeSheet && !gs.NoCaching {
+	if !gs.NoCaching {
 		imageMu.Lock()
 		for yy := 0; yy < 16; yy++ {
 			for xx := 0; xx < 16; xx++ {

--- a/settings.go
+++ b/settings.go
@@ -99,7 +99,6 @@ var gsdef settings = settings{
 	precacheImages:      false,
 	throttleSounds:      true,
 	lateInputUpdates:    false,
-	cacheWholeSheet:     true,
 	smoothMoving:        false,
 	dontShiftNewSprites: false,
 	fastBars:            true,
@@ -179,7 +178,6 @@ type settings struct {
 	precacheImages      bool
 	throttleSounds      bool
 	lateInputUpdates    bool
-	cacheWholeSheet     bool
 	smoothMoving        bool
 	dontShiftNewSprites bool
 	fastBars            bool
@@ -224,13 +222,17 @@ func loadSettings() bool {
 		return false
 	}
 
-	newGS := gsdef
-	if err := json.Unmarshal(data, &newGS); err != nil {
+	var tmp struct {
+		settings
+		CacheWholeSheet bool `json:"cacheWholeSheet,omitempty"`
+	}
+	tmp.settings = gsdef
+	if err := json.Unmarshal(data, &tmp); err != nil {
 		return false
 	}
 
-	if newGS.Version == SETTINGS_VERSION {
-		gs = newGS
+	if tmp.Version == SETTINGS_VERSION {
+		gs = tmp.settings
 	} else {
 		applyQualityPreset("High")
 	}


### PR DESCRIPTION
## Summary
- drop legacy cacheWholeSheet from settings and defaults
- simplify image caching checks to only respect NoCaching
- ignore cacheWholeSheet when loading old settings

## Testing
- `go build ./...`
- `go test ./...` *(fails: X11 display missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3aa674794832abc126e2c04299cdb