### PR TITLE
Ensure hotkey editor preserves selected function

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -473,6 +473,18 @@ func openHotkeyEditor(idx int) {
 		hotkeyComboText.Text = hk.Combo
 		hotkeyNameInput.Text = hk.Name
 		if len(hk.Commands) > 0 {
+			firstFn := hk.Commands[0].Function
+			firstPlugin := hk.Commands[0].Plugin
+			if firstFn != "" {
+				fnSel = firstFn
+				fnSelKey = firstPlugin
+				for i, inf := range infos {
+					if inf.Name == firstFn && inf.Plugin == firstPlugin {
+						fnDD.Selected = i + 1
+						break
+					}
+				}
+			}
 			for _, c := range hk.Commands {
 				addHotkeyCommand(c.Command, c.Function, c.Plugin)
 			}

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -155,6 +155,29 @@ func TestHotkeyFunctionPersisted(t *testing.T) {
 	}
 }
 
+// Test that editing a hotkey preselects its function in the dropdown.
+func TestHotkeyEditPreselectsFunction(t *testing.T) {
+	hotkeys = []Hotkey{{Combo: "Ctrl-P", Commands: []HotkeyCommand{{Function: "ponder"}}}}
+	pluginMu.Lock()
+	origFuncs := pluginFuncs
+	pluginFuncs = map[string]map[string]PluginFunc{"": {"ponder": nil}}
+	pluginMu.Unlock()
+	defer func() {
+		pluginMu.Lock()
+		pluginFuncs = origFuncs
+		pluginMu.Unlock()
+	}()
+
+	openHotkeyEditor(0)
+	flow := hotkeyEditWin.Contents[0]
+	fnRow := flow.Contents[4]
+	fnDD := fnRow.Contents[1]
+	if fnDD.Selected != 1 {
+		t.Fatalf("function dropdown not preselected: %d", fnDD.Selected)
+	}
+	hotkeyEditWin.Close()
+}
+
 // Test that editing a hotkey with no name still saves changes.
 func TestHotkeyEditWithoutName(t *testing.T) {
 	hotkeys = []Hotkey{{Combo: "Ctrl-A", Commands: []HotkeyCommand{{Command: "say hi"}}}}


### PR DESCRIPTION
## Summary
- pre-select existing function in hotkey editor dropdown when editing
- add regression test for function preselection

## Testing
- `go test ./...` *(fails: GLFW library requires DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68ac686a84b4832aacef5822379a96c7