### PR TITLE
propagate piper voice extraction errors

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -196,7 +196,10 @@ func preparePiper(dataDir string) (string, string, string, error) {
 		modelPath := filepath.Join(voicesDir, v, v+".onnx")
 		if _, err := os.Stat(modelPath); err != nil {
 			archive := filepath.Join(piperDir, v+".tar.gz")
-			_ = extractArchive(archive, voicesDir)
+			if err := extractArchive(archive, voicesDir); err != nil {
+				logError("chat tts extract voice %s: %v", v, err)
+				return "", "", "", err
+			}
 		}
 	}
 	voice := "en_US-hfc_female-medium"

--- a/chat_tts_test.go
+++ b/chat_tts_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestPreparePiperMissingArchive(t *testing.T) {
+	origSilent := silent
+	silent = true
+	defer func() { silent = origSilent }()
+
+	supported := false
+	switch runtime.GOOS {
+	case "linux":
+		switch runtime.GOARCH {
+		case "amd64", "arm64", "arm":
+			supported = true
+		}
+	case "darwin":
+		switch runtime.GOARCH {
+		case "amd64", "arm64":
+			supported = true
+		}
+	case "windows":
+		if runtime.GOARCH == "amd64" {
+			supported = true
+		}
+	}
+	if !supported {
+		t.Skipf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	dataDir := t.TempDir()
+	binDir := filepath.Join(dataDir, "piper", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	binName := "piper"
+	if runtime.GOOS == "windows" {
+		binName = "piper.exe"
+	}
+	if err := os.WriteFile(filepath.Join(binDir, binName), []byte{}, 0o755); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, _, _, err := preparePiper(dataDir)
+	if err == nil {
+		t.Fatal("expected error for missing voice archive")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected missing file error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add error handling when extracting piper voice archives so callers see failures
- test preparePiper error path with missing voice archive

## Testing
- `EBITENGINE_HEADLESS=1 go test` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4313f8b8832aac05c8156a8e13f0