### PR TITLE
Expose input state and last-click data to plugins

### DIFF
--- a/click_info.go
+++ b/click_info.go
@@ -1,0 +1,53 @@
+package main
+
+import "sync"
+
+// Mobile represents basic info about a mobile clicked in the world.
+type Mobile struct {
+	Index  uint8
+	Name   string
+	H, V   int16
+	PictID uint16
+	Colors uint8
+}
+
+// ClickInfo describes the last left-click in the game world.
+type ClickInfo struct {
+	X, Y     int16
+	OnMobile bool
+	Mobile   Mobile
+}
+
+var (
+	lastClick   ClickInfo
+	lastClickMu sync.Mutex
+)
+
+// handleWorldClick records a left-click in the game world and captures
+// information about any mobile under the cursor.
+func handleWorldClick(x, y int16) {
+	info := ClickInfo{X: x, Y: y}
+	stateMu.Lock()
+	for _, m := range state.liveMobs {
+		if d, ok := state.descriptors[m.Index]; ok {
+			size := mobileSize(d.PictID)
+			half := int16(size / 2)
+			if x >= m.H-half && x < m.H+half && y >= m.V-half && y < m.V+half {
+				info.OnMobile = true
+				info.Mobile = Mobile{
+					Index:  m.Index,
+					Name:   d.Name,
+					H:      m.H,
+					V:      m.V,
+					PictID: d.PictID,
+					Colors: m.Colors,
+				}
+				break
+			}
+		}
+	}
+	stateMu.Unlock()
+	lastClickMu.Lock()
+	lastClick = info
+	lastClickMu.Unlock()
+}

--- a/game.go
+++ b/game.go
@@ -770,6 +770,9 @@ func (g *Game) Update() error {
 			heldTime = 0
 		}
 	}
+	if click && !uiMouseDown {
+		handleWorldClick(baseX, baseY)
+	}
 
 	x, y := baseX, baseY
 	walk := false

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -135,3 +135,43 @@ func Unequip(id uint16) {}
 
 // PlaySound plays the sounds referenced by the provided IDs.
 func PlaySound(ids []uint16) {}
+
+// KeyPressed reports whether the given key is currently pressed.
+func KeyPressed(name string) bool { return false }
+
+// KeyJustPressed reports whether the given key was pressed this frame.
+func KeyJustPressed(name string) bool { return false }
+
+// MousePressed reports whether the given mouse button is pressed.
+func MousePressed(name string) bool { return false }
+
+// MouseJustPressed reports whether the given mouse button was pressed this frame.
+func MouseJustPressed(name string) bool { return false }
+
+// Mobile contains basic info about a clicked mobile.
+type Mobile struct {
+	Index  uint8
+	Name   string
+	H, V   int16
+	PictID uint16
+	Colors uint8
+}
+
+// ClickInfo describes the last click in the game world.
+type ClickInfo struct {
+	X, Y     int16
+	OnMobile bool
+	Mobile   Mobile
+}
+
+// LastClick returns information about the last left-click in the world.
+func LastClick() ClickInfo { return ClickInfo{} }
+
+// EquippedItems returns the items currently equipped.
+func EquippedItems() []InventoryItem { return nil }
+
+// HasItem reports whether an inventory item with the given name exists.
+func HasItem(name string) bool { return false }
+
+// FrameNumber returns the current frame counter.
+func FrameNumber() int { return 0 }

--- a/plugin.go
+++ b/plugin.go
@@ -44,6 +44,16 @@ var basePluginExports = interp.Exports{
 		"PlayerStats":           reflect.ValueOf(pluginPlayerStats),
 		"Stats":                 reflect.ValueOf((*Stats)(nil)),
 		"RegisterPlayerHandler": reflect.ValueOf(pluginRegisterPlayerHandler),
+		"KeyPressed":            reflect.ValueOf(pluginKeyPressed),
+		"KeyJustPressed":        reflect.ValueOf(pluginKeyJustPressed),
+		"MousePressed":          reflect.ValueOf(pluginMousePressed),
+		"MouseJustPressed":      reflect.ValueOf(pluginMouseJustPressed),
+		"LastClick":             reflect.ValueOf(pluginLastClick),
+		"ClickInfo":             reflect.ValueOf((*ClickInfo)(nil)),
+		"Mobile":                reflect.ValueOf((*Mobile)(nil)),
+		"EquippedItems":         reflect.ValueOf(pluginEquippedItems),
+		"HasItem":               reflect.ValueOf(pluginHasItem),
+		"FrameNumber":           reflect.ValueOf(pluginFrameNumber),
 	},
 }
 

--- a/plugin_extra.go
+++ b/plugin_extra.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+var keyNameMap = func() map[string]ebiten.Key {
+	m := make(map[string]ebiten.Key)
+	for k := ebiten.Key(0); k <= ebiten.KeyMax; k++ {
+		m[strings.ToLower(k.String())] = k
+	}
+	return m
+}()
+
+func keyFromName(name string) (ebiten.Key, bool) {
+	k, ok := keyNameMap[strings.ToLower(name)]
+	return k, ok
+}
+
+func mouseButtonFromName(name string) (ebiten.MouseButton, bool) {
+	n := strings.ToLower(strings.TrimSpace(name))
+	switch n {
+	case "right", "rightclick":
+		return ebiten.MouseButtonRight, true
+	case "middle", "middleclick":
+		return ebiten.MouseButtonMiddle, true
+	}
+	if strings.HasPrefix(n, "mouse") {
+		numStr := strings.TrimSpace(strings.TrimPrefix(n, "mouse"))
+		if numStr == "" {
+			return 0, false
+		}
+		if num, err := strconv.Atoi(numStr); err == nil {
+			b := ebiten.MouseButton(num)
+			if b > ebiten.MouseButtonLeft && b <= ebiten.MouseButtonMax {
+				return b, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func pluginKeyPressed(name string) bool {
+	if k, ok := keyFromName(name); ok {
+		return ebiten.IsKeyPressed(k)
+	}
+	return false
+}
+
+func pluginKeyJustPressed(name string) bool {
+	if k, ok := keyFromName(name); ok {
+		return inpututil.IsKeyJustPressed(k)
+	}
+	return false
+}
+
+func pluginMousePressed(name string) bool {
+	if b, ok := mouseButtonFromName(name); ok {
+		return ebiten.IsMouseButtonPressed(b)
+	}
+	return false
+}
+
+func pluginMouseJustPressed(name string) bool {
+	if b, ok := mouseButtonFromName(name); ok {
+		return inpututil.IsMouseButtonJustPressed(b)
+	}
+	return false
+}
+
+func pluginLastClick() ClickInfo {
+	lastClickMu.Lock()
+	defer lastClickMu.Unlock()
+	return lastClick
+}
+
+func pluginEquippedItems() []InventoryItem {
+	items := getInventory()
+	res := make([]InventoryItem, 0, len(items))
+	for _, it := range items {
+		if it.Equipped {
+			res = append(res, it)
+		}
+	}
+	return res
+}
+
+func pluginHasItem(name string) bool {
+	n := strings.ToLower(name)
+	for _, it := range getInventory() {
+		if strings.ToLower(it.Name) == n {
+			return true
+		}
+	}
+	return false
+}
+
+func pluginFrameNumber() int {
+	return frameCounter
+}


### PR DESCRIPTION
## Summary
- add helper functions for key and mouse presses
- surface last-click info including clicked mobile
- expose equipped items, inventory lookups, and frame counter

## Testing
- `go vet ./...`
- `go build`
- `go test ./...` *(fails: no output; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ac57e6b394832a857405d4f9ca1a7c