### PR TITLE
Guard music buffer wait with loop

### DIFF
--- a/synth.go
+++ b/synth.go
@@ -419,7 +419,9 @@ func (m *musicStream) Read(p []byte) (int, error) {
 			m.mu.Unlock()
 			return 0, io.EOF
 		}
-		m.cond.Wait()
+		for m.bufLen() == 0 && m.pos < m.total && !m.closed {
+			m.cond.Wait()
+		}
 		m.mu.Unlock()
 	}
 }


### PR DESCRIPTION
## Summary
- avoid spurious wakeups in musicStream.Read by waiting in a loop while the PCM buffer is empty

## Testing
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; Xrandr headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa30d5ca58832ab5e823858183f01b