### PR TITLE
Add instrument velocity scaling for chords and melody

### DIFF
--- a/synth_test.go
+++ b/synth_test.go
@@ -87,7 +87,8 @@ func TestPlayOverlappingNotes(t *testing.T) {
 
 func TestEventsToNotesChordStart(t *testing.T) {
 	events := parseClanLordTune("[ce]d")
-	notes := eventsToNotes(events, 0)
+	inst := instrument{program: 0, octave: 0, chord: 100, melody: 100}
+	notes := eventsToNotes(events, inst, 100)
 	if len(notes) != 3 {
 		t.Fatalf("expected 3 notes, got %d", len(notes))
 	}

--- a/tune_test.go
+++ b/tune_test.go
@@ -52,7 +52,8 @@ func TestParseClanLordTuneDurations(t *testing.T) {
 
 func TestEventsToNotesAddsGap(t *testing.T) {
 	events := parseClanLordTune("cd")
-	notes := eventsToNotes(events, 0, 100)
+	inst := instrument{program: 0, octave: 0, chord: 100, melody: 100}
+	notes := eventsToNotes(events, inst, 100)
 	if len(notes) != 2 {
 		t.Fatalf("expected 2 notes, got %d", len(notes))
 	}
@@ -65,5 +66,34 @@ func TestEventsToNotesAddsGap(t *testing.T) {
 	gap := notes[1].Start - notes[0].Start - notes[0].Duration
 	if gap != 100*time.Millisecond {
 		t.Fatalf("gap = %v, want 100ms", gap)
+	}
+}
+
+func TestInstrumentVelocityFactors(t *testing.T) {
+	inst0 := instruments[0]
+	if inst0.chord != 100 || inst0.melody != 100 {
+		t.Fatalf("instrument 0 velocities = %d,%d; want 100,100", inst0.chord, inst0.melody)
+	}
+	inst1 := instruments[1]
+	if inst1.chord != 100 || inst1.melody != 100 {
+		t.Fatalf("instrument 1 velocities = %d,%d; want 100,100", inst1.chord, inst1.melody)
+	}
+}
+
+func TestEventsToNotesVelocityFactors(t *testing.T) {
+	inst := instrument{program: 0, octave: 0, chord: 50, melody: 100}
+	events := []noteEvent{
+		{keys: []int{60, 64}, durMS: 1000},
+		{keys: []int{67}, durMS: 1000},
+	}
+	notes := eventsToNotes(events, inst, 100)
+	if len(notes) != 3 {
+		t.Fatalf("expected 3 notes, got %d", len(notes))
+	}
+	if notes[0].Velocity != 50 || notes[1].Velocity != 50 {
+		t.Fatalf("chord note velocities = %d,%d; want 50", notes[0].Velocity, notes[1].Velocity)
+	}
+	if notes[2].Velocity != 100 {
+		t.Fatalf("melody note velocity = %d; want 100", notes[2].Velocity)
 	}
 }


### PR DESCRIPTION
## Summary
- extend instrument table with chord and melody velocity factors
- apply instrument-specific velocity scaling in `eventsToNotes`
- test instrument velocity values and velocity application

## Testing
- `go test ./...` *(fails: redeclared identifiers and missing synth vars)*

------
https://chatgpt.com/codex/tasks/task_e_68aa20d890ac832a93a949eceaafe974