### PR TITLE
Use pose commands for dance macros

### DIFF
--- a/data/plugins/README.txt
+++ b/data/plugins/README.txt
@@ -146,8 +146,8 @@ Plays tunes without typing long commands.
 The plugin pulls the instrument from your case, plays it, then puts it back.
 
 ### Dance Macros (`dance.go`)
-Adds a simple dance command.
-- Type `/dance` or press `Shift-D` to dance.
+Adds a simple dance command using `/pose` positions.
+- Type `/dance` or press `Shift-D` to run a short pose routine.
 
 ### Dice Roller (`dice_roll.go`) *(optional example)*
 Roll virtual dice.

--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -146,8 +146,8 @@ Plays tunes without typing long commands.
 The plugin pulls the instrument from your case, plays it, then puts it back.
 
 ### Dance Macros (`dance.go`)
-Adds a simple dance command.
-- Type `/dance` or press `Shift-D` to dance.
+Adds a simple dance command using `/pose` positions.
+- Type `/dance` or press `Shift-D` to run a short pose routine.
 
 ### Dice Roller (`dice_roll.go`) *(optional example)*
 Roll virtual dice.

--- a/example_plugins/dance.go
+++ b/example_plugins/dance.go
@@ -2,13 +2,21 @@
 
 package main
 
-import "gt"
+import (
+	"time"
+
+	"gt"
+)
 
 var PluginName = "dance_macros"
 
 func Init() {
 	gt.RegisterCommand("dance", func(args string) {
-		gt.RunCommand("/dance")
+		poses := []string{"celebrate", "leanleft", "leanright", "celebrate"}
+		for _, p := range poses {
+			gt.RunCommand("/pose " + p)
+			time.Sleep(250 * time.Millisecond)
+		}
 	})
 	gt.AddHotkey("Shift-D", "/dance")
 }

--- a/example_plugins/example_ponder.go
+++ b/example_plugins/example_ponder.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"     // used for building strings like "HP 10/10"
 	"strings" // simple helpers for splitting and matching text
+	"time"    // used for simple delays between poses
 
 	"gt" // the small API exposed by the client
 )
@@ -43,9 +44,13 @@ func Init() {
 	gt.RegisterCommand("rad", handleRad)
 }
 
-// Dance sends a fun emote and plays a short sound.
+// Dance cycles through a few pose commands and plays a short sound.
 func Dance() {
-	gt.RunCommand("/me dances")
+	poses := []string{"celebrate", "leanleft", "leanright", "celebrate"}
+	for _, p := range poses {
+		gt.RunCommand("/pose " + p)
+		time.Sleep(250 * time.Millisecond)
+	}
 	gt.PlaySound([]uint16{315})
 }
 


### PR DESCRIPTION
## Summary
- Replace `/me dances` emote with a pose-based routine in `dance.go`
- Run dance poses in `example_ponder.go` and document them in README files

## Testing
- `go vet ./...` (fails: missing ALSA and Xrandr libs)
- `go test ./...` (fails: missing ALSA and Xrandr libs)


------
https://chatgpt.com/codex/tasks/task_e_68ac87261d78832ab8351ded40a9b6e2