### PR TITLE
Decode fallen/unfallen BEPP messages

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -115,6 +115,12 @@ func decodeBEPP(data []byte) string {
 		if text != "" {
 			return text
 		}
+	case "hf", "nf":
+		// Fallen or no-longer-fallen notices
+		parseFallenText(raw, text)
+		if text != "" {
+			return text
+		}
 	case "be":
 		// Back-end command: handle internally using raw (unstripped) data.
 		parseBackend(raw)

--- a/fallen_text_test.go
+++ b/fallen_text_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+// helper to wrap message into BEPP prefix without pn tag
+func fallenLine(prefix, msg string) []byte {
+	b := []byte{0xC2, prefix[0], prefix[1]}
+	b = append(b, []byte(msg)...)
+	b = append(b, 0) // simulate NUL terminator
+	return b
+}
+
+func TestDecodeFallenWithoutTag(t *testing.T) {
+	players = make(map[string]*Player)
+	raw := fallenLine("hf", "Bob has fallen")
+	if got := decodeBEPP(raw); got != "Bob has fallen" {
+		t.Fatalf("decodeBEPP returned %q", got)
+	}
+	playersMu.RLock()
+	dead := players["Bob"].Dead
+	playersMu.RUnlock()
+	if !dead {
+		t.Errorf("player not marked dead")
+	}
+}
+
+func TestDecodeUnfallenWithoutTag(t *testing.T) {
+	players = make(map[string]*Player)
+	players["Bob"] = &Player{Name: "Bob", Dead: true}
+	raw := fallenLine("nf", "Bob is no longer fallen")
+	if got := decodeBEPP(raw); got != "Bob is no longer fallen" {
+		t.Fatalf("decodeBEPP returned %q", got)
+	}
+	playersMu.RLock()
+	dead := players["Bob"].Dead
+	playersMu.RUnlock()
+	if dead {
+		t.Errorf("player still marked dead")
+	}
+}

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -238,7 +238,12 @@ func parseFallenText(raw []byte, s string) bool {
 		// Extract main player name
 		name := firstTagContent(raw, 'p', 'n')
 		if name == "" {
-			return true
+			if idx := strings.Index(s, " has fallen"); idx >= 0 {
+				name = strings.TrimSpace(s[:idx])
+			}
+		}
+		if name == "" {
+			return false
 		}
 		killer := firstTagContent(raw, 'm', 'n')
 		where := firstTagContent(raw, 'l', 'o')
@@ -258,7 +263,12 @@ func parseFallenText(raw []byte, s string) bool {
 	if strings.Contains(s, " is no longer fallen") {
 		name := firstTagContent(raw, 'p', 'n')
 		if name == "" {
-			return true
+			if idx := strings.Index(s, " is no longer fallen"); idx >= 0 {
+				name = strings.TrimSpace(s[:idx])
+			}
+		}
+		if name == "" {
+			return false
 		}
 		playersMu.Lock()
 		if p, ok := players[name]; ok {


### PR DESCRIPTION
## Summary
- decode BEPP `hf`/`nf` messages and update player fallen state
- add tests verifying decode of fallen and recovery messages without player tags

## Testing
- `go mod download`
- `go test ./...` *(fails: glfw X11 DISPLAY environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a9b88900832a89fed4b3a97dcd73