### PR TITLE
Fix yell bubble spike alignment

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -283,15 +283,19 @@ func drawSpikes(screen *ebiten.Image, left, top, right, bottom, radius, size flo
 
 	startX := left + radius
 	endX := right - radius
-	width := endX - startX
-	count := int(width / step)
-	offsetX := (width - float32(count)*step) / 2
 	// top and bottom edges
-	for x := startX + offsetX; x+step <= endX; x += step {
+	for x := startX; x < endX; x += step {
+		end := x + step
+		mid := x + size
+		if end > endX {
+			end = endX
+			mid = x + (end-x)/2
+		}
+
 		var p vector.Path
 		p.MoveTo(x, top)
-		p.LineTo(x+size, top-size)
-		p.LineTo(x+step, top)
+		p.LineTo(mid, top-size)
+		p.LineTo(end, top)
 		p.Close()
 		vs, is := p.AppendVerticesAndIndicesForFilling(nil, nil)
 		for i := range vs {
@@ -306,8 +310,8 @@ func drawSpikes(screen *ebiten.Image, left, top, right, bottom, radius, size flo
 
 		p = vector.Path{}
 		p.MoveTo(x, bottom)
-		p.LineTo(x+size, bottom+size)
-		p.LineTo(x+step, bottom)
+		p.LineTo(mid, bottom+size)
+		p.LineTo(end, bottom)
 		p.Close()
 		vs, is = p.AppendVerticesAndIndicesForFilling(nil, nil)
 		for i := range vs {
@@ -323,15 +327,19 @@ func drawSpikes(screen *ebiten.Image, left, top, right, bottom, radius, size flo
 
 	startY := top + radius
 	endY := bottom - radius
-	height := endY - startY
-	count = int(height / step)
-	offsetY := (height - float32(count)*step) / 2
 	// left and right edges
-	for y := startY + offsetY; y+step <= endY; y += step {
+	for y := startY; y < endY; y += step {
+		end := y + step
+		mid := y + size
+		if end > endY {
+			end = endY
+			mid = y + (end-y)/2
+		}
+
 		var p vector.Path
 		p.MoveTo(left, y)
-		p.LineTo(left-size, y+size)
-		p.LineTo(left, y+step)
+		p.LineTo(left-size, mid)
+		p.LineTo(left, end)
 		p.Close()
 		vs, is := p.AppendVerticesAndIndicesForFilling(nil, nil)
 		for i := range vs {
@@ -346,8 +354,8 @@ func drawSpikes(screen *ebiten.Image, left, top, right, bottom, radius, size flo
 
 		p = vector.Path{}
 		p.MoveTo(right, y)
-		p.LineTo(right+size, y+size)
-		p.LineTo(right, y+step)
+		p.LineTo(right+size, mid)
+		p.LineTo(right, end)
 		p.Close()
 		vs, is = p.AppendVerticesAndIndicesForFilling(nil, nil)
 		for i := range vs {


### PR DESCRIPTION
## Summary
- ensure yell bubble spike triangles cover edge gaps by stretching last spike

## Testing
- `xvfb-run go test ./...` *(fails: CL_Images missing; will fetch from server, parseMusicCommand failed to parse raw payload, parseMovie open clmovFiles/lore1.clMov: no such file or directory, parseNames() = [Méme], want [Meme], soundfont missing data/soundfont.sf2, unexpected second event {key:64 on:true sample:0}, third note start = 1s; want 500ms, Bob not marked sharee after share: <nil>, note duration mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68aa45933298832a8f43e37ea81e07fb