### PR TITLE
Disable smart input updates by default

### DIFF
--- a/game.go
+++ b/game.go
@@ -2137,11 +2137,12 @@ func sendInputLoop(ctx context.Context, conn net.Conn) {
 		if time.Since(last) > 2*time.Second || conn == nil {
 			continue
 		}
-		delay := interval
-		if delay <= 0 {
-			delay = 200 * time.Millisecond
-		}
+		delay := time.Duration(0)
 		if gs.lateInputUpdates {
+			delay = interval
+			if delay <= 0 {
+				delay = 200 * time.Millisecond
+			}
 			latencyMu.Lock()
 			lat := netLatency
 			latencyMu.Unlock()

--- a/network.go
+++ b/network.go
@@ -149,7 +149,8 @@ func sendPlayerInput(connection net.Conn, mouseX, mouseY int16, mouseDown bool) 
 	binary.BigEndian.PutUint16(packet[6:8], flags)
 	binary.BigEndian.PutUint32(packet[8:12], uint32(ackFrame))
 	binary.BigEndian.PutUint32(packet[12:16], uint32(resendFrame))
-	binary.BigEndian.PutUint32(packet[16:20], commandNum)
+	packetCommand := commandNum
+	binary.BigEndian.PutUint32(packet[16:20], packetCommand)
 	copy(packet[20:], cmdBytes)
 	packet[20+len(cmdBytes)] = 0
 	if cmd != "" {
@@ -157,9 +158,9 @@ func sendPlayerInput(connection net.Conn, mouseX, mouseY int16, mouseDown bool) 
 		whoLastCommandFrame = ackFrame
 		pendingCommand = ""
 		nextCommand()
+		commandNum++
 	}
-	commandNum++
-	logDebug("player input ack=%d resend=%d cmd=%d mouse=%d,%d flags=%#x", ackFrame, resendFrame, commandNum-1, mouseX, mouseY, flags)
+	logDebug("player input ack=%d resend=%d cmd=%d mouse=%d,%d flags=%#x", ackFrame, resendFrame, packetCommand, mouseX, mouseY, flags)
 	latencyMu.Lock()
 	lastInputSent = time.Now()
 	latencyMu.Unlock()

--- a/settings.go
+++ b/settings.go
@@ -105,7 +105,7 @@ var gsdef settings = settings{
 	vsync:               true,
 	nightEffect:         true,
 	throttleSounds:      true,
-	lateInputUpdates:    true,
+	lateInputUpdates:    false,
 	lateInputAdjustment: 30,
 }
 


### PR DESCRIPTION
## Summary
- Turn smart input updates (experimental networking adjustments) off by default
- When disabled, send player input immediately after each frame like the classic Mac client
- Increment command numbers only when an actual command is sent

## Testing
- `go vet`
- `go vet ./...` *(fails: command interrupted after long runtime)*
- `go test` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae58d24d70832a8feabda4a40318c5