### PR TITLE
Fix plugin hotkeys window font size

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -255,6 +255,7 @@ func refreshHotkeysList() {
 		if !headerAdded {
 			label := &eui.ItemData{ItemType: eui.ITEM_TEXT, Text: "Plugin Hotkeys", Fixed: true}
 			label.Size = eui.Point{X: 480, Y: 20}
+			label.FontSize = 10
 			hotkeysList.AddItem(label)
 			headerAdded = true
 		}
@@ -284,6 +285,7 @@ func refreshHotkeysList() {
 		}
 		lbl := &eui.ItemData{ItemType: eui.ITEM_TEXT, Text: disp + " -> " + text, Fixed: true}
 		lbl.Size = eui.Point{X: 460, Y: 20}
+		lbl.FontSize = 10
 		row.AddItem(lbl)
 		hotkeysList.AddItem(row)
 	}

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -277,3 +277,29 @@ func TestHotkeyEquipAlreadyEquipped(t *testing.T) {
 		t.Fatalf("unexpected console messages %v", msgs)
 	}
 }
+
+// Test that plugin hotkeys are rendered with a valid font size.
+func TestPluginHotkeysFontSize(t *testing.T) {
+	hotkeys = []Hotkey{{Combo: "Ctrl-P", Plugin: "plug", Commands: []HotkeyCommand{{Command: "say hi"}}}}
+	hotkeysWin = nil
+	hotkeysList = nil
+	pluginDisplayNames = map[string]string{"plug": "Plugin"}
+
+	makeHotkeysWindow()
+
+	if len(hotkeysList.Contents) != 2 {
+		t.Fatalf("expected plugin header and row, got %d", len(hotkeysList.Contents))
+	}
+	header := hotkeysList.Contents[0]
+	if header.FontSize == 0 {
+		t.Fatalf("plugin header font size not set")
+	}
+	row := hotkeysList.Contents[1]
+	if len(row.Contents) != 2 {
+		t.Fatalf("plugin row malformed")
+	}
+	lbl := row.Contents[1]
+	if lbl.FontSize == 0 {
+		t.Fatalf("plugin hotkey label font size not set")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure plugin hotkey header and entries use a non-zero font size
- add test checking plugin hotkey rows initialize with a valid font size

## Testing
- `go test -run PluginHotkeysFontSize -count=1` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68acdc99203c832aa6cebd961458e07d