### PR TITLE
Track chat handlers per plugin

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -42,7 +42,10 @@ func chatMessage(msg string) {
 	}
 
 	chatHandlersMu.RLock()
-	handlers := append([]func(string){}, chatHandlers...)
+	var handlers []func(string)
+	for _, hs := range pluginChatHandlers {
+		handlers = append(handlers, hs...)
+	}
 	chatHandlersMu.RUnlock()
 	for _, h := range handlers {
 		go h(msg)

--- a/plugin_macros.go
+++ b/plugin_macros.go
@@ -70,7 +70,7 @@ func pluginRemoveMacros(owner string) {
 // automatic responses.
 func pluginAutoReply(owner, trigger, cmd string) {
 	trig := strings.ToLower(trigger)
-	pluginRegisterChatHandler(func(msg string) {
+	pluginRegisterChatHandler(owner, func(msg string) {
 		if strings.HasPrefix(strings.ToLower(msg), trig) {
 			pluginRunCommand(owner, cmd)
 		}

--- a/plugin_macros_test.go
+++ b/plugin_macros_test.go
@@ -49,7 +49,7 @@ func TestPluginAutoReplyRunsCommand(t *testing.T) {
 	inputHandlersMu = sync.RWMutex{}
 	inputHandlers = nil
 	chatHandlersMu = sync.RWMutex{}
-	chatHandlers = nil
+	pluginChatHandlers = map[string][]func(string){}
 	consoleLog = messageLog{max: maxMessages}
 	commandQueue = nil
 	pendingCommand = ""
@@ -58,7 +58,7 @@ func TestPluginAutoReplyRunsCommand(t *testing.T) {
 	pluginAutoReply("bot", "hi", "/wave")
 
 	chatHandlersMu.RLock()
-	handlers := append([]func(string){}, chatHandlers...)
+	handlers := append([]func(string){}, pluginChatHandlers["bot"]...)
 	chatHandlersMu.RUnlock()
 	if len(handlers) != 1 {
 		t.Fatalf("unexpected handler count: %d", len(handlers))


### PR DESCRIPTION
## Summary
- Maintain chat handlers per plugin and expose RegisterChatHandler with owner context
- Deliver chat messages to plugin-specific handlers and clean them up on disable
- Adjust tests and plugin macros to new handler registry

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2cc01300832aab65e86a19c89af0