### PR TITLE
Stop music during clMov seek

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	blockSound    bool
 	blockBubbles  bool
 	blockTTS      bool
+	blockMusic    bool
 	dumpMusic     bool
 	imgDump       bool
 	sndDump       bool

--- a/movie_player.go
+++ b/movie_player.go
@@ -448,13 +448,16 @@ func (p *moviePlayer) seek(idx int) {
 	// Stop any currently playing sounds so scrubbing is silent.
 	stopAllSounds()
 	stopAllTTS()
+	stopAllMusic()
 	blockSound = true
 	blockBubbles = true
 	blockTTS = true
+	blockMusic = true
 	defer func() {
 		blockSound = false
 		blockBubbles = false
 		blockTTS = false
+		blockMusic = false
 	}()
 
 	if idx < 0 {

--- a/tune.go
+++ b/tune.go
@@ -152,6 +152,9 @@ func playClanLordTune(tune string) error {
 	if audioContext == nil {
 		return fmt.Errorf("audio disabled")
 	}
+	if blockMusic {
+		return fmt.Errorf("music blocked")
+	}
 	if gs.Mute || !gs.Music || gs.MasterVolume <= 0 || gs.MusicVolume <= 0 {
 		return fmt.Errorf("music muted")
 	}
@@ -721,6 +724,9 @@ func handleMusicParams(mp MusicParams) {
 			stopAllMusic()
 			clearTuneQueue()
 		}
+		return
+	}
+	if blockMusic {
 		return
 	}
 	// Ignore play requests while muted, matching classic behavior when sound


### PR DESCRIPTION
## Summary
- add global flag to block music
- stop music and block music playback while seeking clMov files
- guard tune playback functions to respect blockMusic flag

## Testing
- `go build -v ./...` *(fails: function main is undeclared in the main package)*
- `go test ./...` *(no output; command produced package list then hung)*

------
https://chatgpt.com/codex/tasks/task_e_68ac476525b8832a9b3c6651b22fbbf9