### PR TITLE
Detect and persist working keyring backend

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,12 +62,13 @@ func main() {
 
 	var err error
 
+	loadSettings()
+
 	ring, err = openPortableRing()
 	if err != nil {
 		consoleMessage("Unable to open keyring for password storage.")
 	}
 
-	loadSettings()
 	loadCharacters()
 	initSoundContext()
 

--- a/portable_keyring.go
+++ b/portable_keyring.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -8,48 +9,99 @@ import (
 	keyring "github.com/99designs/keyring"
 )
 
-// openPortableRing tries to open a system keyring using native backends and
-// falls back to the encrypted file backend when necessary. The file backend can
-// also be forced by setting KEYRING_FORCE_FILE=1.
+// openPortableRing tries to find a working keyring backend by actually storing
+// and retrieving a test value. The detected backend is saved in the settings
+// for future runs. KEYRING_FORCE_FILE=1 forces the encrypted file backend.
 func openPortableRing() (keyring.Keyring, error) {
+	_ = os.MkdirAll(dataDirPath, 0o755)
 	if os.Getenv("KEYRING_FORCE_FILE") == "1" {
-		return openFileRing()
+		ring, err := tryBackend(keyring.FileBackend)
+		if err == nil {
+			gs.KeyringBackend = string(keyring.FileBackend)
+			saveSettings()
+		}
+		return ring, err
 	}
 
-	cfg := keyring.Config{
-		ServiceName: keyringService,
-	}
-
+	var backends []keyring.BackendType
 	switch runtime.GOOS {
 	case "darwin":
-		cfg.AllowedBackends = []keyring.BackendType{
+		backends = []keyring.BackendType{
 			keyring.KeychainBackend,
 			keyring.FileBackend,
 		}
 	case "linux":
-		cfg.AllowedBackends = []keyring.BackendType{
+		backends = []keyring.BackendType{
 			keyring.SecretServiceBackend,
 			keyring.KWalletBackend,
 			keyring.PassBackend,
 			keyring.FileBackend,
 		}
 	case "windows":
-		cfg.AllowedBackends = []keyring.BackendType{
+		backends = []keyring.BackendType{
 			keyring.WinCredBackend,
 			keyring.FileBackend,
 		}
 	default:
-		return openFileRing()
+		backends = []keyring.BackendType{keyring.FileBackend}
 	}
 
-	cfg.FilePasswordFunc = keyring.FixedStringPrompt(os.Getenv("KEYRING_FILE_PASSPHRASE"))
-	if cfg.FilePasswordFunc == nil {
-		cfg.FilePasswordFunc = keyring.FixedStringPrompt("test-passphrase")
+	if gs.KeyringBackend != "" {
+		if ring, err := tryBackend(keyring.BackendType(gs.KeyringBackend)); err == nil {
+			return ring, nil
+		}
 	}
-	cfg.FileDir = defaultFileDir()
-	cfg.PassPrefix = keyringService
 
-	return keyring.Open(cfg)
+	for _, b := range backends {
+		ring, err := tryBackend(b)
+		if err == nil {
+			if gs.KeyringBackend != string(b) {
+				gs.KeyringBackend = string(b)
+				saveSettings()
+			}
+			return ring, nil
+		}
+	}
+
+	return nil, errors.New("no usable keyring backend found")
+}
+
+func tryBackend(b keyring.BackendType) (keyring.Keyring, error) {
+	var (
+		ring keyring.Keyring
+		err  error
+	)
+	if b == keyring.FileBackend {
+		ring, err = openFileRing()
+	} else {
+		cfg := keyring.Config{
+			ServiceName:     keyringService,
+			AllowedBackends: []keyring.BackendType{b},
+			FileDir:         defaultFileDir(),
+			FilePasswordFunc: keyring.FixedStringPrompt(
+				envOr("KEYRING_FILE_PASSPHRASE", "test-passphrase"),
+			),
+			PassPrefix: keyringService,
+		}
+		ring, err = keyring.Open(cfg)
+	}
+	if err != nil {
+		return nil, err
+	}
+	const testKey = "__kr_test__"
+	const testVal = "ok"
+	if err := ring.Set(keyring.Item{Key: testKey, Data: []byte(testVal)}); err != nil {
+		return nil, err
+	}
+	item, err := ring.Get(testKey)
+	if err != nil {
+		return nil, err
+	}
+	if string(item.Data) != testVal {
+		return nil, errors.New("keyring test mismatch")
+	}
+	_ = ring.Remove(testKey)
+	return ring, nil
 }
 
 // openFileRing opens the encrypted file keyring backend directly.

--- a/settings.go
+++ b/settings.go
@@ -83,6 +83,7 @@ type settings struct {
 	Version int
 
 	LastCharacter      string
+	KeyringBackend     string
 	ClickToToggle      bool
 	KBWalkSpeed        float64
 	MainFontSize       float64


### PR DESCRIPTION
## Summary
- detect a working keyring backend by round-tripping a test credential
- store selected backend in settings for reuse
- load settings before opening keyring

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f6c2bf60832a8ff05c673020c1ba