### PR TITLE
Align tune durations with classic client

### DIFF
--- a/tune.go
+++ b/tune.go
@@ -1,16 +1,21 @@
 package main
 
 import (
-    "log"
-    "fmt"
-    "strconv"
-    "strings"
-    "time"
-    "unicode"
-    "sync"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
 )
 
-const defaultInstrument = 10
+const (
+	defaultInstrument    = 10
+	durationBlack        = 2.0
+	durationWhite        = 4.0
+	defaultChordDuration = 4.0
+)
 
 // instruments holds the instrument table extracted from the classic client.
 // Only the program number and octave offset are currently used.
@@ -43,48 +48,48 @@ var instruments = []instrument{
 // instrument describes a playable instrument mapping Clan Lord's instrument
 // index to a General MIDI program number and an octave offset.
 type instrument struct {
-    program int
-    octave  int
+	program int
+	octave  int
 }
 
 // queue sequentializes tune playback so overlapping /play commands do not
 // render concurrently. Each tune section is played to completion before the
 // next begins.
 type tuneJob struct {
-    program int
-    notes   []Note
-    who     int
+	program int
+	notes   []Note
+	who     int
 }
 
 var (
-    tuneOnce  sync.Once
-    tuneQueue chan tuneJob
-    currentMu sync.Mutex
-    currentWho int
+	tuneOnce   sync.Once
+	tuneQueue  chan tuneJob
+	currentMu  sync.Mutex
+	currentWho int
 )
 
 func startTuneWorker() {
-    tuneQueue = make(chan tuneJob, 128)
-    go func() {
-        for job := range tuneQueue {
-            if audioContext == nil {
-                continue
-            }
-            currentMu.Lock()
-            currentWho = job.who
-            currentMu.Unlock()
-            if err := Play(audioContext, job.program, job.notes); err != nil {
-                log.Printf("play tune worker: %v", err)
-                if musicDebug {
-                    consoleMessage("play tune: " + err.Error())
-                    chatMessage("play tune: " + err.Error())
-                }
-            }
-            currentMu.Lock()
-            currentWho = 0
-            currentMu.Unlock()
-        }
-    }()
+	tuneQueue = make(chan tuneJob, 128)
+	go func() {
+		for job := range tuneQueue {
+			if audioContext == nil {
+				continue
+			}
+			currentMu.Lock()
+			currentWho = job.who
+			currentMu.Unlock()
+			if err := Play(audioContext, job.program, job.notes); err != nil {
+				log.Printf("play tune worker: %v", err)
+				if musicDebug {
+					consoleMessage("play tune: " + err.Error())
+					chatMessage("play tune: " + err.Error())
+				}
+			}
+			currentMu.Lock()
+			currentWho = 0
+			currentMu.Unlock()
+		}
+	}()
 }
 
 // noteEvent represents a parsed tune event. A single event may contain multiple
@@ -98,11 +103,11 @@ type noteEvent struct {
 // music package. The tune may optionally begin with an instrument index.
 // For example: "3 cde" plays on instrument #3. It returns any playback error.
 func playClanLordTune(tune string) error {
-    if audioContext == nil {
-        return fmt.Errorf("audio disabled")
-    }
-    if gs.Mute || gs.MusicVolume <= 0 {
-        return fmt.Errorf("music muted")
+	if audioContext == nil {
+		return fmt.Errorf("audio disabled")
+	}
+	if gs.Mute || gs.MusicVolume <= 0 {
+		return fmt.Errorf("music muted")
 	}
 
 	inst := defaultInstrument
@@ -114,7 +119,7 @@ func playClanLordTune(tune string) error {
 		}
 	}
 
-    events := parseClanLordTuneWithTempo(tune, 120)
+	events := parseClanLordTuneWithTempo(tune, 120)
 	if len(events) == 0 {
 		return fmt.Errorf("empty tune")
 	}
@@ -122,60 +127,60 @@ func playClanLordTune(tune string) error {
 	prog := instruments[inst].program
 	oct := instruments[inst].octave
 
-    notes := eventsToNotes(events, oct, 100)
+	notes := eventsToNotes(events, oct, 100)
 
-    // Enqueue for sequential playback and return immediately.
-    tuneOnce.Do(startTuneWorker)
-    select {
-    case tuneQueue <- tuneJob{program: prog, notes: notes}:
-    default:
-        // If the queue is full, drop the oldest by draining one then enqueue.
-        // This prevents unbounded growth during bursts.
-        select {
-        case <-tuneQueue:
-        default:
-        }
-        tuneQueue <- tuneJob{program: prog, notes: notes}
-    }
-    return nil
+	// Enqueue for sequential playback and return immediately.
+	tuneOnce.Do(startTuneWorker)
+	select {
+	case tuneQueue <- tuneJob{program: prog, notes: notes}:
+	default:
+		// If the queue is full, drop the oldest by draining one then enqueue.
+		// This prevents unbounded growth during bursts.
+		select {
+		case <-tuneQueue:
+		default:
+		}
+		tuneQueue <- tuneJob{program: prog, notes: notes}
+	}
+	return nil
 }
 
 // eventsToNotes converts parsed note events into synth notes with explicit start
 // times. All notes in the same event (a chord) share the same start time.
 func eventsToNotes(events []noteEvent, oct int, velocity int) []Note {
-    var notes []Note
-    startMS := 0
-    for _, ev := range events {
-        for _, k := range ev.keys {
-            key := k + oct*12
-            if key < 0 || key > 127 {
-                continue
-            }
-            notes = append(notes, Note{
-                Key:      key,
-                Velocity: velocity,
-                Start:    time.Duration(startMS) * time.Millisecond,
-                Duration: time.Duration(ev.durMS) * time.Millisecond,
-            })
-        }
-        startMS += ev.durMS
-    }
-    return notes
+	var notes []Note
+	startMS := 0
+	for _, ev := range events {
+		for _, k := range ev.keys {
+			key := k + oct*12
+			if key < 0 || key > 127 {
+				continue
+			}
+			notes = append(notes, Note{
+				Key:      key,
+				Velocity: velocity,
+				Start:    time.Duration(startMS) * time.Millisecond,
+				Duration: time.Duration(ev.durMS) * time.Millisecond,
+			})
+		}
+		startMS += ev.durMS
+	}
+	return notes
 }
 
 // parseClanLordTune converts Clan Lord music notation into a slice of note
 // events at the default tempo of 120 BPM.
 func parseClanLordTune(s string) []noteEvent {
-    return parseClanLordTuneWithTempo(s, 120)
+	return parseClanLordTuneWithTempo(s, 120)
 }
 
 // parseClanLordTuneWithTempo converts Clan Lord music notation into a slice of
 // note events using the provided tempo in BPM.
 func parseClanLordTuneWithTempo(s string, tempo int) []noteEvent {
-    if tempo <= 0 {
-        tempo = 120
-    }
-    quarter := 60000 / tempo // ms
+	if tempo <= 0 {
+		tempo = 120
+	}
+	quarter := 60000 / tempo // ms
 	octave := 4
 	i := 0
 	var events []noteEvent
@@ -208,9 +213,9 @@ func parseClanLordTuneWithTempo(s string, tempo int) []noteEvent {
 			i++
 		case 'p': // rest
 			i++
-			durBeats := 1.0
+			durBeats := durationBlack
 			if i < len(s) && s[i] >= '1' && s[i] <= '9' {
-				durBeats = 4.0 / float64(s[i]-'0')
+				durBeats = float64(s[i] - '0')
 				i++
 			}
 			events = append(events, noteEvent{nil, int(durBeats * float64(quarter))})
@@ -234,9 +239,9 @@ func parseClanLordTuneWithTempo(s string, tempo int) []noteEvent {
 			if i < len(s) && s[i] == ']' {
 				i++
 			}
-			durBeats := 1.0
+			durBeats := defaultChordDuration
 			if i < len(s) && s[i] >= '1' && s[i] <= '9' {
-				durBeats = 4.0 / float64(s[i]-'0')
+				durBeats = float64(s[i] - '0')
 				i++
 			}
 			if len(keys) > 0 {
@@ -288,9 +293,9 @@ func parseNoteCL(s string, i *int, octave *int) (int, float64) {
 	}
 	(*i)++
 	pitch := base + ((*octave)+1)*12
-	beats := 1.0
+	beats := durationBlack
 	if isUpper {
-		beats = 2.0
+		beats = durationWhite
 	}
 	for *i < len(s) {
 		ch := s[*i]
@@ -302,7 +307,7 @@ func parseNoteCL(s string, i *int, octave *int) (int, float64) {
 			pitch--
 			(*i)++
 		case ch >= '1' && ch <= '9':
-			beats = 4.0 / float64(ch-'0')
+			beats = float64(ch - '0')
 			(*i)++
 		case ch == '_':
 			(*i)++ // ignore ties
@@ -334,216 +339,237 @@ func noteOffset(r rune) int {
 }
 
 func isNoteLetter(b byte) bool {
-    return (b >= 'a' && b <= 'g') || (b >= 'A' && b <= 'G')
+	return (b >= 'a' && b <= 'g') || (b >= 'A' && b <= 'G')
 }
 
 // Extended support for /music commands
 type MusicParams struct {
-    Inst   int
-    Notes  string
-    Tempo  int // BPM 60..180
-    VolPct int // 0..100
-    Part   bool
-    Stop   bool
-    Who    int
-    With   []int
-    Me     bool
+	Inst   int
+	Notes  string
+	Tempo  int // BPM 60..180
+	VolPct int // 0..100
+	Part   bool
+	Stop   bool
+	Who    int
+	With   []int
+	Me     bool
 }
 
 // Internal state for assembling multipart songs.
 type pendingSong struct {
-    inst   int
-    tempo  int
-    volPct int
-    notes  []string
-    withIDs []int
+	inst    int
+	tempo   int
+	volPct  int
+	notes   []string
+	withIDs []int
 }
 
 var (
-    pendingMu   sync.Mutex
-    pendingByID = make(map[int]*pendingSong)
+	pendingMu   sync.Mutex
+	pendingByID = make(map[int]*pendingSong)
 )
 
 // handleMusicParams translates parsed music params into queued playback. It
 // supports /stop, /part accumulation and tempo/volume/instrument parameters.
 func handleMusicParams(mp MusicParams) {
-    if mp.Stop {
-        // Scoped stop: if who provided, clear that pending and stop if playing.
-        if mp.Who != 0 {
-            pendingMu.Lock()
-            delete(pendingByID, mp.Who)
-            pendingMu.Unlock()
-            currentMu.Lock()
-            cw := currentWho
-            currentMu.Unlock()
-            if cw == mp.Who {
-                stopAllMusic()
-            }
-        } else {
-            // Global stop
-            pendingMu.Lock()
-            pendingByID = make(map[int]*pendingSong)
-            pendingMu.Unlock()
-            stopAllMusic()
-        }
-        return
-    }
-    // Ignore play requests while muted, matching classic behavior when sound
-    // is off. Still handled /stop above regardless of mute state.
-    if gs.Mute || gs.MusicVolume <= 0 {
-        return
-    }
-    // Validate basics
-    if mp.Inst < 0 || mp.Inst >= len(instruments) {
-        mp.Inst = defaultInstrument
-    }
-    if mp.Tempo <= 0 {
-        mp.Tempo = 120
-    }
-    if mp.VolPct <= 0 {
-        mp.VolPct = 100
-    }
-    id := mp.Who // 0 is the system queue
+	if mp.Stop {
+		// Scoped stop: if who provided, clear that pending and stop if playing.
+		if mp.Who != 0 {
+			pendingMu.Lock()
+			delete(pendingByID, mp.Who)
+			pendingMu.Unlock()
+			currentMu.Lock()
+			cw := currentWho
+			currentMu.Unlock()
+			if cw == mp.Who {
+				stopAllMusic()
+			}
+		} else {
+			// Global stop
+			pendingMu.Lock()
+			pendingByID = make(map[int]*pendingSong)
+			pendingMu.Unlock()
+			stopAllMusic()
+		}
+		return
+	}
+	// Ignore play requests while muted, matching classic behavior when sound
+	// is off. Still handled /stop above regardless of mute state.
+	if gs.Mute || gs.MusicVolume <= 0 {
+		return
+	}
+	// Validate basics
+	if mp.Inst < 0 || mp.Inst >= len(instruments) {
+		mp.Inst = defaultInstrument
+	}
+	if mp.Tempo <= 0 {
+		mp.Tempo = 120
+	}
+	if mp.VolPct <= 0 {
+		mp.VolPct = 100
+	}
+	id := mp.Who // 0 is the system queue
 
-    // Accumulate multipart songs when /part is present.
-    if mp.Part {
-        pendingMu.Lock()
-        ps := pendingByID[id]
-        if ps == nil {
-            ps = &pendingSong{inst: mp.Inst, tempo: mp.Tempo, volPct: mp.VolPct}
-            pendingByID[id] = ps
-        } else {
-            if mp.Inst != 0 {
-                ps.inst = mp.Inst
-            }
-            if mp.Tempo != 0 {
-                ps.tempo = mp.Tempo
-            }
-            if mp.VolPct != 0 {
-                ps.volPct = mp.VolPct
-            }
-        }
-        if n := strings.TrimSpace(mp.Notes); n != "" {
-            ps.notes = append(ps.notes, n)
-        }
-        if len(mp.With) > 0 {
-            ps.withIDs = append([]int(nil), mp.With...)
-        }
-        pendingMu.Unlock()
-        return
-    }
+	// Accumulate multipart songs when /part is present.
+	if mp.Part {
+		pendingMu.Lock()
+		ps := pendingByID[id]
+		if ps == nil {
+			ps = &pendingSong{inst: mp.Inst, tempo: mp.Tempo, volPct: mp.VolPct}
+			pendingByID[id] = ps
+		} else {
+			if mp.Inst != 0 {
+				ps.inst = mp.Inst
+			}
+			if mp.Tempo != 0 {
+				ps.tempo = mp.Tempo
+			}
+			if mp.VolPct != 0 {
+				ps.volPct = mp.VolPct
+			}
+		}
+		if n := strings.TrimSpace(mp.Notes); n != "" {
+			ps.notes = append(ps.notes, n)
+		}
+		if len(mp.With) > 0 {
+			ps.withIDs = append([]int(nil), mp.With...)
+		}
+		pendingMu.Unlock()
+		return
+	}
 
-    // Finalize: merge any pending parts, then queue a single tune.
-    inst := mp.Inst
-    tempo := mp.Tempo
-    vol := mp.VolPct
-    notes := strings.TrimSpace(mp.Notes)
-    pendingMu.Lock()
-    if ps := pendingByID[id]; ps != nil {
-        if notes != "" {
-            ps.notes = append(ps.notes, notes)
-        }
-        notes = strings.Join(ps.notes, " ")
-        if ps.inst != 0 {
-            inst = ps.inst
-        }
-        if ps.tempo != 0 {
-            tempo = ps.tempo
-        }
-        if ps.volPct != 0 {
-            vol = ps.volPct
-        }
-        if len(mp.With) == 0 && len(ps.withIDs) > 0 {
-            mp.With = append([]int(nil), ps.withIDs...)
-        }
-        delete(pendingByID, id)
-    }
-    // If sync requested via /with, require that all referenced IDs also have
-    // pending content; otherwise, store this song and return until ready.
-    if len(mp.With) > 0 {
-        // Save current as pending with its group
-        p := &pendingSong{inst: inst, tempo: tempo, volPct: vol, notes: []string{notes}, withIDs: append([]int(nil), mp.With...)}
-        pendingByID[id] = p
-        // Check readiness of group (including self)
-        all := append([]int{id}, mp.With...)
-        ready := true
-        for _, w := range all {
-            if _, ok := pendingByID[w]; !ok {
-                ready = false
-                break
-            }
-        }
-        if !ready {
-            pendingMu.Unlock()
-            return
-        }
-        // All parts present: build jobs in sorted order
-        // Deduplicate and sort IDs
-        idmap := map[int]struct{}{}
-        for _, w := range all { idmap[w] = struct{}{} }
-        ids := make([]int, 0, len(idmap))
-        for w := range idmap { ids = append(ids, w) }
-        // simple insertion sort
-        for i:=1;i<len(ids);i++{j:=i;for j>0 && ids[j-1]>ids[j]{ids[j-1],ids[j]=ids[j],ids[j-1];j--}}
-        jobs := make([]tuneJob, 0, len(ids))
-        for _, w := range ids {
-            ps := pendingByID[w]
-            nstr := strings.Join(ps.notes, " ")
-            jobs = append(jobs, makeTuneJob(w, ps.inst, ps.tempo, ps.volPct, nstr))
-            delete(pendingByID, w)
-        }
-        pendingMu.Unlock()
-        // Enqueue jobs sequentially
-        for _, job := range jobs {
-            enqueueTune(job)
-        }
-        return
-    }
-    pendingMu.Unlock()
-    if notes == "" {
-        return
-    }
+	// Finalize: merge any pending parts, then queue a single tune.
+	inst := mp.Inst
+	tempo := mp.Tempo
+	vol := mp.VolPct
+	notes := strings.TrimSpace(mp.Notes)
+	pendingMu.Lock()
+	if ps := pendingByID[id]; ps != nil {
+		if notes != "" {
+			ps.notes = append(ps.notes, notes)
+		}
+		notes = strings.Join(ps.notes, " ")
+		if ps.inst != 0 {
+			inst = ps.inst
+		}
+		if ps.tempo != 0 {
+			tempo = ps.tempo
+		}
+		if ps.volPct != 0 {
+			vol = ps.volPct
+		}
+		if len(mp.With) == 0 && len(ps.withIDs) > 0 {
+			mp.With = append([]int(nil), ps.withIDs...)
+		}
+		delete(pendingByID, id)
+	}
+	// If sync requested via /with, require that all referenced IDs also have
+	// pending content; otherwise, store this song and return until ready.
+	if len(mp.With) > 0 {
+		// Save current as pending with its group
+		p := &pendingSong{inst: inst, tempo: tempo, volPct: vol, notes: []string{notes}, withIDs: append([]int(nil), mp.With...)}
+		pendingByID[id] = p
+		// Check readiness of group (including self)
+		all := append([]int{id}, mp.With...)
+		ready := true
+		for _, w := range all {
+			if _, ok := pendingByID[w]; !ok {
+				ready = false
+				break
+			}
+		}
+		if !ready {
+			pendingMu.Unlock()
+			return
+		}
+		// All parts present: build jobs in sorted order
+		// Deduplicate and sort IDs
+		idmap := map[int]struct{}{}
+		for _, w := range all {
+			idmap[w] = struct{}{}
+		}
+		ids := make([]int, 0, len(idmap))
+		for w := range idmap {
+			ids = append(ids, w)
+		}
+		// simple insertion sort
+		for i := 1; i < len(ids); i++ {
+			j := i
+			for j > 0 && ids[j-1] > ids[j] {
+				ids[j-1], ids[j] = ids[j], ids[j-1]
+				j--
+			}
+		}
+		jobs := make([]tuneJob, 0, len(ids))
+		for _, w := range ids {
+			ps := pendingByID[w]
+			nstr := strings.Join(ps.notes, " ")
+			jobs = append(jobs, makeTuneJob(w, ps.inst, ps.tempo, ps.volPct, nstr))
+			delete(pendingByID, w)
+		}
+		pendingMu.Unlock()
+		// Enqueue jobs sequentially
+		for _, job := range jobs {
+			enqueueTune(job)
+		}
+		return
+	}
+	pendingMu.Unlock()
+	if notes == "" {
+		return
+	}
 
-    job := makeTuneJob(id, inst, tempo, vol, notes)
-    enqueueTune(job)
+	job := makeTuneJob(id, inst, tempo, vol, notes)
+	enqueueTune(job)
 }
 
 func makeTuneJob(who, inst, tempo, vol int, notes string) tuneJob {
-    events := parseClanLordTuneWithTempo(notes, tempo)
-    prog := instruments[inst].program
-    oct := instruments[inst].octave
-    // Scale 0..100 to 1..127 velocity.
-    vel := vol
-    if vel <= 0 { vel = 100 }
-    if vel > 100 { vel = 100 }
-    vel = int(float64(vel)*1.27 + 0.5)
-    if vel < 1 { vel = 1 } else if vel > 127 { vel = 127 }
-    notesOut := eventsToNotes(events, oct, vel)
-    return tuneJob{program: prog, notes: notesOut, who: who}
+	events := parseClanLordTuneWithTempo(notes, tempo)
+	prog := instruments[inst].program
+	oct := instruments[inst].octave
+	// Scale 0..100 to 1..127 velocity.
+	vel := vol
+	if vel <= 0 {
+		vel = 100
+	}
+	if vel > 100 {
+		vel = 100
+	}
+	vel = int(float64(vel)*1.27 + 0.5)
+	if vel < 1 {
+		vel = 1
+	} else if vel > 127 {
+		vel = 127
+	}
+	notesOut := eventsToNotes(events, oct, vel)
+	return tuneJob{program: prog, notes: notesOut, who: who}
 }
 
 func enqueueTune(job tuneJob) {
-    tuneOnce.Do(startTuneWorker)
-    select {
-    case tuneQueue <- job:
-    default:
-        select { case <-tuneQueue: default: }
-        tuneQueue <- job
-    }
+	tuneOnce.Do(startTuneWorker)
+	select {
+	case tuneQueue <- job:
+	default:
+		select {
+		case <-tuneQueue:
+		default:
+		}
+		tuneQueue <- job
+	}
 }
 
 // clearTuneQueue drains any queued tunes so newly queued items can take effect
 // immediately after mute/unmute or a stop request.
 func clearTuneQueue() {
-    if tuneQueue == nil {
-        return
-    }
-    for {
-        select {
-        case <-tuneQueue:
-            // drained one
-        default:
-            return
-        }
-    }
+	if tuneQueue == nil {
+		return
+	}
+	for {
+		select {
+		case <-tuneQueue:
+			// drained one
+		default:
+			return
+		}
+	}
 }

--- a/tune_test.go
+++ b/tune_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// Stubs to satisfy references in tune.go when building this test.
+type Note struct {
+	Key      int
+	Velocity int
+	Start    time.Duration
+	Duration time.Duration
+}
+
+var audioContext interface{}
+var gs struct {
+	Mute        bool
+	MusicVolume int
+}
+var musicDebug bool
+
+func Play(interface{}, int, []Note) error { return nil }
+func consoleMessage(string)               {}
+func chatMessage(string)                  {}
+func stopAllMusic()                       {}
+
+func TestParseClanLordTuneDurations(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []int
+	}{
+		{"c", []int{1000}},     // lowercase uses durationBlack=2 beats
+		{"C", []int{2000}},     // uppercase uses durationWhite=4 beats
+		{"c1", []int{500}},     // explicit duration 1 beat
+		{"p", []int{1000}},     // rest defaults to durationBlack
+		{"[ce]", []int{2000}},  // chord defaults to defaultChordDuration
+		{"[ce]3", []int{1500}}, // chord with explicit duration
+	}
+	for _, tt := range tests {
+		events := parseClanLordTuneWithTempo(tt.input, 120)
+		if len(events) != len(tt.want) {
+			t.Fatalf("%q parsed to %d events, want %d", tt.input, len(events), len(tt.want))
+		}
+		for i, ev := range events {
+			if ev.durMS != tt.want[i] {
+				t.Errorf("%q event %d duration = %d, want %d", tt.input, i, ev.durMS, tt.want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Map lowercase notes to classic `duration_Black` beats and uppercase to `duration_White`
- Treat numeric modifiers as raw beat counts and update rest/chord defaults for parity with the Mac client
- Add regression test verifying parsed beat lengths

## Testing
- `go test ./...` *(fails: synth_test.go undefined: synth)*
- `go test tune.go tune_test.go -run TestParseClanLordTuneDurations -v`


------
https://chatgpt.com/codex/tasks/task_e_68aa1ce3f190832aa6aa6cee9da7b5e7