### PR TITLE
Allow custom timestamp format

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -46,9 +46,13 @@ func getChatMessages() []string {
 	defer chatMsgMu.Unlock()
 
 	out := make([]string, len(chatMsgs))
+	format := gs.TimestampFormat
+	if format == "" {
+		format = "3:04PM"
+	}
 	for i, msg := range chatMsgs {
 		if gs.ChatTimestamps {
-			out[i] = fmt.Sprintf("[%s] %s", msg.Time.Format("15:04"), msg.Text)
+			out[i] = fmt.Sprintf("[%s] %s", msg.Time.Format(format), msg.Text)
 		} else {
 			out[i] = msg.Text
 		}

--- a/console.go
+++ b/console.go
@@ -37,9 +37,13 @@ func getConsoleMessages() []string {
 	defer messageMu.Unlock()
 
 	out := make([]string, len(messages))
+	format := gs.TimestampFormat
+	if format == "" {
+		format = "3:04PM"
+	}
 	for i, msg := range messages {
 		if gs.ConsoleTimestamps {
-			out[i] = fmt.Sprintf("[%s] %s", msg.Time.Format("15:04"), msg.Text)
+			out[i] = fmt.Sprintf("[%s] %s", msg.Time.Format(format), msg.Text)
 		} else {
 			out[i] = msg.Text
 		}

--- a/settings.go
+++ b/settings.go
@@ -79,6 +79,7 @@ var gsdef settings = settings{
 	ChatTTSVolume:     1.0,
 	ChatTimestamps:    false,
 	ConsoleTimestamps: false,
+	TimestampFormat:   "3:04PM",
 	WindowTiling:      false,
 	WindowSnapping:    false,
 	NoCaching:         false,
@@ -162,6 +163,7 @@ type settings struct {
 	ChatTTSVolume     float64
 	ChatTimestamps    bool
 	ConsoleTimestamps bool
+	TimestampFormat   string
 	WindowTiling      bool
 	WindowSnapping    bool
 

--- a/ui.go
+++ b/ui.go
@@ -1303,6 +1303,23 @@ func makeSettingsWindow() {
 	}
 	right.AddItem(consoleTSCB)
 
+	tsFormatInput, tsFormatEvents := eui.NewInput()
+	tsFormatInput.Label = "Timestamp format"
+	tsFormatInput.TextPtr = &gs.TimestampFormat
+	tsFormatInput.Size = eui.Point{X: rightW, Y: 24}
+	tsFormatInput.Tooltip = "01 Month, 02 Day, 03 Hour, 04 minute, 05 second (golang)"
+	tsFormatEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventInputChanged {
+			SettingsLock.Lock()
+			gs.TimestampFormat = ev.Text
+			SettingsLock.Unlock()
+			settingsDirty = true
+			updateChatWindow()
+			updateConsoleWindow()
+		}
+	}
+	right.AddItem(tsFormatInput)
+
 	chatTTSRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL}
 
 	chatTTSCB, chatTTSEvents := eui.NewCheckbox()


### PR DESCRIPTION
## Summary
- allow players to specify custom timestamp format
- use new format for chat and console timestamps

## Testing
- `go test ./...` *(fails: X11 The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d3f38cec832a9b6999c1e40710f3