### PR TITLE
Use currentNightLevel for night rendering

### DIFF
--- a/night.go
+++ b/night.go
@@ -210,24 +210,10 @@ func init() {
 }
 
 // drawNightAmbient applies a uniform darkening to the scene based on the
-// current night level. This keeps overall brightness appropriate even without
-// the shader path.
+// current night level. This mirrors classic client behavior and keeps overall
+// brightness appropriate even without the shader path.
 func drawNightAmbient(screen *ebiten.Image, ox, oy int) {
-	gNight.mu.Lock()
-	lvl := gNight.Level
-	flags := gNight.Flags
-	gNight.mu.Unlock()
-
-	limit := gs.MaxNightLevel
-	if flags&kLightForce100Pct != 0 {
-		limit = 100
-	}
-	if gs.ForceNightLevel >= 0 {
-		lvl = gs.ForceNightLevel
-	}
-	if lvl > limit {
-		lvl = limit
-	}
+	lvl := currentNightLevel() // Mirrors classic client night level logic
 	if lvl <= 0 {
 		return
 	}
@@ -248,22 +234,10 @@ func drawNightAmbient(screen *ebiten.Image, ox, oy int) {
 	screen.DrawImage(blackImg, op)
 }
 
+// drawNightOverlay applies the vignette overlay based on the current night
+// level. Matches classic client behavior.
 func drawNightOverlay(screen *ebiten.Image, ox, oy int) {
-	gNight.mu.Lock()
-	lvl := gNight.Level
-	flags := gNight.Flags
-	gNight.mu.Unlock()
-
-	limit := gs.MaxNightLevel
-	if flags&kLightForce100Pct != 0 {
-		limit = 100
-	}
-	if gs.ForceNightLevel >= 0 {
-		lvl = gs.ForceNightLevel
-	}
-	if lvl > limit {
-		lvl = limit
-	}
+	lvl := currentNightLevel() // Mirrors classic client night level logic
 	if lvl <= 0 {
 		return
 	}


### PR DESCRIPTION
## Summary
- rely on currentNightLevel for night overlay and ambient darkening
- document parity with classic client behavior

## Testing
- `golangci-lint run` *(fails: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25))*
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; fatal error: X11/extensions/Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: Package alsa was not found; Package gtk+-3.0 was not found; fatal error: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b02a0167b0832a998c3bd227624049