### PR TITLE
Open browser for client updates

### DIFF
--- a/login.go
+++ b/login.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/pkg/browser"
 )
 
 var (
@@ -379,20 +381,10 @@ func login(ctx context.Context, clientVersion int) error {
 		}
 
 		if result == -30972 || result == -30973 {
-			logDebug("server requested update, downloading...")
-			newVer, err := autoUpdate(resp, dataDirPath)
-			if err != nil {
-				tcpConn.Close()
-				udpConn.Close()
-				return fmt.Errorf("auto update: %w", err)
-			}
-			if s, err := checkDataFiles(newVer); err == nil {
-				status = s
-			}
-			logDebug("update complete, reconnecting...")
+			browser.OpenURL("https://github.com/Distortions81/goThoom/releases")
 			tcpConn.Close()
 			udpConn.Close()
-			continue
+			return fmt.Errorf("client out of date; please download the latest release")
 		}
 
 		if result != 0 {


### PR DESCRIPTION
## Summary
- Direct users to GitHub releases when the server requires an update

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3b3b8e40832a8430b34ad3d2cd86