### PR TITLE
Add macOS build and cert helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ export MAC_SIGN_IDENTITY="-"                # ad-hoc by default; set to your cer
 scripts/build_binaries.sh
 ```
 
+To produce only the macOS `.app` bundle you can run:
+
+```bash
+scripts/build_mac_app.sh v1.2.3
+```
+
+On macOS, create a self-signed certificate for codesigning with:
+
+```bash
+scripts/macos_create_cert.sh gothoom-dev
+```
+
+Use the resulting certificate name with `MAC_SIGN_IDENTITY` when building.
+
 ## Command-line Flags
 
 The Go client accepts the following flags:

--- a/scripts/build_mac_app.sh
+++ b/scripts/build_mac_app.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# build_mac_app.sh - Build gothoom macOS .app and zip archive.
+#
+# Usage: scripts/build_mac_app.sh <version>
+# Example: scripts/build_mac_app.sh v1.2.3
+#
+# Requires Go and (optionally) codesign if signing the bundle. If both amd64
+# and arm64 builds succeed a universal binary is created via lipo.
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+VERSION="$1"
+
+APP_NAME="gothoom"
+BINARY_NAME="gothoom"
+IDENTIFIER="com.goThoom.client"
+APP_DIR="${APP_NAME}.app"
+
+# 1. Build binaries for both architectures
+
+echo "Building macOS amd64 binary..."
+GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o "${BINARY_NAME}-amd64" .
+
+echo "Building macOS arm64 binary..."
+GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=${VERSION}" -o "${BINARY_NAME}-arm64" .
+
+# 2. Combine into a universal binary
+
+echo "Creating universal binary..."
+if command -v llvm-lipo-14 >/dev/null 2>&1; then
+  llvm-lipo-14 -create "${BINARY_NAME}-amd64" "${BINARY_NAME}-arm64" -output "${BINARY_NAME}"
+else
+  lipo -create "${BINARY_NAME}-amd64" "${BINARY_NAME}-arm64" -output "${BINARY_NAME}"
+fi
+rm -f "${BINARY_NAME}-amd64" "${BINARY_NAME}-arm64"
+
+# 3. Create .app bundle
+
+rm -rf "${APP_DIR}"
+mkdir -p "${APP_DIR}/Contents/MacOS" "${APP_DIR}/Contents/Resources"
+mv "${BINARY_NAME}" "${APP_DIR}/Contents/MacOS/${BINARY_NAME}"
+
+cat <<PLIST > "${APP_DIR}/Contents/Info.plist"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleName</key><string>${APP_NAME}</string>
+    <key>CFBundleDisplayName</key><string>${APP_NAME}</string>
+    <key>CFBundleExecutable</key><string>${BINARY_NAME}</string>
+    <key>CFBundleIdentifier</key><string>${IDENTIFIER}</string>
+    <key>CFBundleVersion</key><string>${VERSION}</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleSignature</key><string>????</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  </dict>
+</plist>
+PLIST
+
+# 4. Codesign if available
+
+if command -v codesign >/dev/null 2>&1; then
+  IDENTITY="${MAC_SIGN_IDENTITY:--}"
+  echo "Codesigning with identity ${IDENTITY}..."
+  codesign --force --deep --sign "${IDENTITY}" "${APP_DIR}" || echo "codesign failed" >&2
+else
+  echo "codesign not found; skipping signing" >&2
+fi
+
+# 5. Zip the .app bundle
+
+ZIP_NAME="${APP_NAME}-Mac.zip"
+rm -f "$ZIP_NAME"
+zip -r "$ZIP_NAME" "${APP_DIR}"
+
+# 6. Cleanup
+
+rm -rf "${APP_DIR}"
+
+echo "Built ${ZIP_NAME}" 

--- a/scripts/macos_create_cert.sh
+++ b/scripts/macos_create_cert.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# macos_create_cert.sh - Generate a self-signed codesigning certificate for macOS.
+#
+# This script must be run on macOS with the `openssl` and `security` tools
+# available. It creates a new certificate and private key, imports them into
+# the specified keychain, and grants codesign access.
+#
+# Usage: scripts/macos_create_cert.sh [cert-name]
+# Example: scripts/macos_create_cert.sh gothoom-dev
+
+CERT_NAME="${1:-gothoom-dev}"
+KEYCHAIN="${MAC_KEYCHAIN:-login.keychain}"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+openssl req -new -newkey rsa:2048 -nodes -keyout "$TMPDIR/${CERT_NAME}.key" \
+  -x509 -days 3650 -out "$TMPDIR/${CERT_NAME}.cer" -subj "/CN=${CERT_NAME}"
+
+security import "$TMPDIR/${CERT_NAME}.cer" -k "$KEYCHAIN" -T /usr/bin/codesign >/dev/null
+security import "$TMPDIR/${CERT_NAME}.key" -k "$KEYCHAIN" -T /usr/bin/codesign >/dev/null
+security set-key-partition-list -S apple-tool:,apple: -s -k "" "$KEYCHAIN" >/dev/null
+
+echo "Created self-signed certificate '${CERT_NAME}' in $KEYCHAIN."


### PR DESCRIPTION
## Summary
- add `build_mac_app.sh` to create a macOS `.app` bundle and optional codesign
- add `macos_create_cert.sh` to generate and import self-signed signing certs
- document mac build and cert scripts in README

## Testing
- `go test ./...` *(fails: X11/GLX libraries and display not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a55bed8d70832aa4110ef8ff4327d3