### PR TITLE
Ensure clothing swap unequips previous item

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -573,11 +573,7 @@ func pluginEquip(id uint16) {
 	if idx < 0 {
 		return
 	}
-	if idx >= 0 {
-		pendingCommand = fmt.Sprintf("/equip %d %d", id, idx+1)
-	} else {
-		pendingCommand = fmt.Sprintf("/equip %d", id)
-	}
+	queueEquipCommand(id, idx)
 	equipInventoryItem(id, idx, true)
 }
 


### PR DESCRIPTION
## Summary
- Queue unequip commands for other clothing in the same slot before equipping a new piece
- Update inventory toggling and plugin equip to use the new queuing logic

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aed7bee4c0832abc594ad7d44d1814