### PR TITLE
Add in-game notification overlay with settings toggle

### DIFF
--- a/game.go
+++ b/game.go
@@ -525,6 +525,7 @@ func (g *Game) Update() error {
 	default:
 	}
 	eui.Update() //We really need this to return eaten clicks
+	updateNotifications()
 
 	once.Do(func() {
 		initGame()
@@ -1830,9 +1831,11 @@ func makeGameWindow() {
 		}
 		_ = gameWin.SetPos(eui.Point{X: float32(newX), Y: 0})
 		updateGameImageSize()
+		layoutNotifications()
 	}
 	updateGameWindowSize()
 	updateGameImageSize()
+	layoutNotifications()
 }
 
 // onGameWindowResize enforces the game's aspect ratio on the window's
@@ -1879,6 +1882,7 @@ func onGameWindowResize() {
 		inAspectResize = false
 	}
 	updateGameImageSize()
+	layoutNotifications()
 }
 
 func noteFrame() {

--- a/notifications.go
+++ b/notifications.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"time"
+
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+	"gothoom/eui"
+)
+
+type notification struct {
+	item   *eui.ItemData
+	expiry time.Time
+}
+
+var notifications []*notification
+
+const notificationDuration = 6 * time.Second
+
+// showNotification displays msg in the Clan Lord window if notifications are
+// enabled. Messages disappear after a timeout or when clicked.
+func showNotification(msg string) {
+	if !gs.Notifications || gameWin == nil {
+		return
+	}
+	btn, events := eui.NewButton()
+	btn.Text = msg
+	btn.FontSize = float32(gs.ChatFontSize)
+	btn.Filled = true
+	btn.Outlined = false
+	btn.Color = eui.NewColor(0, 0, 0, 160)
+	btn.TextColor = eui.NewColor(255, 255, 255, 255)
+	btn.HoverColor = btn.Color
+	btn.ClickColor = btn.Color
+	btn.Fillet = 6
+	btn.Padding = 4
+	btn.Margin = 0
+
+	textSize := (btn.FontSize * eui.UIScale()) + 2
+	face := &text.GoTextFace{Source: eui.FontSource(), Size: float64(textSize)}
+	w, h := text.Measure(msg, face, 0)
+	btn.Size = eui.Point{
+		X: float32(w)/eui.UIScale() + btn.Padding*2 + btn.BorderPad*2,
+		Y: float32(h)/eui.UIScale() + btn.Padding*2 + btn.BorderPad*2,
+	}
+
+	events.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			removeNotification(btn)
+		}
+	}
+
+	notifications = append(notifications, &notification{item: btn, expiry: time.Now().Add(notificationDuration)})
+	gameWin.AddItem(btn)
+	layoutNotifications()
+}
+
+func removeNotification(item *eui.ItemData) {
+	for i, n := range notifications {
+		if n.item == item {
+			notifications = append(notifications[:i], notifications[i+1:]...)
+			break
+		}
+	}
+	if gameWin != nil {
+		for i, it := range gameWin.Contents {
+			if it == item {
+				gameWin.Contents = append(gameWin.Contents[:i], gameWin.Contents[i+1:]...)
+				break
+			}
+		}
+		gameWin.Refresh()
+	}
+}
+
+func clearNotifications() {
+	for _, n := range notifications {
+		if gameWin != nil {
+			for i, it := range gameWin.Contents {
+				if it == n.item {
+					gameWin.Contents = append(gameWin.Contents[:i], gameWin.Contents[i+1:]...)
+					break
+				}
+			}
+		}
+	}
+	notifications = nil
+	if gameWin != nil {
+		gameWin.Refresh()
+	}
+}
+
+func layoutNotifications() {
+	if gameWin == nil {
+		return
+	}
+	margin := float32(8)
+	spacer := float32(4)
+	winSz := gameWin.GetSize()
+	y := winSz.Y - margin
+	for i := len(notifications) - 1; i >= 0; i-- {
+		it := notifications[i].item
+		sz := it.GetSize()
+		y -= sz.Y
+		x := winSz.X - sz.X - margin
+		it.Position = eui.Point{X: x / eui.UIScale(), Y: y / eui.UIScale()}
+		y -= spacer
+		it.Dirty = true
+	}
+	gameWin.Refresh()
+}
+
+func updateNotifications() {
+	if len(notifications) == 0 {
+		return
+	}
+	now := time.Now()
+	changed := false
+	for i := 0; i < len(notifications); {
+		if now.After(notifications[i].expiry) {
+			removeNotification(notifications[i].item)
+			changed = true
+		} else {
+			i++
+		}
+	}
+	if changed {
+		layoutNotifications()
+	}
+}

--- a/settings.go
+++ b/settings.go
@@ -69,6 +69,7 @@ var gsdef settings = settings{
 	GameScale:         2,
 	BarPlacement:      BarPlacementBottom,
 	ChatTTSVolume:     1.0,
+	Notifications:     true,
 	TimestampFormat:   "3:04PM",
 
 	GameWindow:      WindowState{Open: true},
@@ -134,6 +135,7 @@ type settings struct {
 	MessagesToConsole bool
 	ChatTTS           bool
 	ChatTTSVolume     float64
+	Notifications     bool
 	ChatTimestamps    bool
 	ConsoleTimestamps bool
 	TimestampFormat   string

--- a/ui.go
+++ b/ui.go
@@ -1254,6 +1254,24 @@ func makeSettingsWindow() {
 	}
 	left.AddItem(keySpeedSlider)
 
+	notifCB, notifEvents := eui.NewCheckbox()
+	notifCB.Text = "Game Notifications"
+	notifCB.Size = eui.Point{X: leftW, Y: 24}
+	notifCB.Checked = gs.Notifications
+	notifCB.Tooltip = "Show in-game notifications"
+	notifEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			SettingsLock.Lock()
+			gs.Notifications = ev.Checked
+			SettingsLock.Unlock()
+			settingsDirty = true
+			if !ev.Checked {
+				clearNotifications()
+			}
+		}
+	}
+	left.AddItem(notifCB)
+
 	label, _ = eui.NewText()
 	label.Text = "\nWindow Behavior:"
 	label.FontSize = 15


### PR DESCRIPTION
## Summary
- Add semi-transparent stacked notifications in Clan Lord window
- Allow enabling or disabling notifications from Settings
- Auto-hide notifications after 6 seconds or on click and relayout on resize

## Testing
- `go test ./...` *(fails: Package alsa was not found, Package gtk+-3.0 was not found, X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4869459dc832a8edf2118a933cd73