### PR TITLE
Add dice roll and weapon cycle plugin examples

### DIFF
--- a/example_plugins/dice_roll.go
+++ b/example_plugins/dice_roll.go
@@ -1,0 +1,66 @@
+//go:build plugin
+
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"gt"
+)
+
+// PluginName identifies this plugin in the UI.
+var PluginName = "Dice Roller"
+
+var diceRE = regexp.MustCompile(`(?i)^([0-9]*)d([0-9]+)$`)
+
+// Init registers the /roll command.
+func Init() {
+	rand.Seed(time.Now().UnixNano())
+	gt.RegisterCommand("roll", roll)
+}
+
+func roll(args string) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		gt.Console("usage: /roll NdM, e.g. /roll 2d6")
+		return
+	}
+	m := diceRE.FindStringSubmatch(args)
+	if m == nil {
+		gt.Console("usage: /roll NdM, e.g. /roll 2d6")
+		return
+	}
+	n := 1
+	if m[1] != "" {
+		n, _ = strconv.Atoi(m[1])
+	}
+	sides, _ := strconv.Atoi(m[2])
+	if n <= 0 || sides <= 0 {
+		gt.Console("invalid dice")
+		return
+	}
+
+	// try to equip a dice item if present
+	for _, it := range gt.Inventory() {
+		if strings.Contains(strings.ToLower(it.Name), "dice") {
+			if !it.Equipped {
+				gt.Equip(it.ID)
+			}
+			break
+		}
+	}
+
+	rolls := make([]string, n)
+	total := 0
+	for i := 0; i < n; i++ {
+		r := rand.Intn(sides) + 1
+		rolls[i] = strconv.Itoa(r)
+		total += r
+	}
+	gt.RunCommand(fmt.Sprintf("/me rolls %s: %s (total %d)", args, strings.Join(rolls, " "), total))
+}

--- a/example_plugins/weapon_cycle.go
+++ b/example_plugins/weapon_cycle.go
@@ -1,0 +1,44 @@
+//go:build plugin
+
+package main
+
+import (
+	"strings"
+
+	"gt"
+)
+
+// PluginName identifies this plugin in the UI.
+var PluginName = "Weapon Cycle"
+
+var cycleItems = []string{"Axe", "Short Sword", "Dagger", "Chocolate"}
+
+// Init binds F3 to cycle through weapons.
+func Init() {
+	gt.RegisterFunc("cycleWeapon", cycleWeapon)
+	gt.AddHotkeyFunc("F3", "cycleWeapon")
+}
+
+func cycleWeapon() {
+	inv := gt.Inventory()
+	current := ""
+	for _, it := range inv {
+		if it.Equipped {
+			current = it.Name
+			break
+		}
+	}
+	next := cycleItems[0]
+	for i, name := range cycleItems {
+		if strings.EqualFold(current, name) {
+			next = cycleItems[(i+1)%len(cycleItems)]
+			break
+		}
+	}
+	for _, it := range inv {
+		if strings.EqualFold(it.Name, next) {
+			gt.Equip(it.ID)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `/roll` command plugin for dice-style macros
- add `F3` weapon cycling plugin replicating common macro behavior

## Testing
- `go vet ./...`
- `go test ./...` *(fails: `glfw: X11: The DISPLAY environment variable is missing`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7691b788832a86acf1df06ff2412