### PR TITLE
Fix hotkey function selection

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -52,6 +52,7 @@ var (
 	hotkeyCmdSection *eui.ItemData
 	hotkeyCmdInputs  []*eui.ItemData
 	hotkeyCmdFuncs   []hotkeyFuncRef
+	hotkeyFnLabel    *eui.ItemData
 	editingHotkey    int = -1
 
 	recording     bool
@@ -418,6 +419,7 @@ func openHotkeyEditor(idx int) {
 				fnSel = ""
 				fnSelKey = ""
 			}
+			selectHotkeyFunction(fnSel, fnSelKey)
 		}
 	}
 	fnRow.AddItem(fnDD)
@@ -497,6 +499,9 @@ func addHotkeyCommand(cmd, fn, plugin string) {
 		fnLabel.Size = eui.Point{X: hotkeyEditWin.Size.X - 40, Y: 20}
 		fnLabel.FontSize = 12
 		hotkeyCmdSection.AddItem(fnLabel)
+		if len(hotkeyCmdInputs) == 0 {
+			hotkeyFnLabel = fnLabel
+		}
 	}
 	cmdLabel, _ := eui.NewText()
 	cmdLabel.Text = "Command:"
@@ -521,6 +526,37 @@ func addHotkeyCommand(cmd, fn, plugin string) {
 
 	hotkeyEditWin.Refresh()
 	wrapHotkeyInputs()
+}
+
+// selectHotkeyFunction applies a function selection to the first blank
+// hotkey command slot. It updates the stored function reference and shows a
+// label in the editor so users don't need to press the add button for the
+// initial function choice.
+func selectHotkeyFunction(fn, plugin string) {
+	if hotkeyCmdSection == nil {
+		return
+	}
+	// Only apply to a single empty command slot.
+	if len(hotkeyCmdInputs) != 1 || hotkeyCmdInputs[0].Text != "" {
+		return
+	}
+	hotkeyCmdFuncs[0] = hotkeyFuncRef{Name: fn, Plugin: plugin}
+	if fn == "" {
+		if hotkeyFnLabel != nil {
+			hotkeyCmdSection.Contents = hotkeyCmdSection.Contents[1:]
+			hotkeyFnLabel = nil
+			hotkeyEditWin.Refresh()
+		}
+		return
+	}
+	if hotkeyFnLabel == nil {
+		hotkeyFnLabel, _ = eui.NewText()
+		hotkeyFnLabel.Size = eui.Point{X: hotkeyEditWin.Size.X - 40, Y: 20}
+		hotkeyFnLabel.FontSize = 12
+		hotkeyCmdSection.Contents = append([]*eui.ItemData{hotkeyFnLabel}, hotkeyCmdSection.Contents...)
+	}
+	hotkeyFnLabel.Text = "Function: " + fn
+	hotkeyEditWin.Refresh()
 }
 
 func wrapHotkeyInputs() {

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -96,6 +96,26 @@ func TestHotkeyFunctionWithoutCommand(t *testing.T) {
 	}
 }
 
+// Test that selecting a function without clicking add saves the hotkey.
+func TestHotkeyFunctionSelectionSaves(t *testing.T) {
+	hotkeys = nil
+	openHotkeyEditor(-1)
+	hotkeyComboText.Text = "Ctrl-H"
+	selectHotkeyFunction("ponder", "")
+	finishHotkeyEdit(true)
+
+	if len(hotkeys) != 1 {
+		t.Fatalf("hotkey not saved")
+	}
+	cmd := hotkeys[0].Commands[0]
+	if cmd.Command != "" || cmd.Function != "ponder" {
+		t.Fatalf("unexpected hotkey command: %+v", cmd)
+	}
+	if hotkeyEditWin != nil {
+		hotkeyEditWin.Close()
+	}
+}
+
 // Test that a hotkey with an empty command saves correctly.
 func TestHotkeyEmptyCommandSaved(t *testing.T) {
 	hotkeys = nil


### PR DESCRIPTION
## Summary
- ensure selecting a function in the hotkey editor populates the first command slot without needing the add button
- add test coverage for function selection saving

## Testing
- `go test` *(fails: Package alsa not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac562dcfdc832aad60b43927b7a974