### PR TITLE
Shorten note playback for classic timing

### DIFF
--- a/tune.go
+++ b/tune.go
@@ -151,6 +151,8 @@ func eventsToNotes(events []noteEvent, oct int, velocity int) []Note {
 	var notes []Note
 	startMS := 0
 	for _, ev := range events {
+		noteMS := ev.durMS * 9 / 10
+		restMS := ev.durMS - noteMS
 		for _, k := range ev.keys {
 			key := k + oct*12
 			if key < 0 || key > 127 {
@@ -160,10 +162,10 @@ func eventsToNotes(events []noteEvent, oct int, velocity int) []Note {
 				Key:      key,
 				Velocity: velocity,
 				Start:    time.Duration(startMS) * time.Millisecond,
-				Duration: time.Duration(ev.durMS) * time.Millisecond,
+				Duration: time.Duration(noteMS) * time.Millisecond,
 			})
 		}
-		startMS += ev.durMS
+		startMS += noteMS + restMS
 	}
 	return notes
 }

--- a/tune_test.go
+++ b/tune_test.go
@@ -49,3 +49,21 @@ func TestParseClanLordTuneDurations(t *testing.T) {
 		}
 	}
 }
+
+func TestEventsToNotesAddsGap(t *testing.T) {
+	events := parseClanLordTune("cd")
+	notes := eventsToNotes(events, 0, 100)
+	if len(notes) != 2 {
+		t.Fatalf("expected 2 notes, got %d", len(notes))
+	}
+	if notes[0].Duration != 900*time.Millisecond {
+		t.Fatalf("first note duration = %v, want 900ms", notes[0].Duration)
+	}
+	if notes[1].Start != 1000*time.Millisecond {
+		t.Fatalf("second note start = %v, want 1000ms", notes[1].Start)
+	}
+	gap := notes[1].Start - notes[0].Start - notes[0].Duration
+	if gap != 100*time.Millisecond {
+		t.Fatalf("gap = %v, want 100ms", gap)
+	}
+}


### PR DESCRIPTION
## Summary
- reduce each note duration to 90% of its beat length
- ensure a 10% rest between notes for classic tune spacing
- add test covering note gap logic

## Testing
- `go test tune_test.go tune.go`

------
https://chatgpt.com/codex/tasks/task_e_68aa1efe4204832abc8e251a8b378fbd