### PR TITLE
Ensure scanWith advances and add coverage for malformed /with

### DIFF
--- a/music_command_test.go
+++ b/music_command_test.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseMusicCommandWithWho(t *testing.T) {
@@ -78,5 +79,25 @@ func TestParseMusicCommandFromMovie(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected %q in console log, got %#v", expected, consoleLog.entries)
+	}
+}
+
+func TestParseMusicCommandWithMalformedWith(t *testing.T) {
+	cases := []string{
+		"/music/play/inst1/with/with/notesabc",
+		"/music/play/inst1/withabc/notesabc",
+	}
+	for _, cmd := range cases {
+		done := make(chan struct{})
+		go func(c string) {
+			parseMusicCommand(c, nil)
+			close(done)
+		}(cmd)
+		select {
+		case <-done:
+			// ok
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("parseMusicCommand did not terminate for %q", cmd)
+		}
 	}
 }

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -487,13 +487,23 @@ func parseMusicCommand(s string, raw []byte) bool {
             idx := strings.Index(s[pos:], tag)
             if idx < 0 { break }
             idx += pos + len(tag)
+            start := idx
             v := s[idx:]
-            if len(v) > 0 && v[0] == '/' { v = v[1:] }
+            if len(v) > 0 && v[0] == '/' {
+                v = v[1:]
+                idx++
+            }
             if j := strings.IndexByte(v, '/'); j >= 0 { v = v[:j] }
             if n, err := strconv.Atoi(v); err == nil {
                 withIDs = append(withIDs, n)
             }
-            pos = idx
+            pos = idx + len(v)
+            if pos <= start {
+                pos = start + 1
+            }
+            if pos >= len(s) {
+                break
+            }
         }
     }
     scanWith("/with")


### PR DESCRIPTION
## Summary
- advance scanWith position beyond numeric value and guard against stalls on malformed IDs
- test parseMusicCommand with repeated `/with` and malformed `/withabc` segments to verify loop termination

## Testing
- `go test ./... -v` *(fails: Note redeclared, missing DISPLAY for ebiten)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3435e178832a997d2ed71cbb304c