### PR TITLE
Log when Chat TTS disabled and enable TTS by default

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -1,10 +1,15 @@
 package main
 
+import "sync"
+
 const (
 	maxChatMessages = 1000
 )
 
-var chatLog = messageLog{max: maxChatMessages}
+var (
+	chatLog             = messageLog{max: maxChatMessages}
+	chatTTSDisabledOnce sync.Once
+)
 
 func chatMessage(msg string) {
 	if msg == "" {
@@ -17,6 +22,10 @@ func chatMessage(msg string) {
 
 	if gs.ChatTTS && !blockTTS {
 		speakChatMessage(msg)
+	} else if !gs.ChatTTS {
+		chatTTSDisabledOnce.Do(func() {
+			consoleMessage("Chat TTS is disabled. Enable it in settings to hear messages.")
+		})
 	}
 }
 

--- a/settings.go
+++ b/settings.go
@@ -75,6 +75,7 @@ var gsdef settings = settings{
 	GameScale:            2,
 	BarPlacement:         BarPlacementBottom,
 	MaxNightLevel:        100,
+	ChatTTS:              true,
 	ChatTTSVolume:        1.0,
 	Notifications:        true,
 	NotifyFallen:         true,


### PR DESCRIPTION
## Summary
- Notify players via console when Chat TTS is disabled so they know why messages aren't spoken
- Enable Chat TTS by default in settings

## Testing
- `go build ./...`
- `go test ./...` *(fails: command hung or produced no output; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68abb00776c4832aab1d6f5fec8375a8