### PR TITLE
Load lighting shader from disk when available with embedded fallback

### DIFF
--- a/lighting_shader.go
+++ b/lighting_shader.go
@@ -43,9 +43,7 @@ const (
 )
 
 func init() {
-	var err error
-	lightingShader, err = ebiten.NewShader(lightShaderSrc)
-	if err != nil {
+	if err := ReloadLightingShader(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Summary
- Initialize lighting shader by attempting to load from `data/shaders/light.kage` and falling back to the embedded shader source

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory, Package 'alsa' not found)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory, Package 'alsa' not found)*
- `golangci-lint run` *(fails: Go language version used to build golangci-lint is lower than module requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b045b71c1c832a8b78585be06f3f7b