### PR TITLE
Fix jitter in monster growl bubbles

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -455,7 +455,7 @@ func drawMonsterSpikes(screen *ebiten.Image, left, top, right, bottom, radius, s
 	endX := right - radius
 	// top edge
 	for x := startX; x < endX; x += step {
-		spike := size * (0.7 + 0.3*float32(math.Sin(phase+float64(x))))
+		spike := size * (0.7 + 0.3*float32(math.Sin(phase+float64(x-startX))))
 		end := x + step
 		mid := x + step/2
 		if end > endX {
@@ -489,7 +489,7 @@ func drawMonsterSpikes(screen *ebiten.Image, left, top, right, bottom, radius, s
 	}
 	drawBottom := func(segStart, segEnd float32) {
 		for x := segStart; x < segEnd; x += step {
-			spike := size * (0.7 + 0.3*float32(math.Sin(phase+float64(x))))
+			spike := size * (0.7 + 0.3*float32(math.Sin(phase+float64(x-startX))))
 			end := x + step
 			mid := x + step/2
 			if end > segEnd {
@@ -521,7 +521,7 @@ func drawMonsterSpikes(screen *ebiten.Image, left, top, right, bottom, radius, s
 	endY := bottom - radius
 	// left and right edges
 	for y := startY; y < endY; y += step {
-		spike := size * (0.7 + 0.3*float32(math.Sin(phase+float64(y))))
+		spike := size * (0.7 + 0.3*float32(math.Sin(phase+float64(y-startY))))
 		end := y + step
 		mid := y + step/2
 		if end > endY {


### PR DESCRIPTION
## Summary
- Ensure monster speech bubble spikes stay aligned with their bubble as the screen scrolls

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aac99cd6d8832abbeae43e6bc56cb1