### PR TITLE
Expand allowed plugin imports

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -178,9 +178,13 @@ func loadPlugins() {
 	// Build restricted stdlib symbol map containing safe stdlib packages
 	allowedPkgs := []string{
 		"bytes/bytes",
+		"encoding/json/json",
+		"errors/errors",
 		"fmt/fmt",
+		"math/big/big",
 		"math/math",
 		"math/rand",
+		"regexp/regexp",
 		"sort/sort",
 		"strconv/strconv",
 		"strings/strings",

--- a/plugins/README.txt
+++ b/plugins/README.txt
@@ -17,9 +17,13 @@ The interpreter allows only the following packages:
 
 - `gt` (client API)
 - `bytes`
+- `encoding/json`
+- `errors`
 - `fmt`
 - `math`
+- `math/big`
 - `math/rand`
+- `regexp`
 - `sort`
 - `strconv`
 - `strings`


### PR DESCRIPTION
## Summary
- permit plugin scripts to use encoding/json, errors, regexp, and math/big
- document the expanded import whitelist in plugins/README

## Testing
- `gofmt -w plugin.go`
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68abd648d9bc832ab806695cdb313156