### PR TITLE
Add 'always on top' window option

### DIFF
--- a/game.go
+++ b/game.go
@@ -1767,8 +1767,8 @@ func runGame(ctx context.Context) {
 	}
 	if gs.Fullscreen {
 		ebiten.SetFullscreen(true)
-		ebiten.SetWindowFloating(true)
 	}
+	ebiten.SetWindowFloating(gs.Fullscreen || gs.AlwaysOnTop)
 
 	op := &ebiten.RunGameOptions{ScreenTransparent: false}
 	if err := ebiten.RunGameWithOptions(&Game{}, op); err != nil {

--- a/settings.go
+++ b/settings.go
@@ -68,6 +68,7 @@ var gsdef settings = settings{
 	ShowFPS:           true,
 	UIScale:           1.0,
 	Fullscreen:        false,
+	AlwaysOnTop:       false,
 	Volume:            1.0,
 	Mute:              false,
 	GameScale:         2,
@@ -148,6 +149,7 @@ type settings struct {
 	ShowFPS           bool
 	UIScale           float64
 	Fullscreen        bool
+	AlwaysOnTop       bool
 	Volume            float64
 	Mute              bool
 	GameScale         float64
@@ -252,7 +254,7 @@ func applySettings() {
 	}
 	ebiten.SetVsyncEnabled(gs.vsync)
 	ebiten.SetFullscreen(gs.Fullscreen)
-	ebiten.SetWindowFloating(gs.Fullscreen)
+	ebiten.SetWindowFloating(gs.Fullscreen || gs.AlwaysOnTop)
 	initFont()
 	updateSoundVolume()
 }

--- a/ui.go
+++ b/ui.go
@@ -1211,11 +1211,27 @@ func makeSettingsWindow() {
 
 			gs.Fullscreen = ev.Checked
 			ebiten.SetFullscreen(gs.Fullscreen)
-			ebiten.SetWindowFloating(gs.Fullscreen)
+			ebiten.SetWindowFloating(gs.Fullscreen || gs.AlwaysOnTop)
 			settingsDirty = true
 		}
 	}
 	right.AddItem(fullscreenCB)
+
+	alwaysTopCB, alwaysTopEvents := eui.NewCheckbox()
+	alwaysTopCB.Text = "Always on top"
+	alwaysTopCB.Size = eui.Point{X: rightW, Y: 24}
+	alwaysTopCB.Checked = gs.AlwaysOnTop
+	alwaysTopEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			SettingsLock.Lock()
+			defer SettingsLock.Unlock()
+
+			gs.AlwaysOnTop = ev.Checked
+			ebiten.SetWindowFloating(gs.Fullscreen || gs.AlwaysOnTop)
+			settingsDirty = true
+		}
+	}
+	right.AddItem(alwaysTopCB)
 
 	bubbleMsgCB, bubbleMsgEvents := eui.NewCheckbox()
 	bubbleMsgCB.Text = "Combine chat + console"
@@ -1793,11 +1809,24 @@ func makeGraphicsWindow() {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.Fullscreen = ev.Checked
 			ebiten.SetFullscreen(gs.Fullscreen)
-			ebiten.SetWindowFloating(gs.Fullscreen)
+			ebiten.SetWindowFloating(gs.Fullscreen || gs.AlwaysOnTop)
 			settingsDirty = true
 		}
 	}
 	simple.AddItem(fullscreenCB)
+
+	alwaysTopCB, alwaysTopEvents := eui.NewCheckbox()
+	alwaysTopCB.Text = "Always on top"
+	alwaysTopCB.Size = eui.Point{X: width, Y: 24}
+	alwaysTopCB.Checked = gs.AlwaysOnTop
+	alwaysTopEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.AlwaysOnTop = ev.Checked
+			ebiten.SetWindowFloating(gs.Fullscreen || gs.AlwaysOnTop)
+			settingsDirty = true
+		}
+	}
+	simple.AddItem(alwaysTopCB)
 
 	// Render scale (world zoom) 1x..10x, defaults to 2x
 	renderScale, renderScaleEvents := eui.NewSlider()


### PR DESCRIPTION
## Summary
- Add configurable "Always on top" window option and use it to control window floating
- Update UI to expose the new option below the Fullscreen toggle

## Testing
- `go test ./...` *(fails: GLFW missing DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c0097f6c832a85a9f123a38cdc10