### PR TITLE
night: add tests for currentNightLevel

### DIFF
--- a/night_test.go
+++ b/night_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+func TestCurrentNightLevel(t *testing.T) {
+	cases := []struct {
+		name   string
+		force  int
+		max    int
+		flags  uint
+		server int
+		want   int
+	}{
+		{"AutoWithinLimit", -1, 100, 0, 60, 60},
+		{"AutoClampedToMax", -1, 25, 0, 80, 25},
+		{"ForcedNightClamped", 100, 25, 0, 0, 25},
+		{"ForcedDayOverrides", 0, 100, 0, 80, 0},
+		{"Force100FlagOverridesMax", -1, 25, kLightForce100Pct, 80, 80},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gNight.mu.Lock()
+			oldLvl, oldFlags := gNight.Level, gNight.Flags
+			gNight.Level = tc.server
+			gNight.Flags = tc.flags
+			gNight.mu.Unlock()
+			defer func() {
+				gNight.mu.Lock()
+				gNight.Level, gNight.Flags = oldLvl, oldFlags
+				gNight.mu.Unlock()
+			}()
+
+			oldForce, oldMax := gs.ForceNightLevel, gs.MaxNightLevel
+			gs.ForceNightLevel, gs.MaxNightLevel = tc.force, tc.max
+			defer func() {
+				gs.ForceNightLevel, gs.MaxNightLevel = oldForce, oldMax
+			}()
+
+			if got := currentNightLevel(); got != tc.want {
+				t.Fatalf("currentNightLevel() = %d; want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven tests for currentNightLevel covering auto mode, forced levels, clamping and server force-100 flag

## Testing
- `go vet ./...`
- `go build ./...`
- `golangci-lint run` *(fails: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25))*
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b02a05a374832ab97bd5fabe0f5b79