### PR TITLE
Handle piper voice archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you build from source, you'll need Go **1.24+** and OpenGL/X11 dev libs on Li
 - Drop a `background.png` and/or `splash.png` into `data/` for a custom look.
 
 ### Text-to-speech voices
-Piper voices are stored as raw `.onnx` models with matching `.onnx.json` configs in `data/piper/voices`. The helper script `scripts/download_piper.sh` downloads these files individually.
+Piper voices are stored in `data/piper/voices`. The client and `scripts/download_piper.sh` support voice archives in `.tar.gz` format and automatically extract and remove the archives. If a voice archive isn't available, the script falls back to downloading raw `.onnx` models with matching `.onnx.json` configs.
 
 ---
 

--- a/chat_tts.go
+++ b/chat_tts.go
@@ -196,6 +196,18 @@ func preparePiper(dataDir string) (string, string, string, error) {
 	_ = os.Chmod(binPath, 0o755)
 
 	voicesDir := filepath.Join(piperDir, "voices")
+	// Automatically extract any voice archives placed in the voices directory.
+	if archives, _ := filepath.Glob(filepath.Join(voicesDir, "*.tar.gz")); len(archives) > 0 {
+		if err := os.MkdirAll(voicesDir, 0o755); err != nil {
+			return "", "", "", err
+		}
+		for _, arch := range archives {
+			if err := extractArchive(arch, voicesDir); err != nil {
+				return "", "", "", err
+			}
+			_ = os.Remove(arch)
+		}
+	}
 	voice := "en_US-hfc_female-medium"
 
 	model := filepath.Join(voicesDir, voice, voice+".onnx")

--- a/prepare_piper_test.go
+++ b/prepare_piper_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Test that preparePiper extracts voice archives and removes them.
+func TestPreparePiperVoiceArchive(t *testing.T) {
+	dataDir := t.TempDir()
+	piperDir := filepath.Join(dataDir, "piper")
+	binDir := filepath.Join(piperDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// create dummy piper binary to skip download
+	binPath := filepath.Join(binDir, "piper")
+	if err := os.WriteFile(binPath, []byte(""), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	voicesDir := filepath.Join(piperDir, "voices")
+	if err := os.MkdirAll(voicesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// create voice tarball
+	tarPath := filepath.Join(voicesDir, piperFemaleVoice+".tar.gz")
+	f, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	files := map[string]string{
+		filepath.Join(piperFemaleVoice, piperFemaleVoice+".onnx"):      "",
+		filepath.Join(piperFemaleVoice, piperFemaleVoice+".onnx.json"): "{}",
+	}
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0644, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// run preparePiper which should extract and remove tarball
+	_, model, cfg, err := preparePiper(dataDir)
+	if err != nil {
+		t.Fatalf("preparePiper: %v", err)
+	}
+	if _, err := os.Stat(tarPath); !os.IsNotExist(err) {
+		t.Fatalf("archive not removed")
+	}
+	if _, err := os.Stat(model); err != nil {
+		t.Fatalf("model missing: %v", err)
+	}
+	if _, err := os.Stat(cfg); err != nil {
+		t.Fatalf("config missing: %v", err)
+	}
+}

--- a/scripts/download_piper.sh
+++ b/scripts/download_piper.sh
@@ -34,12 +34,18 @@ declare -A VOICES=(
 
 for name in "${!VOICES[@]}"; do
   path="${VOICES[$name]}"
-  vdir="$VOICE_DIR/$name"
-  mkdir -p "$vdir"
+  tmp="$VOICE_DIR/$name.tar.gz"
   echo "Downloading voice $name..."
-  curl -L "$VOICE_BASE/$path/$name.onnx" -o "$vdir/$name.onnx"
-  curl -L "$VOICE_BASE/$path/$name.onnx.json" -o "$vdir/$name.onnx.json"
-  curl -L "$VOICE_BASE/$path/MODEL_CARD" -o "$vdir/MODEL_CARD"
+  if curl -fL "$VOICE_BASE/$path/$name.tar.gz" -o "$tmp"; then
+    tar -xzf "$tmp" -C "$VOICE_DIR"
+    rm -f "$tmp"
+  else
+    vdir="$VOICE_DIR/$name"
+    mkdir -p "$vdir"
+    curl -L "$VOICE_BASE/$path/$name.onnx" -o "$vdir/$name.onnx"
+    curl -L "$VOICE_BASE/$path/$name.onnx.json" -o "$vdir/$name.onnx.json"
+    curl -L "$VOICE_BASE/$path/MODEL_CARD" -o "$vdir/MODEL_CARD"
+  fi
 done
 
 echo "Piper binaries downloaded to $PIPER_DIR and voices to $VOICE_DIR"


### PR DESCRIPTION
## Summary
- Automatically extract and remove `.tar.gz` voice archives
- Prefer voice archives when downloading Piper voices and add tests
- Support voice archives in helper script and docs

## Testing
- `go vet ./...`
- `go test ./...` *(fails: Package alsa was not found... Package gtk+-3.0 was not found...)*


------
https://chatgpt.com/codex/tasks/task_e_68ac4641025c832a8f44d902c8875e06