### PR TITLE
Add macOS signing entitlements support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,16 @@ A helper script builds **Linux + Windows** binaries (and can sign Windows EXEs a
 ```bash
 export WINDOWS_CERT_FILE=certs/fullchain.pem
 export WINDOWS_KEY_FILE=certs/privkey.pem   # optional: WINDOWS_KEY_PASS, WINDOWS_CERT_NAME, WINDOWS_TIMESTAMP_URL
-export MAC_SIGN_IDENTITY="-"                # ad-hoc by default; set to your certificate name to sign
+# macOS signing (defaults: ad-hoc identity, repo entitlements)
+export MAC_SIGN_IDENTITY="-"                # '-' for ad-hoc; set to your certificate name to sign
+export MAC_ENTITLEMENTS=scripts/goThoom.entitlements  # override for custom entitlements
 scripts/build_binaries.sh
 ```
+
+`MAC_SIGN_IDENTITY` uses `-` by default for ad-hoc signatures. Set it to
+your certificate name to sign with a real identity. `MAC_ENTITLEMENTS`
+defaults to `scripts/goThoom.entitlements`; point it elsewhere (or to
+`/dev/null`) to use custom entitlements.
 
 ---
 

--- a/scripts/build_binaries.sh
+++ b/scripts/build_binaries.sh
@@ -249,7 +249,12 @@ EOF
 
     if command -v codesign >/dev/null 2>&1; then
       echo "Codesigning ${APP_NAME}.app..."
-      codesign --force --deep --sign "${MAC_SIGN_IDENTITY:--}" "$APP_DIR" || echo "codesign failed, continuing" >&2
+      MAC_ENTITLEMENTS="${MAC_ENTITLEMENTS:-${SCRIPT_DIR}/goThoom.entitlements}"
+      if [ -f "$MAC_ENTITLEMENTS" ]; then
+        codesign --force --deep --sign "${MAC_SIGN_IDENTITY:--}" --entitlements "$MAC_ENTITLEMENTS" "$APP_DIR" || echo "codesign failed, continuing" >&2
+      else
+        codesign --force --deep --sign "${MAC_SIGN_IDENTITY:--}" "$APP_DIR" || echo "codesign failed, continuing" >&2
+      fi
     else
       echo "codesign tool not found; skipping macOS signing." >&2
     fi

--- a/scripts/goThoom.entitlements
+++ b/scripts/goThoom.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add default goThoom.entitlements with sandbox entitlement
- allow overriding MAC_ENTITLEMENTS and MAC_SIGN_IDENTITY in macOS signing block
- document MAC_SIGN_IDENTITY and MAC_ENTITLEMENTS usage for ad-hoc vs real certs

## Testing
- `shellcheck scripts/build_binaries.sh`
- `bash -n scripts/build_binaries.sh`


------
https://chatgpt.com/codex/tasks/task_e_68adcc626a94832abb6f0b5f25947f1f