### PR TITLE
Parse loops, tempo shifts, and volume in tunes

### DIFF
--- a/synth_test.go
+++ b/synth_test.go
@@ -86,9 +86,9 @@ func TestPlayOverlappingNotes(t *testing.T) {
 }
 
 func TestEventsToNotesChordStart(t *testing.T) {
-	events := parseClanLordTune("[ce]d")
+	pt := parseClanLordTune("[ce]d")
 	inst := instrument{program: 0, octave: 0, chord: 100, melody: 100}
-	notes := eventsToNotes(events, inst, 100)
+	notes := eventsToNotes(pt, inst, 100)
 	if len(notes) != 3 {
 		t.Fatalf("expected 3 notes, got %d", len(notes))
 	}


### PR DESCRIPTION
## Summary
- Track loop markers, tempo events, and volume changes when parsing Clan Lord tunes
- Apply loops, tempo shifts, and volume scaling when converting events to playable notes
- Add unit tests for loops, tempo changes, and volume modifiers

## Testing
- `go test ./...` *(fails: Package 'alsa' not found; Xrandr headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2f657554832a95048ca39adb3472