### PR TITLE
Expose ShowNotification in plugin API

### DIFF
--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -18,6 +18,9 @@ func Logf(format string, args ...interface{}) {}
 // Console writes a message to the in-client console.
 func Console(msg string) {}
 
+// ShowNotification displays a notification bubble.
+func ShowNotification(msg string) {}
+
 // AddHotkey binds a key combo to a slash command.
 func AddHotkey(combo, command string) {}
 

--- a/plugin.go
+++ b/plugin.go
@@ -23,6 +23,7 @@ var basePluginExports = interp.Exports{
 	"gt/gt": {
 		"Logf":                  reflect.ValueOf(pluginLogf),
 		"Console":               reflect.ValueOf(pluginConsole),
+		"ShowNotification":      reflect.ValueOf(pluginShowNotification),
 		"RegisterCommand":       reflect.ValueOf(pluginRegisterCommand),
 		"RegisterFunc":          reflect.ValueOf(pluginRegisterFunc),
 		"RunCommand":            reflect.ValueOf(pluginRunCommand),
@@ -118,6 +119,10 @@ func pluginLogf(format string, args ...interface{}) {
 
 func pluginConsole(msg string) {
 	consoleMessage(msg)
+}
+
+func pluginShowNotification(msg string) {
+	showNotification(msg)
 }
 
 func pluginAddHotkey(owner, combo, command string) {


### PR DESCRIPTION
## Summary
- Allow plugins to trigger in-game notification bubbles via ShowNotification
- Add ShowNotification stub to gt plugin API for editor support

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing)*
- `go vet ./...` *(fails: gtk+-3.0, alsa missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac57c8b294832a953691afbd160e6a