### PR TITLE
feat: add debug plugin output option

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -217,6 +217,9 @@ func pluginLogf(format string, args ...interface{}) {
 
 func pluginConsole(msg string) {
 	consoleMessage(msg)
+	if gs.pluginOutputDebug {
+		chatMessage(msg)
+	}
 }
 
 func pluginShowNotification(msg string) {

--- a/settings.go
+++ b/settings.go
@@ -195,6 +195,7 @@ type settings struct {
 	smoothingDebug      bool
 	pictAgainDebug      bool
 	pictIDDebug         bool
+	pluginOutputDebug   bool
 	hideMoving          bool
 	hideMobiles         bool
 	vsync               bool

--- a/ui.go
+++ b/ui.go
@@ -3537,6 +3537,18 @@ func makeDebugWindow() {
 	}
 	debugFlow.AddItem(pictIDCB)
 
+	pluginOutCB, pluginOutEvents := eui.NewCheckbox()
+	pluginOutCB.Text = "Always show plugin output"
+	pluginOutCB.Size = eui.Point{X: width, Y: 24}
+	pluginOutCB.Checked = gs.pluginOutputDebug
+	pluginOutEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.pluginOutputDebug = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(pluginOutCB)
+
 	smoothinCB, smoothinEvents := eui.NewCheckbox()
 	smoothinCB.Text = "Tint moving objects red"
 	smoothinCB.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- add `Always show plugin output` toggle to Debug Settings
- when enabled, show plugin messages in chat

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68aceca554f8832a848dbc13aced30e5