### PR TITLE
Detect dropped frames and expand interpolation window

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -583,6 +583,7 @@ func parseDrawState(data []byte, buildCache bool) error {
 	ackCmd := data[0]
 	ackFrame = int32(binary.BigEndian.Uint32(data[1:5]))
 	resendFrame = int32(binary.BigEndian.Uint32(data[5:9]))
+	dropped := updateFrameCounters(ackFrame)
 	p := 9
 
 	stage = "descriptor count"
@@ -924,7 +925,12 @@ func parseDrawState(data []byte, buildCache bool) error {
 		if interval <= 0 {
 			interval = time.Second / 5
 		}
-		//logDebug("interp mobiles interval=%v", interval)
+		extra := dropped
+		if extra > 2 {
+			extra = 2
+		}
+		interval *= time.Duration(extra + 1)
+		//logDebug("interp mobiles interval=%v extra=%d", interval, extra)
 		state.prevTime = time.Now()
 		state.curTime = state.prevTime.Add(interval)
 	}

--- a/frames_test.go
+++ b/frames_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestUpdateFrameCounters(t *testing.T) {
+	lastAckFrame = 0
+	numFrames = 0
+	lostFrames = 0
+
+	if dropped := updateFrameCounters(1); dropped != 0 {
+		t.Fatalf("expected 0 dropped, got %d", dropped)
+	}
+	if numFrames != 1 || lostFrames != 0 || lastAckFrame != 1 {
+		t.Fatalf("unexpected counters after first frame: num=%d lost=%d last=%d", numFrames, lostFrames, lastAckFrame)
+	}
+
+	if dropped := updateFrameCounters(3); dropped != 1 {
+		t.Fatalf("expected 1 dropped, got %d", dropped)
+	}
+	if numFrames != 2 || lostFrames != 1 || lastAckFrame != 3 {
+		t.Fatalf("unexpected counters after second frame: num=%d lost=%d last=%d", numFrames, lostFrames, lastAckFrame)
+	}
+
+	if dropped := updateFrameCounters(4); dropped != 0 {
+		t.Fatalf("expected 0 dropped, got %d", dropped)
+	}
+	if numFrames != 3 || lostFrames != 1 || lastAckFrame != 4 {
+		t.Fatalf("unexpected counters after third frame: num=%d lost=%d last=%d", numFrames, lostFrames, lastAckFrame)
+	}
+}

--- a/util.go
+++ b/util.go
@@ -129,10 +129,30 @@ var doDebug bool
 var silent bool
 var ackFrame int32
 var resendFrame int32
+var lastAckFrame int32
+var numFrames int
+var lostFrames int
 var commandNum uint32 = 1
 var pendingCommand string
 var playerName string
 var playerIndex uint8 = 0xff
+
+// updateFrameCounters tracks frame statistics and detects dropped frames.
+// It returns the number of frames missing between the previous and
+// current acknowledgement numbers.
+func updateFrameCounters(newFrame int32) int {
+	numFrames++
+	dropped := 0
+	if lastAckFrame != 0 {
+		lost := int(newFrame - lastAckFrame - 1)
+		if lost > 0 {
+			lostFrames += lost
+			dropped = lost
+		}
+	}
+	lastAckFrame = newFrame
+	return dropped
+}
 
 const (
 	kBubbleNormal = iota


### PR DESCRIPTION
## Summary
- track ack frame progress and count dropped frames
- stretch interpolation duration when frames are missing
- add unit test for frame counter logic

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a76fb46ccc832aa8bbc01145a229b0