### PR TITLE
Add test for duplicate plugin hotkeys

### DIFF
--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -363,3 +363,20 @@ func TestPluginHotkeyStatePersisted(t *testing.T) {
 		t.Fatalf("plugin hotkey not re-added")
 	}
 }
+func TestPluginAddHotkeyDuplicate(t *testing.T) {
+	hotkeys = nil
+	pluginHotkeyEnabled = map[string]map[string]bool{}
+
+	pluginAddHotkey("plug", "Ctrl-P", "say hi")
+	pluginAddHotkey("plug", "Ctrl-P", "say hi")
+
+	hotkeysMu.RLock()
+	if len(hotkeys) != 1 {
+		hotkeysMu.RUnlock()
+		t.Fatalf("expected 1 hotkey, got %d", len(hotkeys))
+	}
+	hotkeysMu.RUnlock()
+	if len(pluginHotkeyEnabled) != 0 {
+		t.Fatalf("unexpected pluginHotkeyEnabled entries: %v", pluginHotkeyEnabled)
+	}
+}


### PR DESCRIPTION
## Summary
- add regression test to ensure plugin hotkeys are not duplicated

## Testing
- `go test -run TestPluginAddHotkeyDuplicate` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aee7619804832aafde544eedbbc5ad