### PR TITLE
Handle symlinks when extracting piper tar archives

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -210,8 +210,17 @@ func extractArchive(src, dst string) error {
 				return err
 			}
 			target := filepath.Join(dst, hdr.Name)
-			if hdr.Typeflag == tar.TypeDir {
+			switch hdr.Typeflag {
+			case tar.TypeDir:
 				if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
+					return err
+				}
+				continue
+			case tar.TypeSymlink:
+				if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+					return err
+				}
+				if err := os.Symlink(hdr.Linkname, target); err != nil {
 					return err
 				}
 				continue


### PR DESCRIPTION
## Summary
- extractArchive now preserves symlink entries when unpacking tar files

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3ba5da20832a9b157857d84b4277