### PR TITLE
Add optional splash and background images

### DIFF
--- a/game.go
+++ b/game.go
@@ -862,7 +862,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	} else {
 		gameImageItem.Disabled = false
 	}
-	screen.Fill(dimmedScreenBG)
+	if backgroundImg != nil {
+		drawBackground(screen)
+	} else {
+		screen.Fill(dimmedScreenBG)
+	}
 
 	// Ensure the game image item/buffer exists and matches window content.
 	updateGameImageSize()


### PR DESCRIPTION
## Summary
- allow users to override splash and background images from the data directory
- crop custom images to cover their target areas
- render background image in place of solid color

## Testing
- `go test ./...` *(fails: `glfw: X11: The DISPLAY environment variable is missing`)*

------
https://chatgpt.com/codex/tasks/task_e_68a4847097a4832ab229a744bd2ca047