### PR TITLE
Limit experimental flag to CL data patching

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ var (
 	blockTTS      bool
 	dumpMusic     bool
 	clientVersion int
+	experimental  bool
 )
 
 func main() {
@@ -47,6 +48,7 @@ func main() {
 	flag.BoolVar(&doDebug, "debug", false, "verbose/debug logging")
 	flag.BoolVar(&eui.CacheCheck, "cacheCheck", false, "display window and item render counts")
 	flag.BoolVar(&dumpMusic, "dumpMusic", false, "write played music as a .wav file")
+	flag.BoolVar(&experimental, "experimental", false, "enable experimental features like CL_Images/CL_Sounds patching")
 	genPGO := flag.Bool("pgo", false, "create default.pgo using test.clMov at 30 fps for 30s")
 	flag.Parse()
 
@@ -75,7 +77,6 @@ func main() {
 
 	applySettings()
 	setupLogging(doDebug)
-	go checkForNewVersion()
 	defer func() {
 		if r := recover(); r != nil {
 			logPanic(r)

--- a/update.go
+++ b/update.go
@@ -179,16 +179,24 @@ func autoUpdate(resp []byte, dataDir string) (int, error) {
 	sndVer := int(binary.BigEndian.Uint32(resp[12:16]) >> 8)
 	imgPath := filepath.Join(dataDir, CL_ImagesFile)
 	if old, err := readKeyFileVersion(imgPath); err == nil {
-		patchURL := fmt.Sprintf("%v/data/CL_Images.%dto%d.gz", base, int(old>>8), imgVer)
-		if err := downloadPatch(patchURL, imgPath, climg.ApplyPatch); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				imgURL := fmt.Sprintf("%v/data/CL_Images.%d.gz", base, imgVer)
-				if err := downloadGZ(imgURL, imgPath); err != nil {
-					logError("download %v: %v", imgURL, err)
+		if experimental {
+			patchURL := fmt.Sprintf("%v/data/CL_Images.%dto%d.gz", base, int(old>>8), imgVer)
+			if err := downloadPatch(patchURL, imgPath, climg.ApplyPatch); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					imgURL := fmt.Sprintf("%v/data/CL_Images.%d.gz", base, imgVer)
+					if err := downloadGZ(imgURL, imgPath); err != nil {
+						logError("download %v: %v", imgURL, err)
+						return 0, err
+					}
+				} else {
+					logError("patch %v: %v", patchURL, err)
 					return 0, err
 				}
-			} else {
-				logError("patch %v: %v", patchURL, err)
+			}
+		} else {
+			imgURL := fmt.Sprintf("%v/data/CL_Images.%d.gz", base, imgVer)
+			if err := downloadGZ(imgURL, imgPath); err != nil {
+				logError("download %v: %v", imgURL, err)
 				return 0, err
 			}
 		}
@@ -201,16 +209,24 @@ func autoUpdate(resp []byte, dataDir string) (int, error) {
 	}
 	sndPath := filepath.Join(dataDir, CL_SoundsFile)
 	if old, err := readKeyFileVersion(sndPath); err == nil {
-		patchURL := fmt.Sprintf("%v/data/CL_Sounds.%dto%d.gz", base, int(old>>8), sndVer)
-		if err := downloadPatch(patchURL, sndPath, clsnd.ApplyPatch); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				sndURL := fmt.Sprintf("%v/data/CL_Sounds.%d.gz", base, sndVer)
-				if err := downloadGZ(sndURL, sndPath); err != nil {
-					logError("download %v: %v", sndURL, err)
+		if experimental {
+			patchURL := fmt.Sprintf("%v/data/CL_Sounds.%dto%d.gz", base, int(old>>8), sndVer)
+			if err := downloadPatch(patchURL, sndPath, clsnd.ApplyPatch); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					sndURL := fmt.Sprintf("%v/data/CL_Sounds.%d.gz", base, sndVer)
+					if err := downloadGZ(sndURL, sndPath); err != nil {
+						logError("download %v: %v", sndURL, err)
+						return 0, err
+					}
+				} else {
+					logError("patch %v: %v", patchURL, err)
 					return 0, err
 				}
-			} else {
-				logError("patch %v: %v", patchURL, err)
+			}
+		} else {
+			sndURL := fmt.Sprintf("%v/data/CL_Sounds.%d.gz", base, sndVer)
+			if err := downloadGZ(sndURL, sndPath); err != nil {
+				logError("download %v: %v", sndURL, err)
 				return 0, err
 			}
 		}
@@ -284,7 +300,7 @@ func downloadDataFiles(clientVer int, status dataFilesStatus) error {
 	}
 	if status.NeedImages {
 		imgPath := filepath.Join(dataDirPath, CL_ImagesFile)
-		if status.ImageVersion > 0 {
+		if status.ImageVersion > 0 && experimental {
 			patchURL := fmt.Sprintf("%v/data/CL_Images.%dto%d.gz", updateBase, status.ImageVersion, clientVer)
 			if err := downloadPatch(patchURL, imgPath, climg.ApplyPatch); err != nil {
 				if errors.Is(err, os.ErrNotExist) {
@@ -308,7 +324,7 @@ func downloadDataFiles(clientVer int, status dataFilesStatus) error {
 	}
 	if status.NeedSounds {
 		sndPath := filepath.Join(dataDirPath, CL_SoundsFile)
-		if status.SoundVersion > 0 {
+		if status.SoundVersion > 0 && experimental {
 			patchURL := fmt.Sprintf("%v/data/CL_Sounds.%dto%d.gz", updateBase, status.SoundVersion, clientVer)
 			if err := downloadPatch(patchURL, sndPath, clsnd.ApplyPatch); err != nil {
 				if errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
## Summary
- only patch CL_Images and CL_Sounds when `-experimental` is set
- drop goThoom version check and always run data file checks
- allow data downloads regardless of experimental mode

## Testing
- `go build ./... && echo BUILD_OK`
- `go test ./...` *(fails: GLFW missing DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68a55565d508832a907b2872e9978a61