### PR TITLE
Add fast draw-state parsing during movie seek

### DIFF
--- a/movie_player.go
+++ b/movie_player.go
@@ -339,7 +339,7 @@ func (p *moviePlayer) step() {
 	}
 	m := p.frames[p.cur]
 	if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
-		handleDrawState(m)
+		handleDrawState(m, true)
 	} else {
 		// Advance the logical frame counter even when this movie frame
 		// does not contain a draw-state update so time-based effects
@@ -465,13 +465,17 @@ func (p *moviePlayer) seek(idx int) {
 
 	stateMu.Lock()
 	state = cloneDrawState(cp.state)
+	// Ensure render caches reflect the restored checkpoint state. The cache
+	// will be rebuilt again if additional frames are parsed.
+	prepareRenderCacheLocked()
 	stateMu.Unlock()
 	frameCounter = cp.idx
 
 	for i := cp.idx; i < idx; i++ {
 		m := p.frames[i]
 		if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
-			handleDrawState(m)
+			// Skip render cache preparation for intermediate frames.
+			handleDrawState(m, i == idx-1)
 		} else {
 			// Keep timeline consistent during scrubbing when frames
 			// without draw-state are encountered.

--- a/network.go
+++ b/network.go
@@ -196,7 +196,7 @@ func processServerMessage(msg []byte) {
 	tag := binary.BigEndian.Uint16(msg[:2])
 	if tag == 2 {
 		noteFrame()
-		handleDrawState(msg)
+		handleDrawState(msg, true)
 		return
 	}
 	if txt := decodeMessage(msg); txt != "" {


### PR DESCRIPTION
## Summary
- allow draw-state parser to skip render cache generation when requested
- use fast parsing for intermediate frames while seeking movies
- rebuild caches once at seek target and update network handler

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a3a918db0c832aa98e25580fce5276