### PR TITLE
Add meltysynth-based music player module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2
 	github.com/remeh/sizedwaitgroup v1.0.0
+	github.com/sinshu/go-meltysynth v0.0.0-20230205031334-05d311382fc4
 	github.com/sqweek/dialog v0.0.0-20240226140203-065105509627
 	github.com/thiagokokada/dark-mode-go v0.0.1
 	golang.design/x/clipboard v0.7.1
@@ -19,7 +20,7 @@ require (
 	golang.org/x/time v0.12.0
 )
 
-require github.com/ebitengine/oto/v3 v3.3.3 // indirect
+require github.com/ebitengine/oto/v3 v3.3.3
 
 require (
 	github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
+github.com/sinshu/go-meltysynth v0.0.0-20230205031334-05d311382fc4 h1:VgeknFh4pciKVtwtjn9tZtItvV20x/+10NnUXKfyW6s=
+github.com/sinshu/go-meltysynth v0.0.0-20230205031334-05d311382fc4/go.mod h1:Afi/YpLztHvWSbiLFi6RgtxLLwmIiRmd/q7f3Ymed2g=
 github.com/sqweek/dialog v0.0.0-20240226140203-065105509627 h1:2JL2wmHXWIAxDofCK+AdkFi1KEg3dgkefCsm7isADzQ=
 github.com/sqweek/dialog v0.0.0-20240226140203-065105509627/go.mod h1:/qNPSY91qTz/8TgHEMioAUc6q7+3SOybeKczHMXFcXw=
 github.com/thiagokokada/dark-mode-go v0.0.1 h1:layfdBOM9xaxBa1Dw6f97ng/GbRJh+f8+afBOvDzXz4=

--- a/music/player.go
+++ b/music/player.go
@@ -1,0 +1,142 @@
+package music
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math"
+	"time"
+
+	"github.com/ebitengine/oto/v3"
+	meltysynth "github.com/sinshu/go-meltysynth/meltysynth"
+)
+
+// Note represents a single MIDI note with a duration.
+type Note struct {
+	// Key is the MIDI note number (e.g. 60 = middle C).
+	Key int
+	// Velocity is the MIDI velocity 1..127.
+	Velocity int
+	// Duration specifies how long the note should sound.
+	Duration time.Duration
+}
+
+// Play renders the provided notes using the given SoundFont and plays them.
+// The reader must point to a SoundFont2 (sf2) file. The function blocks until
+// playback has finished.
+func Play(sf io.ReadSeeker, program int, notes []Note) error {
+	const (
+		sampleRate = 44100
+		channels   = 2
+		block      = 512
+	)
+
+	sfnt, err := meltysynth.NewSoundFont(sf)
+	if err != nil {
+		return err
+	}
+	settings := meltysynth.NewSynthesizerSettings(sampleRate)
+	synth, err := meltysynth.NewSynthesizer(sfnt, settings)
+	if err != nil {
+		return err
+	}
+
+	const ch = 0
+	synth.ProcessMidiMessage(ch, 0xC0, program, 0) // program change
+
+	type event struct {
+		key, vel   int
+		start, end int
+	}
+	cursor := 0
+	var events []event
+	for _, n := range notes {
+		durSamples := int(float64(sampleRate) * n.Duration.Seconds())
+		if durSamples <= 0 {
+			continue
+		}
+		ev := event{key: n.Key, vel: n.Velocity, start: cursor, end: cursor + durSamples}
+		events = append(events, ev)
+		cursor += durSamples
+	}
+	totalSamples := cursor
+
+	leftAll := make([]float32, 0, totalSamples)
+	rightAll := make([]float32, 0, totalSamples)
+	active := map[int]bool{}
+
+	trigger := func(start, count int) {
+		end := start + count
+		for _, ev := range events {
+			if ev.start >= start && ev.start < end && !active[ev.key] {
+				synth.NoteOn(ch, int32(ev.key), int32(ev.vel))
+				active[ev.key] = true
+			}
+			if ev.end >= start && ev.end < end && active[ev.key] {
+				synth.NoteOff(ch, int32(ev.key))
+				active[ev.key] = false
+			}
+		}
+	}
+
+	for pos := 0; pos < totalSamples; pos += block {
+		n := block
+		if pos+n > totalSamples {
+			n = totalSamples - pos
+		}
+		trigger(pos, n)
+		left := make([]float32, n)
+		right := make([]float32, n)
+		synth.Render(left, right)
+		leftAll = append(leftAll, left...)
+		rightAll = append(rightAll, right...)
+	}
+
+	// Normalize to avoid clipping and boost quiet audio
+	var peak float32
+	for i := range leftAll {
+		if v := float32(math.Abs(float64(leftAll[i]))); v > peak {
+			peak = v
+		}
+		if v := float32(math.Abs(float64(rightAll[i]))); v > peak {
+			peak = v
+		}
+	}
+	if peak > 0 {
+		g := float32(0.99) / peak
+		if g != 1 {
+			for i := range leftAll {
+				leftAll[i] *= g
+				rightAll[i] *= g
+			}
+		}
+	}
+
+	// Interleave samples for oto
+	inter := make([]float32, 2*len(leftAll))
+	for i := range leftAll {
+		inter[2*i] = leftAll[i]
+		inter[2*i+1] = rightAll[i]
+	}
+
+	ctx, ready, err := oto.NewContext(&oto.NewContextOptions{
+		SampleRate:   sampleRate,
+		ChannelCount: channels,
+		Format:       oto.FormatFloat32LE,
+	})
+	if err != nil {
+		return err
+	}
+	<-ready
+
+	var pcm bytes.Buffer
+	if err := binary.Write(&pcm, binary.LittleEndian, inter); err != nil {
+		return err
+	}
+	player := ctx.NewPlayer(bytes.NewReader(pcm.Bytes()))
+	player.Play()
+
+	dur := time.Duration(float64(totalSamples) / sampleRate * float64(time.Second))
+	time.Sleep(dur)
+	return player.Close()
+}


### PR DESCRIPTION
## Summary
- implement `music` package capable of rendering and playing MIDI-style note sequences using a SoundFont
- normalize rendered output to boost quiet audio and avoid clipping

## Testing
- `go test ./...` *(fails: Package 'alsa' not found; X11 header Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4deb098e4832a9333d128f432b661