### PR TITLE
Log music commands when musicDebug is enabled

### DIFF
--- a/text_parsers.go
+++ b/text_parsers.go
@@ -417,7 +417,15 @@ func parseMusicCommand(s string) bool {
 			return false
 		}
 		go playClanLordTune(strconv.Itoa(inst) + " " + strings.TrimSpace(notes))
-		return !musicDebug
+
+		if musicDebug {
+			msg := "/play " + strconv.Itoa(inst) + " " + strings.TrimSpace(notes)
+			consoleMessage(msg)
+			if !gs.MessagesToConsole {
+				chatMessage(msg)
+			}
+		}
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- Always log `/play` command to the console when `-musicDebug` is set
- Also mirror the message to chat when chat isn't redirected to the console

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; missing Xrandr.h; gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dc2dadb8832ab1fd653b1e52c9bf