### PR TITLE
Clear TTS queue on mute

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -24,7 +24,7 @@ var (
 	chatTTSMu    sync.Mutex
 	ttsPlayers   = make(map[*audio.Player]struct{})
 	ttsPlayersMu sync.Mutex
-	chatTTSQueue = make(chan string, 16)
+	chatTTSQueue = make(chan string, 10)
 
 	piperPath   string
 	piperModel  string
@@ -37,10 +37,21 @@ func init() {
 
 func stopAllTTS() {
 	ttsPlayersMu.Lock()
-	defer ttsPlayersMu.Unlock()
 	for p := range ttsPlayers {
 		_ = p.Close()
 		delete(ttsPlayers, p)
+	}
+	ttsPlayersMu.Unlock()
+	clearChatTTSQueue()
+}
+
+func clearChatTTSQueue() {
+	for {
+		select {
+		case <-chatTTSQueue:
+		default:
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- clear TTS queue when sound is muted or TTS is disabled
- limit chat TTS queue size to 10 entries

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adeb6fcd7c832a8bb1c213e4b85bef