### PR TITLE
fix music loop playback

### DIFF
--- a/tune.go
+++ b/tune.go
@@ -193,6 +193,7 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 		remaining int
 	}
 	var stack []loopState
+	activeLoops := make(map[int]int)
 
 	i := 0
 	for i < len(pt.events) {
@@ -204,7 +205,10 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 
 		if lps, ok := loopMap[i]; ok {
 			for _, lp := range lps {
-				stack = append(stack, loopState{start: lp.start, end: lp.end, remaining: lp.repeat - 1})
+				if activeLoops[lp.start] == 0 {
+					stack = append(stack, loopState{start: lp.start, end: lp.end, remaining: lp.repeat - 1})
+					activeLoops[lp.start] = 1
+				}
 			}
 		}
 
@@ -253,6 +257,7 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 					tempoIdx++
 				}
 			} else {
+				delete(activeLoops, top.start)
 				stack = stack[:len(stack)-1]
 			}
 		}

--- a/tune_test.go
+++ b/tune_test.go
@@ -100,3 +100,14 @@ func TestLoopAndTempoAndVolume(t *testing.T) {
 		t.Fatalf("volume change not applied, got %d", notes[5].Velocity)
 	}
 }
+
+// TestEventsToNotesLoop verifies that repeated loops terminate properly and
+// produce the expected number of notes without getting stuck.
+func TestEventsToNotesLoop(t *testing.T) {
+	pt := parseClanLordTune("(c)2")
+	inst := instrument{chord: 100, melody: 100}
+	notes := eventsToNotes(pt, inst, 100)
+	if len(notes) != 2 {
+		t.Fatalf("expected 2 notes, got %d", len(notes))
+	}
+}


### PR DESCRIPTION
## Summary
- prevent music playback loop stack from growing and hanging
- test repeated music loops to ensure playback terminates correctly

## Testing
- `go test ./...` *(fails: GLFW library not initialized, missing DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68aa37dfe1c4832a8c9d1e91b67578a4