### PR TITLE
Use shared audio context for music playback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,12 +20,11 @@ require (
 	golang.org/x/time v0.12.0
 )
 
-require github.com/ebitengine/oto/v3 v3.3.3
-
 require (
 	github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d // indirect
 	github.com/ebitengine/gomobile v0.0.0-20250329061421-6d0a8e981e4c // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
+	github.com/ebitengine/oto/v3 v3.3.3 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/go-text/typesetting v0.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect

--- a/tune.go
+++ b/tune.go
@@ -107,7 +107,7 @@ func playClanLordTune(tune string) {
 					Velocity: 100,
 					Duration: time.Duration(dur) * time.Millisecond,
 				}}
-				if err := music.Play(rs, prog, notes); err != nil {
+				if err := music.Play(audioContext, rs, prog, notes); err != nil {
 					log.Printf("play note: %v", err)
 				}
 			}(key, ev.durMS)


### PR DESCRIPTION
## Summary
- Remove oto context creation and use Ebiten's shared audio context for music playback.
- Update `Play` to accept an `*audio.Context` and create players via `NewPlayerFromBytes`.
- Pass the global `audioContext` from `tune.go` when playing notes.

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eba0e7f4832a8721bca9a6b2cb14