### PR TITLE
Use open-golang to open plugins folder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,13 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/sinshu/go-meltysynth v0.0.0-20230205031334-05d311382fc4
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/sqweek/dialog v0.0.0-20240226140203-065105509627
 	github.com/thiagokokada/dark-mode-go v0.0.1
 	github.com/traefik/yaegi v0.16.1
 	golang.design/x/clipboard v0.7.1
 	golang.org/x/crypto v0.41.0
+	golang.org/x/image v0.30.0
 	golang.org/x/text v0.28.0
 	golang.org/x/time v0.12.0
 )
@@ -31,7 +33,6 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
-	golang.org/x/image v0.30.0 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/sinshu/go-meltysynth v0.0.0-20230205031334-05d311382fc4 h1:VgeknFh4pciKVtwtjn9tZtItvV20x/+10NnUXKfyW6s=
 github.com/sinshu/go-meltysynth v0.0.0-20230205031334-05d311382fc4/go.mod h1:Afi/YpLztHvWSbiLFi6RgtxLLwmIiRmd/q7f3Ymed2g=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/sqweek/dialog v0.0.0-20240226140203-065105509627 h1:2JL2wmHXWIAxDofCK+AdkFi1KEg3dgkefCsm7isADzQ=
 github.com/sqweek/dialog v0.0.0-20240226140203-065105509627/go.mod h1:/qNPSY91qTz/8TgHEMioAUc6q7+3SOybeKczHMXFcXw=
 github.com/thiagokokada/dark-mode-go v0.0.1 h1:layfdBOM9xaxBa1Dw6f97ng/GbRJh+f8+afBOvDzXz4=

--- a/plugin.go
+++ b/plugin.go
@@ -327,7 +327,6 @@ func enablePlugin(owner string) {
 	}
 	loadPluginSource(owner, name, path, src, restrictedStdlib())
 	refreshPluginsWindow()
-	refreshPluginInfoWindow(owner)
 }
 
 func recordPluginSend(owner string) bool {
@@ -384,7 +383,6 @@ func disablePlugin(owner, reason string) {
 	}
 	consoleMessage("[plugin:" + disp + "] stopped: " + reason)
 	refreshPluginsWindow()
-	refreshPluginInfoWindow(owner)
 }
 
 func stopAllPlugins() {


### PR DESCRIPTION
## Summary
- Remove per-plugin "View" button and plugin info windows
- Add single "Open plugins folder" button powered by github.com/skratchdot/open-golang/open
- Drop unused plugin viewer code and refresh hooks

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68acdba48a14832abb95ec10a247fd6f