### PR TITLE
Fix precision loss in note timing and add uncommon tempo tests

### DIFF
--- a/tune.go
+++ b/tune.go
@@ -213,7 +213,7 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 		}
 
 		ev := pt.events[i]
-		durMS := int((ev.beats / 2) * float64(60000/tempo))
+		durMS := int((ev.beats / 2) * (60000.0 / float64(tempo)))
 		noteMS := durMS * 9 / 10
 		restMS := durMS - noteMS
 

--- a/tune_test.go
+++ b/tune_test.go
@@ -132,3 +132,24 @@ func TestNoteDurationsWithTempoChange(t *testing.T) {
 		}
 	}
 }
+
+func TestNoteDurationsUncommonTempos(t *testing.T) {
+	inst := instrument{program: 0, octave: 0, chord: 100, melody: 100}
+	cases := []struct {
+		tempo int
+		want  time.Duration
+	}{
+		{95, 852 * time.Millisecond},
+		{177, 457 * time.Millisecond},
+	}
+	for _, c := range cases {
+		pt := parseClanLordTuneWithTempo("c3", c.tempo)
+		notes := eventsToNotes(pt, inst, 100)
+		if len(notes) != 1 {
+			t.Fatalf("tempo %d: expected 1 note, got %d", c.tempo, len(notes))
+		}
+		if notes[0].Duration != c.want {
+			t.Errorf("tempo %d: duration = %v, want %v", c.tempo, notes[0].Duration, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- avoid integer truncation when converting event beats to milliseconds
- add tests verifying note durations at uncommon tempos like 95 BPM and 177 BPM

## Testing
- `xvfb-run go test ./...` *(fails: CL_Images missing; will fetch from server, ...)*
- `xvfb-run go test -run NoteDurationsUncommonTempos`


------
https://chatgpt.com/codex/tasks/task_e_68aa49ffcf74832a88b402b9ffaffb12