### PR TITLE
Fix music test build failures after synth refactor

### DIFF
--- a/tune_test.go
+++ b/tune_test.go
@@ -5,26 +5,6 @@ import (
 	"time"
 )
 
-// Stubs to satisfy references in tune.go when building this test.
-type Note struct {
-	Key      int
-	Velocity int
-	Start    time.Duration
-	Duration time.Duration
-}
-
-var audioContext interface{}
-var gs struct {
-	Mute        bool
-	MusicVolume int
-}
-var musicDebug bool
-
-func Play(interface{}, int, []Note) error { return nil }
-func consoleMessage(string)               {}
-func chatMessage(string)                  {}
-func stopAllMusic()                       {}
-
 func TestParseClanLordTuneDurations(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Summary
- allow tests to inject a custom synthesizer
- remove obsolete music stubs from tune tests
- adapt synth tests to new rendering code

## Testing
- `go build ./...`
- `go test` *(fails: GLFW needs DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3424cdc8832abedbd2e9b54c1149