### PR TITLE
Improve piper execution error logging

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -374,6 +374,11 @@ func synthesizeWithPiper(text string) ([]byte, error) {
 		cmd.Stdin = strings.NewReader(text)
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
+			if os.IsPermission(err) {
+				if info, statErr := os.Stat(piperPath); statErr == nil {
+					return nil, fmt.Errorf("piper run: %v (file mode %v): %s", err, info.Mode(), stderr.String())
+				}
+			}
 			return nil, fmt.Errorf("piper run: %v: %s", err, stderr.String())
 		}
 		data, err := os.ReadFile(tmpName)
@@ -391,6 +396,11 @@ func synthesizeWithPiper(text string) ([]byte, error) {
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if os.IsPermission(err) {
+			if info, statErr := os.Stat(piperPath); statErr == nil {
+				return nil, fmt.Errorf("piper run: %v (file mode %v): %s", err, info.Mode(), stderr.String())
+			}
+		}
 		return nil, fmt.Errorf("piper run: %v: %s", err, stderr.String())
 	}
 	return out.Bytes(), nil


### PR DESCRIPTION
## Summary
- log file mode when piper fails to run due to permissions

## Testing
- `go test` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68ac467a9d94832aa6a17bbcea30278a