### PR TITLE
Adjust pointer scaling for UI scale and device scale

### DIFF
--- a/eui/pointer.go
+++ b/eui/pointer.go
@@ -20,14 +20,20 @@ const touchScrollScale = 0.05
 
 // PointerPosition returns the current pointer position in screen pixels.
 // If a touch is active, the first touch is used; otherwise the mouse cursor
-// position is returned. The coordinates already match the UI's scaled
-// coordinate space.
+// position is returned. Mouse coordinates are adjusted for the last device
+// scale factor so they match the UI's coordinate space.
 func PointerPosition() (int, int) {
 	ids := ebiten.AppendTouchIDs(nil)
 	if len(ids) > 0 {
 		return ebiten.TouchPosition(ids[0])
 	}
-	return ebiten.CursorPosition()
+
+	x, y := ebiten.CursorPosition()
+	if lastDeviceScale != 1.0 {
+		x = int(float64(x) * lastDeviceScale)
+		y = int(float64(y) * lastDeviceScale)
+	}
+	return x, y
 }
 
 // pointerWheel returns the wheel delta for mouse or two-finger touch scrolling.


### PR DESCRIPTION
## Summary
- adjust pointer handling so mouse coordinates are scaled only by the last device scale factor, keeping clicks aligned with window contents

## Testing
- `go vet ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h missing; gtk+-3.0 missing)*
- `go test ./...` *(fails: Package alsa not found; gtk+-3.0 missing; X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2b6ee3c8832a971aa91e4e560dfd