### PR TITLE
Add block and ignore player support

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -1,0 +1,90 @@
+package main
+
+import "strings"
+
+func init() {
+	pluginRegisterCommand("client", "block", handleBlockCommand)
+	pluginRegisterCommand("client", "ignore", handleIgnoreCommand)
+	pluginRegisterCommand("client", "forget", handleForgetCommand)
+}
+
+func handleBlockCommand(args string) {
+	name := utfFold(strings.TrimSpace(args))
+	if name == "" {
+		return
+	}
+	p := getPlayer(name)
+	playersMu.Lock()
+	wasBlocked := p.Blocked
+	if wasBlocked {
+		p.Blocked = false
+	} else {
+		p.Blocked = true
+		p.Ignored = false
+		p.Friend = false
+	}
+	playerCopy := *p
+	playersMu.Unlock()
+	playersDirty = true
+	notifyPlayerHandlers(playerCopy)
+	msg := "Blocking " + p.Name + "."
+	if wasBlocked {
+		msg = "No longer blocking " + p.Name + "."
+	}
+	consoleMessage(msg)
+}
+
+func handleIgnoreCommand(args string) {
+	name := utfFold(strings.TrimSpace(args))
+	if name == "" {
+		return
+	}
+	p := getPlayer(name)
+	playersMu.Lock()
+	wasIgnored := p.Ignored
+	if wasIgnored {
+		p.Ignored = false
+	} else {
+		p.Ignored = true
+		p.Blocked = false
+		p.Friend = false
+	}
+	playerCopy := *p
+	playersMu.Unlock()
+	playersDirty = true
+	notifyPlayerHandlers(playerCopy)
+	msg := "Ignoring " + p.Name + "."
+	if wasIgnored {
+		msg = "No longer ignoring " + p.Name + "."
+	}
+	consoleMessage(msg)
+}
+
+func handleForgetCommand(args string) {
+	name := utfFold(strings.TrimSpace(args))
+	if name == "" {
+		return
+	}
+	p := getPlayer(name)
+	playersMu.Lock()
+	wasBlocked := p.Blocked
+	wasIgnored := p.Ignored
+	wasFriend := p.Friend
+	p.Blocked = false
+	p.Ignored = false
+	p.Friend = false
+	playerCopy := *p
+	playersMu.Unlock()
+	playersDirty = true
+	notifyPlayerHandlers(playerCopy)
+	msg := "Forgot " + p.Name + "."
+	switch {
+	case wasIgnored:
+		msg = "No longer ignoring " + p.Name + "."
+	case wasBlocked:
+		msg = "No longer blocking " + p.Name + "."
+	case wasFriend:
+		msg = "Removing label from " + p.Name + "."
+	}
+	consoleMessage(msg)
+}

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+func TestHandleBlockCommandToggle(t *testing.T) {
+	players = make(map[string]*Player)
+	consoleLog = messageLog{max: maxMessages}
+	handleBlockCommand("Bob")
+	p := getPlayer("Bob")
+	if !p.Blocked || p.Ignored || p.Friend {
+		t.Fatalf("expected Bob to be blocked only")
+	}
+	msgs := getConsoleMessages()
+	if len(msgs) == 0 || msgs[len(msgs)-1] != "Blocking Bob." {
+		t.Fatalf("unexpected message: %v", msgs)
+	}
+	handleBlockCommand("Bob")
+	if p.Blocked {
+		t.Fatalf("expected Bob to be unblocked")
+	}
+	msgs = getConsoleMessages()
+	if msgs[len(msgs)-1] != "No longer blocking Bob." {
+		t.Fatalf("unexpected message: %v", msgs[len(msgs)-1])
+	}
+}
+
+func TestHandleIgnoreCommandToggle(t *testing.T) {
+	players = make(map[string]*Player)
+	consoleLog = messageLog{max: maxMessages}
+	handleIgnoreCommand("Bob")
+	p := getPlayer("Bob")
+	if !p.Ignored || p.Blocked || p.Friend {
+		t.Fatalf("expected Bob to be ignored only")
+	}
+	msgs := getConsoleMessages()
+	if len(msgs) == 0 || msgs[len(msgs)-1] != "Ignoring Bob." {
+		t.Fatalf("unexpected message: %v", msgs)
+	}
+	handleIgnoreCommand("Bob")
+	if p.Ignored {
+		t.Fatalf("expected Bob to be unignored")
+	}
+	msgs = getConsoleMessages()
+	if msgs[len(msgs)-1] != "No longer ignoring Bob." {
+		t.Fatalf("unexpected message: %v", msgs[len(msgs)-1])
+	}
+}
+
+func TestHandleForgetCommand(t *testing.T) {
+	players = make(map[string]*Player)
+	consoleLog = messageLog{max: maxMessages}
+	p := getPlayer("Bob")
+	p.Friend = true
+	handleForgetCommand("Bob")
+	if p.Blocked || p.Ignored || p.Friend {
+		t.Fatalf("expected Bob to have no labels")
+	}
+	msgs := getConsoleMessages()
+	if len(msgs) == 0 || msgs[len(msgs)-1] != "Removing label from Bob." {
+		t.Fatalf("unexpected message: %v", msgs)
+	}
+}

