### PR TITLE
Refactor text windows with shared helper

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -32,14 +32,7 @@ func makeChatWindow() error {
 	if chatWin != nil {
 		return nil
 	}
-	chatWin, chatList, _ = makeTextWindow("Chat", eui.HZoneRight, eui.VZoneBottom, false)
-	// Rewrap and refresh on window resize
-	chatWin.OnResize = func() {
-		updateChatWindow()
-		if chatWin != nil {
-			chatWin.Refresh()
-		}
-	}
+	chatWin, chatList, _ = newTextWindow("Chat", eui.HZoneRight, eui.VZoneBottom, false, updateChatWindow)
 	updateChatWindow()
 	chatWin.Refresh()
 	return nil

--- a/console_ui.go
+++ b/console_ui.go
@@ -35,14 +35,7 @@ func makeConsoleWindow() {
 	if consoleWin != nil {
 		return
 	}
-	consoleWin, messagesFlow, inputFlow = makeTextWindow("Console", eui.HZoneLeft, eui.VZoneBottom, true)
-	// Rewrap and refresh on window resize
-	consoleWin.OnResize = func() {
-		updateConsoleWindow()
-		if consoleWin != nil {
-			consoleWin.Refresh()
-		}
-	}
+	consoleWin, messagesFlow, inputFlow = newTextWindow("Console", eui.HZoneLeft, eui.VZoneBottom, true, updateConsoleWindow)
 	consoleMessage("Starting...")
 	updateConsoleWindow()
 }

--- a/text_window.go
+++ b/text_window.go
@@ -37,6 +37,21 @@ func makeTextWindow(title string, hz eui.HZone, vz eui.VZone, withInput bool) (*
 	return win, list, input
 }
 
+// newTextWindow wraps makeTextWindow and assigns a resize handler that
+// invokes the provided update callback.
+func newTextWindow(name string, hz eui.HZone, vz eui.VZone, hasInput bool, update func()) (*eui.WindowData, *eui.ItemData, *eui.ItemData) {
+	win, list, input := makeTextWindow(name, hz, vz, hasInput)
+	if update != nil {
+		win.OnResize = func() {
+			update()
+			if win != nil {
+				win.Refresh()
+			}
+		}
+	}
+	return win, list, input
+}
+
 // updateTextWindow refreshes a text window's content and optional input message.
 func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []string, fontSize float64, inputMsg string) {
 	if list == nil || win == nil {


### PR DESCRIPTION
## Summary
- add `newTextWindow` helper to create text windows and hook resize updates
- refactor chat and console window setup to use `newTextWindow`

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6c2bee8ac832a84a9a03b9c47616b