### PR TITLE
Disable smoothing while seeking movies

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -804,7 +804,7 @@ func parseDrawState(data []byte) error {
 	state.balance = bal
 	state.balanceMax = balMax
 	changed := false
-	if gs.BlendMobiles {
+	if gs.BlendMobiles && !seekingMov {
 		if len(descs) > 0 {
 			changed = true
 		}
@@ -844,7 +844,7 @@ func parseDrawState(data []byte) error {
 		newPics[i].Again = false
 	}
 	dx, dy, bgIdxs, ok := pictureShift(prevPics, newPics)
-	if gs.MotionSmoothing {
+	if gs.MotionSmoothing && !seekingMov {
 		if gs.smoothMoving {
 			logDebug("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, ok)
 			if !ok {
@@ -961,7 +961,7 @@ func parseDrawState(data []byte) error {
 	}
 	state.pictures = kept
 
-	needPrev := (gs.MotionSmoothing || gs.BlendMobiles) && ok
+	needPrev := (gs.MotionSmoothing || gs.BlendMobiles) && ok && !seekingMov
 	if needPrev {
 		if state.prevMobiles == nil {
 			state.prevMobiles = make(map[uint8]frameMobile)
@@ -971,7 +971,7 @@ func parseDrawState(data []byte) error {
 			state.prevMobiles[idx] = m
 		}
 	}
-	needAnimUpdate := (gs.MotionSmoothing || (gs.BlendMobiles && changed)) && ok
+	needAnimUpdate := (gs.MotionSmoothing || (gs.BlendMobiles && changed)) && ok && !seekingMov
 	if needAnimUpdate {
 		frameMu.Lock()
 		interval := frameInterval

--- a/movie_player.go
+++ b/movie_player.go
@@ -437,6 +437,7 @@ func (p *moviePlayer) skipForwardMilli(milli int) {
 
 func (p *moviePlayer) seek(idx int) {
 	seekingMov = true
+	defer func() { seekingMov = false }()
 
 	// Stop any currently playing sounds so scrubbing is silent.
 	stopAllSounds()
@@ -504,8 +505,6 @@ func (p *moviePlayer) seek(idx int) {
 	setInterpFPS(p.fps)
 	p.updateUI()
 	p.playing = wasPlaying
-
-	seekingMov = false
 }
 
 // maybeDecodeMessage applies a simple heuristic to determine whether a frame


### PR DESCRIPTION
## Summary
- skip mobile blending and picture smoothing during movie seeking
- ensure seeking flag wraps seek's intermediate frame parsing

## Testing
- `go test ./...` *(fails: GLFW display error)*

------
https://chatgpt.com/codex/tasks/task_e_68a3aa22c164832a97b3747c36ac485e