--- a/chat_messages_test.go
+++ b/chat_messages_test.go
@@ -21,3 +21,29 @@ func TestIsSelfChatMessage(t *testing.T) {
 		}
 	}
 }
+
+func TestChatMessageBlocked(t *testing.T) {
+	players = make(map[string]*Player)
+	chatLog = messageLog{max: maxChatMessages}
+	p := getPlayer("Bob")
+	playersMu.Lock()
+	p.Blocked = true
+	playersMu.Unlock()
+	chatMessage("Bob says, hi")
+	if len(getChatMessages()) != 0 {
+		t.Fatalf("expected no messages")
+	}
+}
+
+func TestChatMessageIgnored(t *testing.T) {
+	players = make(map[string]*Player)
+	chatLog = messageLog{max: maxChatMessages}
+	p := getPlayer("Bob")
+	playersMu.Lock()
+	p.Ignored = true
+	playersMu.Unlock()
+	chatMessage("Bob says, hi")
+	if len(getChatMessages()) != 0 {
+		t.Fatalf("expected no messages")
+	}
+}

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -70,6 +70,8 @@ type Player struct {
 	Sharing    bool
 	GMLevel    int
 	Friend     bool
+	Blocked    bool
+	Ignored    bool
 	Dead       bool
 	FellWhere  string
 	KillerName string

--- a/player.go
+++ b/player.go
@@ -21,6 +21,8 @@ type Player struct {
 	Sharing    bool // player is sharing to us
 	GMLevel    int  // parsed from be-who; not rendered
 	Friend     bool // marked as friend
+	Blocked    bool // player is blocked (chat muted)
+	Ignored    bool // player is ignored (muted and hidden)
 	Dead       bool // parsed from obit messages (future)
 	FellWhere  string
 	KillerName string

--- a/players_persist.go
+++ b/players_persist.go
@@ -20,6 +20,8 @@ type persistPlayer struct {
 	Dead       bool   `json:"dead"`
 	GMLevel    int    `json:"gm,omitempty"`
 	Friend     bool   `json:"friend,omitempty"`
+	Blocked    bool   `json:"blocked,omitempty"`
+	Ignored    bool   `json:"ignored,omitempty"`
 	Bard       bool   `json:"bard,omitempty"`
 	ColorsHex  string `json:"colors,omitempty"` // hex of [count][colors...]
 	FellWhere  string `json:"fell_where,omitempty"`
@@ -71,6 +73,8 @@ func loadPlayersPersist() {
 		pr.Dead = p.Dead
 		pr.GMLevel = p.GMLevel
 		pr.Friend = p.Friend
+		pr.Blocked = p.Blocked
+		pr.Ignored = p.Ignored
 		pr.Bard = p.Bard
 		pr.FellWhere = p.FellWhere
 		pr.KillerName = p.KillerName
@@ -119,6 +123,8 @@ func savePlayersPersist() {
 			Dead:       p.Dead,
 			GMLevel:    p.GMLevel,
 			Friend:     p.Friend,
+			Blocked:    p.Blocked,
+			Ignored:    p.Ignored,
 			Bard:       p.Bard,
 			ColorsHex:  hex,
 			FellWhere:  p.FellWhere,


### PR DESCRIPTION
## Summary
- toggle `/block` and `/ignore` commands to un/block or un/ignore players and clear other labels
- make `/forget` clear block, ignore and friend labels with context-aware feedback
- cover block, ignore and forget command behavior in tests

## Testing
- `go test ./...` *(fails: Package alsa was not found; fatal error: X11/extensions/Xrandr.h: No such file or directory; Package gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac86fde674832abc3a8910a0d7470d