### PR TITLE
Set Lucky Lyra as default instrument

### DIFF
--- a/music_command_test.go
+++ b/music_command_test.go
@@ -46,7 +46,7 @@ func TestParseMusicCommandFromMovie(t *testing.T) {
 	}
 
 	s := string(msg)
-	inst := "10"
+	inst := "0"
 	if idx := strings.Index(s, "/inst"); idx >= 0 {
 		v := s[idx+len("/inst"):]
 		v = strings.TrimPrefix(v, "/")

--- a/tune.go
+++ b/tune.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultInstrument    = 10
+	defaultInstrument    = 0
 	durationBlack        = 2.0
 	durationWhite        = 4.0
 	defaultChordDuration = 2.0


### PR DESCRIPTION
## Summary
- set the default tune instrument to Lucky Lyra (index 0)
- update music command test to expect instrument 0 when not specified

## Testing
- `xvfb-run go test ./...` *(fails: `TestEventsToNotesChordStart`, soundfont missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa43e6e98832abbe56e664cb1ffd9