### PR TITLE
Enable music playback and improve music debugging

### DIFF
--- a/game.go
+++ b/game.go
@@ -224,16 +224,16 @@ var (
 
 // drawState tracks information needed by the Ebiten renderer.
 type drawState struct {
-    descriptors map[uint8]frameDescriptor
-    pictures    []framePicture
-    prevPictures []framePicture
-    picShiftX   int
-    picShiftY   int
-    mobiles     map[uint8]frameMobile
-	prevMobiles map[uint8]frameMobile
-	prevDescs   map[uint8]frameDescriptor
-	prevTime    time.Time
-	curTime     time.Time
+	descriptors  map[uint8]frameDescriptor
+	pictures     []framePicture
+	prevPictures []framePicture
+	picShiftX    int
+	picShiftY    int
+	mobiles      map[uint8]frameMobile
+	prevMobiles  map[uint8]frameMobile
+	prevDescs    map[uint8]frameDescriptor
+	prevTime     time.Time
+	curTime      time.Time
 
 	bubbles []bubble
 
@@ -323,11 +323,11 @@ type bubble struct {
 
 // drawSnapshot is a read-only copy of the current draw state.
 type drawSnapshot struct {
-    descriptors                 map[uint8]frameDescriptor
-    pictures                    []framePicture
-    prevPictures                []framePicture
-    picShiftX                   int
-    picShiftY                   int
+	descriptors                 map[uint8]frameDescriptor
+	pictures                    []framePicture
+	prevPictures                []framePicture
+	picShiftX                   int
+	picShiftY                   int
 	mobiles                     []frameMobile // sorted right-to-left, top-to-bottom
 	prevMobiles                 map[uint8]frameMobile
 	prevDescs                   map[uint8]frameDescriptor
@@ -356,13 +356,13 @@ func captureDrawSnapshot() drawSnapshot {
 	stateMu.Lock()
 	defer stateMu.Unlock()
 
-    snap := drawSnapshot{
-        descriptors:    make(map[uint8]frameDescriptor, len(state.descriptors)),
-        pictures:       append([]framePicture(nil), state.pictures...),
-        prevPictures:   append([]framePicture(nil), state.prevPictures...),
-        picShiftX:      state.picShiftX,
-        picShiftY:      state.picShiftY,
-        mobiles:        append([]frameMobile(nil), state.nameMobs...),
+	snap := drawSnapshot{
+		descriptors:    make(map[uint8]frameDescriptor, len(state.descriptors)),
+		pictures:       append([]framePicture(nil), state.pictures...),
+		prevPictures:   append([]framePicture(nil), state.prevPictures...),
+		picShiftX:      state.picShiftX,
+		picShiftY:      state.picShiftY,
+		mobiles:        append([]frameMobile(nil), state.nameMobs...),
 		prevTime:       state.prevTime,
 		curTime:        state.curTime,
 		hp:             state.hp,
@@ -650,7 +650,22 @@ func (g *Game) Update() error {
 			txt := strings.TrimSpace(string(inputText))
 			if txt != "" {
 				if strings.HasPrefix(txt, "/play ") {
-					go playClanLordTune(strings.TrimSpace(txt[len("/play "):]))
+					tune := strings.TrimSpace(txt[len("/play "):])
+					if musicDebug {
+						msg := "/play " + tune
+						consoleMessage(msg)
+						chatMessage(msg)
+						log.Print(msg)
+					}
+					go func() {
+						if err := playClanLordTune(tune); err != nil {
+							log.Printf("play tune: %v", err)
+							if musicDebug {
+								consoleMessage("play tune: " + err.Error())
+								chatMessage("play tune: " + err.Error())
+							}
+						}
+					}()
 				} else {
 					pendingCommand = txt
 					//consoleMessage("> " + txt)
@@ -1005,13 +1020,13 @@ func drawScene(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha float6
 	live := snap.liveMobs
 	dead := snap.deadMobs
 
-    for _, p := range negPics {
-        drawPicture(screen, ox, oy, p, alpha, pictFade, snap.mobiles, descMap, snap.prevMobiles, snap.prevPictures, snap.picShiftX, snap.picShiftY)
-    }
+	for _, p := range negPics {
+		drawPicture(screen, ox, oy, p, alpha, pictFade, snap.mobiles, descMap, snap.prevMobiles, snap.prevPictures, snap.picShiftX, snap.picShiftY)
+	}
 
 	if gs.hideMobiles {
 		for _, p := range zeroPics {
-            drawPicture(screen, ox, oy, p, alpha, pictFade, snap.mobiles, descMap, snap.prevMobiles, snap.prevPictures, snap.picShiftX, snap.picShiftY)
+			drawPicture(screen, ox, oy, p, alpha, pictFade, snap.mobiles, descMap, snap.prevMobiles, snap.prevPictures, snap.picShiftX, snap.picShiftY)
 		}
 	} else {
 		for _, m := range dead {
@@ -1042,15 +1057,15 @@ func drawScene(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha float6
 				}
 				i++
 			} else {
-                drawPicture(screen, ox, oy, zeroPics[j], alpha, pictFade, snap.mobiles, descMap, snap.prevMobiles, snap.prevPictures, snap.picShiftX, snap.picShiftY)
+				drawPicture(screen, ox, oy, zeroPics[j], alpha, pictFade, snap.mobiles, descMap, snap.prevMobiles, snap.prevPictures, snap.picShiftX, snap.picShiftY)
 				j++
 			}
 		}
 	}
 
-    for _, p := range posPics {
-        drawPicture(screen, ox, oy, p, alpha, pictFade, snap.mobiles, descMap, snap.prevMobiles, snap.prevPictures, snap.picShiftX, snap.picShiftY)
-    }
+	for _, p := range posPics {
+		drawPicture(screen, ox, oy, p, alpha, pictFade, snap.mobiles, descMap, snap.prevMobiles, snap.prevPictures, snap.picShiftX, snap.picShiftY)
+	}
 }
 
 // drawMobile renders a single mobile object with optional interpolation and onion skinning.
@@ -1216,14 +1231,14 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		w, h = clImages.Size(uint32(p.PictID))
 	}
 
-    var mobileX, mobileY float64
-    if gs.ObjectPinning && gs.MotionSmoothing && w <= 256 && h <= 256 {
-        if dx, dy, ok := pictureMobileOffset(p, mobiles, prevMobiles, prevPictures, alpha); ok {
-            mobileX, mobileY = dx, dy
-            offX = 0
-            offY = 0
-        }
-    }
+	var mobileX, mobileY float64
+	if gs.ObjectPinning && gs.MotionSmoothing && w <= 256 && h <= 256 {
+		if dx, dy, ok := pictureMobileOffset(p, mobiles, prevMobiles, prevPictures, alpha); ok {
+			mobileX, mobileY = dx, dy
+			offX = 0
+			offY = 0
+		}
+	}
 
 	x := roundToInt(((float64(p.H) + offX + mobileX) + float64(fieldCenterX)) * gs.GameScale)
 	y := roundToInt(((float64(p.V) + offY + mobileY) + float64(fieldCenterY)) * gs.GameScale)
@@ -1350,93 +1365,93 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 // mobile across frames using raw coordinates only (no picShift). When matched,
 // it returns the mobile's interpolated delta so the picture follows smoothly.
 func pictureMobileOffset(p framePicture, mobiles []frameMobile, prevMobiles map[uint8]frameMobile, prevPictures []framePicture, alpha float64) (float64, float64, bool) {
-    // Use exact previous picture position for the same PictID to verify the
-    // picture-to-mobile offset stayed identical across frames.
-    // Try the hero (playerIndex) first to ensure centered player effects pin.
-    for i := range mobiles {
-        if mobiles[i].Index != playerIndex {
-            continue
-        }
-        m := mobiles[i]
-        pm, ok := prevMobiles[m.Index]
-        if !ok {
-            break
-        }
-        offH := int(p.H) - int(m.H)
-        offV := int(p.V) - int(m.V)
-        if offH < -64 || offH > 64 || offV < -64 || offV > 64 {
-            break
-        }
-        expPrevH := int(pm.H) + offH
-        expPrevV := int(pm.V) + offV
-        for j := range prevPictures {
-            pp := prevPictures[j]
-            if pp.PictID != p.PictID {
-                continue
-            }
-            if int(pp.H) == expPrevH && int(pp.V) == expPrevV {
-                h := float64(pm.H)*(1-alpha) + float64(m.H)*alpha
-                v := float64(pm.V)*(1-alpha) + float64(m.V)*alpha
-                return h - float64(m.H), v - float64(m.V), true
-            }
-        }
-        break
-    }
-    bestDist := 64*64 + 1
-    var bestDX, bestDY float64
-    found := false
-    for _, m := range mobiles {
-        pm, ok := prevMobiles[m.Index]
-        if !ok {
-            continue
-        }
-        offH := int(p.H) - int(m.H)
-        offV := int(p.V) - int(m.V)
-        if offH < -64 || offH > 64 || offV < -64 || offV > 64 {
-            continue
-        }
-        // Expected previous picture position if offset is identical
-        expPrevH := int(pm.H) + offH
-        expPrevV := int(pm.V) + offV
-        match := false
-        for i := range prevPictures {
-            pp := prevPictures[i]
-            if pp.PictID != p.PictID {
-                continue
-            }
-            if int(pp.H) == expPrevH && int(pp.V) == expPrevV {
-                match = true
-                break
-            }
-        }
-        if !match {
-            continue
-        }
-        // Interpolate mobile
-        h := float64(pm.H)*(1-alpha) + float64(m.H)*alpha
-        v := float64(pm.V)*(1-alpha) + float64(m.V)*alpha
-        dist := offH*offH + offV*offV
-        if dist < bestDist {
-            bestDX = h - float64(m.H)
-            bestDY = v - float64(m.V)
-            bestDist = dist
-            found = true
-        }
-    }
-    if found {
-        return bestDX, bestDY, true
-    }
-    // Exact-center case: picture exactly at a mobile; requires prev sample
-    for _, m := range mobiles {
-        if int(p.H) == int(m.H) && int(p.V) == int(m.V) {
-            if pm, ok := prevMobiles[m.Index]; ok {
-                h := float64(pm.H)*(1-alpha) + float64(m.H)*alpha
-                v := float64(pm.V)*(1-alpha) + float64(m.V)*alpha
-                return h - float64(m.H), v - float64(m.V), true
-            }
-        }
-    }
-    return 0, 0, false
+	// Use exact previous picture position for the same PictID to verify the
+	// picture-to-mobile offset stayed identical across frames.
+	// Try the hero (playerIndex) first to ensure centered player effects pin.
+	for i := range mobiles {
+		if mobiles[i].Index != playerIndex {
+			continue
+		}
+		m := mobiles[i]
+		pm, ok := prevMobiles[m.Index]
+		if !ok {
+			break
+		}
+		offH := int(p.H) - int(m.H)
+		offV := int(p.V) - int(m.V)
+		if offH < -64 || offH > 64 || offV < -64 || offV > 64 {
+			break
+		}
+		expPrevH := int(pm.H) + offH
+		expPrevV := int(pm.V) + offV
+		for j := range prevPictures {
+			pp := prevPictures[j]
+			if pp.PictID != p.PictID {
+				continue
+			}
+			if int(pp.H) == expPrevH && int(pp.V) == expPrevV {
+				h := float64(pm.H)*(1-alpha) + float64(m.H)*alpha
+				v := float64(pm.V)*(1-alpha) + float64(m.V)*alpha
+				return h - float64(m.H), v - float64(m.V), true
+			}
+		}
+		break
+	}
+	bestDist := 64*64 + 1
+	var bestDX, bestDY float64
+	found := false
+	for _, m := range mobiles {
+		pm, ok := prevMobiles[m.Index]
+		if !ok {
+			continue
+		}
+		offH := int(p.H) - int(m.H)
+		offV := int(p.V) - int(m.V)
+		if offH < -64 || offH > 64 || offV < -64 || offV > 64 {
+			continue
+		}
+		// Expected previous picture position if offset is identical
+		expPrevH := int(pm.H) + offH
+		expPrevV := int(pm.V) + offV
+		match := false
+		for i := range prevPictures {
+			pp := prevPictures[i]
+			if pp.PictID != p.PictID {
+				continue
+			}
+			if int(pp.H) == expPrevH && int(pp.V) == expPrevV {
+				match = true
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+		// Interpolate mobile
+		h := float64(pm.H)*(1-alpha) + float64(m.H)*alpha
+		v := float64(pm.V)*(1-alpha) + float64(m.V)*alpha
+		dist := offH*offH + offV*offV
+		if dist < bestDist {
+			bestDX = h - float64(m.H)
+			bestDY = v - float64(m.V)
+			bestDist = dist
+			found = true
+		}
+	}
+	if found {
+		return bestDX, bestDY, true
+	}
+	// Exact-center case: picture exactly at a mobile; requires prev sample
+	for _, m := range mobiles {
+		if int(p.H) == int(m.H) && int(p.V) == int(m.V) {
+			if pm, ok := prevMobiles[m.Index]; ok {
+				h := float64(pm.H)*(1-alpha) + float64(m.H)*alpha
+				v := float64(pm.V)*(1-alpha) + float64(m.V)*alpha
+				return h - float64(m.H), v - float64(m.V), true
+			}
+		}
+	}
+	return 0, 0, false
 }
 
 // drawMobileNameTag renders the name tag and color bar for a single mobile.

--- a/music_command_test.go
+++ b/music_command_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
 func TestParseMusicCommandWithWho(t *testing.T) {
 	// Ensure /music commands with a leading /who segment are parsed.
@@ -12,5 +16,66 @@ func TestParseMusicCommandWithWho(t *testing.T) {
 func TestParseMusicCommandRawFallback(t *testing.T) {
 	if !parseMusicCommand("", []byte("/music/play/inst1/notesabc")) {
 		t.Fatalf("parseMusicCommand failed to parse raw payload")
+	}
+}
+
+// TestParseMusicCommandFromMovie extracts a /music payload from the lore1.clMov
+// sample and verifies that parseMusicCommand can decode it when debug logging
+// is enabled.
+func TestParseMusicCommandFromMovie(t *testing.T) {
+	frames, err := parseMovie("clmovFiles/lore1.clMov", baseVersion)
+	if err != nil {
+		t.Fatalf("parseMovie: %v", err)
+	}
+	var msg []byte
+	for _, f := range frames {
+		if idx := bytes.Index(f, []byte("/music/")); idx >= 0 {
+			msg = f[idx:]
+			if j := bytes.IndexByte(msg, 0); j >= 0 {
+				msg = msg[:j]
+			}
+			break
+		}
+	}
+	if len(msg) == 0 {
+		t.Fatalf("no /music payload found in movie frames")
+	}
+
+	s := string(msg)
+	inst := "10"
+	if idx := strings.Index(s, "/inst"); idx >= 0 {
+		v := s[idx+len("/inst"):]
+		v = strings.TrimPrefix(v, "/")
+		if j := strings.IndexByte(v, '/'); j >= 0 {
+			v = v[:j]
+		}
+		inst = v
+	}
+	notes := ""
+	if idx := strings.Index(s, "/notes"); idx >= 0 {
+		notes = s[idx+len("/notes"):]
+	} else if idx := strings.Index(s, "/N"); idx >= 0 {
+		notes = s[idx+len("/N"):]
+	} else {
+		notes = s
+	}
+	notes = strings.Trim(notes, "/")
+	expected := "/play " + inst + " " + notes
+
+	consoleLog.entries = nil
+	musicDebug = true
+	defer func() { musicDebug = false }()
+	if !parseMusicCommand("", msg) {
+		t.Fatalf("parseMusicCommand failed to parse clMov payload")
+	}
+	found := false
+	for _, m := range consoleLog.entries {
+		if m.Text == expected {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected %q in console log, got %#v", expected, consoleLog.entries)
 	}
 }

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -377,10 +378,22 @@ func parseBardText(raw []byte, s string) bool {
 // backend messages like "/music/.../play/inst<inst>/notes<notes>". If the
 // stripped text is empty, it falls back to decoding the raw BEPP payload.
 func parseMusicCommand(s string, raw []byte) bool {
+	orig := s
+	debug := func(msg string) {
+		if musicDebug {
+			consoleMessage(msg)
+			chatMessage(msg)
+			log.Print(msg)
+		}
+	}
 	if s == "" && len(raw) > 0 {
 		s = strings.TrimSpace(decodeMacRoman(raw))
+		orig = s
 	}
 	if s == "" {
+		if orig != "" {
+			debug(orig)
+		}
 		return false
 	}
 	if strings.HasPrefix(s, "/music/") {
@@ -398,6 +411,7 @@ func parseMusicCommand(s string, raw []byte) bool {
 	} else if len(s) > 0 && (s[0] == 'P' || s[0] == 'p') {
 		s = s[1:]
 	} else {
+		debug(orig)
 		return false
 	}
 
@@ -437,15 +451,23 @@ func parseMusicCommand(s string, raw []byte) bool {
 	}
 	notes = strings.Trim(notes, "/")
 	if notes == "" {
+		debug(orig)
 		return false
 	}
-	//go playClanLordTune(strconv.Itoa(inst) + " " + strings.TrimSpace(notes))
 
+	tune := strconv.Itoa(inst) + " " + strings.TrimSpace(notes)
 	if musicDebug {
-		msg := "/play " + strconv.Itoa(inst) + " " + strings.TrimSpace(notes)
-		consoleMessage(msg)
-		chatMessage(msg)
+		msg := "/play " + tune
+		debug(msg)
 	}
+	go func() {
+		if err := playClanLordTune(tune); err != nil {
+			log.Printf("play tune: %v", err)
+			if musicDebug {
+				debug("play tune: " + err.Error())
+			}
+		}
+	}()
 	return true
 }
 

--- a/tune.go
+++ b/tune.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -54,10 +54,13 @@ type noteEvent struct {
 
 // playClanLordTune decodes a Clan Lord music string and plays it using the
 // music package. The tune may optionally begin with an instrument index.
-// For example: "3 cde" plays on instrument #3.
-func playClanLordTune(tune string) {
-	if audioContext == nil || gs.Mute || gs.MusicVolume <= 0 {
-		return
+// For example: "3 cde" plays on instrument #3. It returns any playback error.
+func playClanLordTune(tune string) error {
+	if audioContext == nil {
+		return fmt.Errorf("audio disabled")
+	}
+	if gs.Mute || gs.MusicVolume <= 0 {
+		return fmt.Errorf("music muted")
 	}
 
 	inst := defaultInstrument
@@ -71,16 +74,14 @@ func playClanLordTune(tune string) {
 
 	events := parseClanLordTune(tune)
 	if len(events) == 0 {
-		return
+		return fmt.Errorf("empty tune")
 	}
 
 	prog := instruments[inst].program
 	oct := instruments[inst].octave
 
 	notes := eventsToNotes(events, oct)
-	if err := Play(audioContext, prog, notes); err != nil {
-		log.Printf("play note: %v", err)
-	}
+	return Play(audioContext, prog, notes)
 }
 
 // eventsToNotes converts parsed note events into synth notes with explicit start


### PR DESCRIPTION
## Summary
- Play bard tunes when parsing /music and log playback errors
- Allow debug logging of tune messages without suppressing playback
- Propagate playback errors from `playClanLordTune`
- Surface debug tune commands and errors to console/chat when `-musicDebug`
- Log unparsed `/music` messages in debug mode to help diagnose missing playback
- Return explicit errors when audio output is unavailable or tune is empty
- Add regression test exercising `/music` payload from `lore1.clMov`
- Add test parsing `lore1.clMov` via `parseMovie` to assert the emitted `/play` tune

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; fatal error: X11/extensions/Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory; Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e490fcf0832a8ce34363b2617d00