### PR TITLE
Ensure consistent nametag opacity

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -323,7 +323,7 @@ func buildNameTagImage(name string, colorCode uint8, opacity uint8, style uint8)
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(float64(iw+5), float64(ih))
 	op.ColorScale.ScaleWithColor(bgClr)
-	op.ColorScale.ScaleAlpha(float32(gs.NameBgOpacity))
+	op.ColorScale.ScaleAlpha(float32(opacity) / 255)
 	img.DrawImage(whiteImage, op)
 	// Border
 	vector.StrokeRect(img, 1, 1, float32(iw+4), float32(ih-1), 1, frameClr, false)
@@ -1116,7 +1116,7 @@ func parseDrawState(data []byte, buildCache bool) error {
 				m.nameTagH = prev.nameTagH
 				m.nameTagKey = prev.nameTagKey
 			} else {
-				img, iw, ih := buildNameTagImage(d.Name, m.Colors, uint8(gs.NameBgOpacity*255), style)
+				img, iw, ih := buildNameTagImage(d.Name, m.Colors, uint8(gs.NameBgOpacity*255+0.5), style)
 				m.nameTag = img
 				m.nameTagW = iw
 				m.nameTagH = ih

--- a/game.go
+++ b/game.go
@@ -1520,7 +1520,7 @@ func drawMobileNameTag(screen *ebiten.Image, snap drawSnapshot, m frameMobile, a
 	x := roundToInt((h + float64(fieldCenterX)) * gs.GameScale)
 	y := roundToInt((v + float64(fieldCenterY)) * gs.GameScale)
 	if d, ok := snap.descriptors[m.Index]; ok {
-		nameAlpha := uint8(gs.NameBgOpacity * 255)
+		nameAlpha := uint8(gs.NameBgOpacity*255 + 0.5)
 		if d.Name != "" {
 			style := styleRegular
 			playersMu.RLock()


### PR DESCRIPTION
## Summary
- use passed opacity value when building name tag images
- round opacity consistently when caching and drawing nametags

## Testing
- `go test ./eui -run TestSliderConstrainedWidth -count=1 -v` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aed5cc1424832abb5035c59996d67d