### PR TITLE
Eliminate implicit rests between notes

### DIFF
--- a/tune.go
+++ b/tune.go
@@ -181,8 +181,6 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 	tempo := pt.tempo
 	tempoIdx := 0
 	startMS := 0
-	var prevWasNote bool
-	var prevRestMS int
 
 	// Build map of loop starts for quick lookup
 	loopMap := make(map[int][]loopMarker)
@@ -218,15 +216,9 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 		durMS := int((ev.beats / 4) * (60000.0 / float64(tempo)))
 
 		if len(ev.keys) == 0 {
-			if prevWasNote {
-				startMS -= prevRestMS
-			}
 			startMS += durMS
-			prevWasNote = false
-			prevRestMS = 0
 		} else {
-			noteMS := durMS * 9 / 10
-			restMS := durMS - noteMS
+			noteMS := durMS
 
 			v := velocity
 			if len(ev.keys) > 1 {
@@ -252,9 +244,7 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 					Duration: time.Duration(noteMS) * time.Millisecond,
 				})
 			}
-			startMS += noteMS + restMS
-			prevWasNote = true
-			prevRestMS = restMS
+			startMS += noteMS
 		}
 		i++
 
@@ -262,16 +252,6 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 			top := &stack[len(stack)-1]
 			if top.remaining > 0 {
 				top.remaining--
-				// If the loop starts with a note and the previous event
-				// was also a note, remove the trailing rest inserted after
-				// the last note of the previous iteration. This prevents an
-				// unintended pause between loop repetitions when no explicit
-				// rest exists at the loop boundary.
-				if prevWasNote && len(pt.events[top.start].keys) > 0 {
-					startMS -= prevRestMS
-					prevWasNote = false
-					prevRestMS = 0
-				}
 				i = top.start
 				// reset tempo to state at loop start
 				tempo = pt.tempo

--- a/tune_test.go
+++ b/tune_test.go
@@ -32,22 +32,22 @@ func TestParseClanLordTuneDurations(t *testing.T) {
 	}
 }
 
-func TestEventsToNotesAddsGap(t *testing.T) {
+func TestEventsToNotesNoGap(t *testing.T) {
 	pt := parseClanLordTune("cd")
 	inst := instrument{program: 0, octave: 0, chord: 100, melody: 100}
 	notes := eventsToNotes(pt, inst, 100)
 	if len(notes) != 2 {
 		t.Fatalf("expected 2 notes, got %d", len(notes))
 	}
-	if notes[0].Duration != 225*time.Millisecond {
-		t.Fatalf("first note duration = %v, want 225ms", notes[0].Duration)
+	if notes[0].Duration != 250*time.Millisecond {
+		t.Fatalf("first note duration = %v, want 250ms", notes[0].Duration)
 	}
 	if notes[1].Start != 250*time.Millisecond {
 		t.Fatalf("second note start = %v, want 250ms", notes[1].Start)
 	}
 	gap := notes[1].Start - notes[0].Start - notes[0].Duration
-	if gap != 25*time.Millisecond {
-		t.Fatalf("gap = %v, want 25ms", gap)
+	if gap != 0 {
+		t.Fatalf("gap = %v, want 0", gap)
 	}
 }
 
@@ -58,8 +58,8 @@ func TestRestDuration(t *testing.T) {
 	if len(notes) != 2 {
 		t.Fatalf("expected 2 notes, got %d", len(notes))
 	}
-	if notes[1].Start != 475*time.Millisecond {
-		t.Fatalf("second note start = %v, want 475ms", notes[1].Start)
+	if notes[1].Start != 500*time.Millisecond {
+		t.Fatalf("second note start = %v, want 500ms", notes[1].Start)
 	}
 	gap := notes[1].Start - notes[0].Start - notes[0].Duration
 	if gap != 250*time.Millisecond {
@@ -108,7 +108,7 @@ func TestLoopAndTempoAndVolume(t *testing.T) {
 		t.Fatalf("expected 6 notes, got %d", len(notes))
 	}
 	// After tempo change to 180 BPM, note 'e' should have shorter duration.
-	if notes[4].Duration != 149*time.Millisecond {
+	if notes[4].Duration != 166*time.Millisecond {
 		t.Fatalf("tempo change not applied, got %v", notes[4].Duration)
 	}
 	// volume change should halve velocity for last note (volume set to 5)
@@ -153,10 +153,10 @@ func TestNoteDurationsWithTempoChange(t *testing.T) {
 		t.Fatalf("expected 4 notes, got %d", len(notes))
 	}
 	want := []time.Duration{
-		225 * time.Millisecond, // c: 1 beat at 120 BPM
-		112 * time.Millisecond, // d1: half beat at 120 BPM
-		299 * time.Millisecond, // E: 2 beats at 180 BPM
-		149 * time.Millisecond, // g2: 1 beat at 180 BPM
+		250 * time.Millisecond, // c: 1 beat at 120 BPM
+		125 * time.Millisecond, // d1: half beat at 120 BPM
+		333 * time.Millisecond, // E: 2 beats at 180 BPM
+		166 * time.Millisecond, // g2: 1 beat at 180 BPM
 	}
 	for i, n := range notes {
 		if n.Duration != want[i] {
@@ -171,8 +171,8 @@ func TestNoteDurationsUncommonTempos(t *testing.T) {
 		tempo int
 		want  time.Duration
 	}{
-		{95, 425 * time.Millisecond},
-		{177, 228 * time.Millisecond},
+		{95, 473 * time.Millisecond},
+		{177, 254 * time.Millisecond},
 	}
 	for _, c := range cases {
 		pt := parseClanLordTuneWithTempo("c3", c.tempo)


### PR DESCRIPTION
## Summary
- Remove automatic 10% rest inserted after every note to prevent unintended pauses in music playback
- Simplify looping logic and adjust tests to expect continuous note timing

## Testing
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa757d5504832aab9c0e52b967d80e