### PR TITLE
Ensure ponder bubbles use consistent transparency

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -78,7 +78,7 @@ func bubbleColors(typ int) (border, bg, text color.Color) {
 		bg = color.NRGBA{0x80, 0x80, 0x80, alpha}
 		text = color.Black
 	case kBubblePonder:
-		border = color.NRGBA{0xcc, 0xcc, 0xcc, 0xff}
+		border = color.NRGBA{0xcc, 0xcc, 0xcc, alpha}
 		bg = color.NRGBA{0xcc, 0xcc, 0xcc, alpha}
 		text = color.Black
 	case kBubbleRealAction:


### PR DESCRIPTION
## Summary
- Use the same alpha for ponder bubble borders and fill so the body and wavy edges render as a single shape

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68af2c406a58832a99581ec3ed249988