### PR TITLE
Add settings for pin indicators and persistent input bar

### DIFF
--- a/eui/glob.go
+++ b/eui/glob.go
@@ -43,6 +43,9 @@ var (
 	// windowSnapping snaps windows to screen edges or other windows when enabled.
 	windowSnapping bool = true
 
+	// showPinLocations enables drawing pin-to zone indicators while dragging windows.
+	showPinLocations bool
+
 	// middleClickMove enables moving windows with the middle mouse button when enabled.
 	middleClickMove bool
 

--- a/eui/public.go
+++ b/eui/public.go
@@ -21,6 +21,12 @@ func WindowSnapping() bool { return windowSnapping }
 // SetWindowSnapping enables or disables window snapping.
 func SetWindowSnapping(enabled bool) { windowSnapping = enabled }
 
+// ShowPinLocations reports whether pin-to zone indicators are shown while dragging windows.
+func ShowPinLocations() bool { return showPinLocations }
+
+// SetShowPinLocations enables or disables pin-to zone indicators while dragging windows.
+func SetShowPinLocations(enabled bool) { showPinLocations = enabled }
+
 // MiddleClickMove reports whether middle-click window dragging is enabled.
 func MiddleClickMove() bool { return middleClickMove }
 

--- a/eui/render.go
+++ b/eui/render.go
@@ -49,11 +49,11 @@ func Draw(screen *ebiten.Image) {
 		win.Draw(screen, &dropdowns)
 	}
 
-	if dragPart == PART_BAR && dragWin != nil {
+	if showPinLocations && dragPart == PART_BAR && dragWin != nil {
 		zoneIndicatorWin = dragWin
 	}
 
-	if zoneIndicatorWin != nil {
+	if showPinLocations && zoneIndicatorWin != nil {
 		drawZoneOverlay(screen, zoneIndicatorWin)
 	}
 

--- a/game.go
+++ b/game.go
@@ -740,7 +740,11 @@ func (g *Game) Update() error {
 				}
 				inputHistory = append(inputHistory, txt)
 			}
-			inputActive = false
+			if gs.InputBarAlwaysOpen {
+				inputActive = true
+			} else {
+				inputActive = false
+			}
 			inputText = inputText[:0]
 			historyPos = len(inputHistory)
 			changedInput = true

--- a/settings.go
+++ b/settings.go
@@ -106,7 +106,7 @@ var gsdef settings = settings{
 	EnabledPlugins:  map[string]bool{},
 	vsync:           true,
 	nightEffect:     true,
-    shaderLighting:  true,
+	shaderLighting:  true,
 	throttleSounds:  true,
 }
 
@@ -116,6 +116,7 @@ type settings struct {
 	LastCharacter         string
 	ClickToToggle         bool
 	MiddleClickMoveWindow bool
+	InputBarAlwaysOpen    bool
 	KBWalkSpeed           float64
 	MainFontSize          float64
 	BubbleFontSize        float64
@@ -188,6 +189,7 @@ type settings struct {
 	NotifiedVersion      int
 	WindowTiling         bool
 	WindowSnapping       bool
+	ShowPinToLocations   bool
 
 	WindowWidth  int
 	WindowHeight int
@@ -306,6 +308,7 @@ func applySettings() {
 	updateBubbleVisibility()
 	eui.SetWindowTiling(gs.WindowTiling)
 	eui.SetWindowSnapping(gs.WindowSnapping)
+	eui.SetShowPinLocations(gs.ShowPinToLocations)
 	eui.SetMiddleClickMove(gs.MiddleClickMoveWindow)
 	eui.SetPotatoMode(gs.PotatoComputer)
 	climg.SetPotatoMode(gs.PotatoComputer)
@@ -319,6 +322,9 @@ func applySettings() {
 	ebiten.SetWindowFloating(gs.Fullscreen || gs.AlwaysOnTop)
 	initFont()
 	updateSoundVolume()
+	if gs.InputBarAlwaysOpen {
+		inputActive = true
+	}
 }
 
 func updateBubbleVisibility() {
@@ -535,55 +541,55 @@ func restoreWindowsAfterScale() {
 }
 
 type qualityPreset struct {
-    DenoiseImages   bool
-    MotionSmoothing bool
-    BlendMobiles    bool
-    BlendPicts      bool
-    NoCaching       bool
-    ShaderLighting  bool
+	DenoiseImages   bool
+	MotionSmoothing bool
+	BlendMobiles    bool
+	BlendPicts      bool
+	NoCaching       bool
+	ShaderLighting  bool
 }
 
 var (
-    ultraLowPreset = qualityPreset{
-        DenoiseImages:   false,
-        MotionSmoothing: false,
-        BlendMobiles:    false,
-        BlendPicts:      false,
-        NoCaching:       true,
-        ShaderLighting:  false,
-    }
-    lowPreset = qualityPreset{
-        DenoiseImages:   false,
-        MotionSmoothing: false,
-        BlendMobiles:    false,
-        BlendPicts:      false,
-        NoCaching:       false,
-        ShaderLighting:  false,
-    }
-    standardPreset = qualityPreset{
-        DenoiseImages:   true,
-        MotionSmoothing: true,
-        BlendMobiles:    false,
-        BlendPicts:      false,
-        NoCaching:       false,
-        ShaderLighting:  true,
-    }
-    highPreset = qualityPreset{
-        DenoiseImages:   true,
-        MotionSmoothing: true,
-        BlendMobiles:    false,
-        BlendPicts:      true,
-        NoCaching:       false,
-        ShaderLighting:  true,
-    }
-    ultimatePreset = qualityPreset{
-        DenoiseImages:   true,
-        MotionSmoothing: true,
-        BlendMobiles:    true,
-        BlendPicts:      true,
-        NoCaching:       false,
-        ShaderLighting:  true,
-    }
+	ultraLowPreset = qualityPreset{
+		DenoiseImages:   false,
+		MotionSmoothing: false,
+		BlendMobiles:    false,
+		BlendPicts:      false,
+		NoCaching:       true,
+		ShaderLighting:  false,
+	}
+	lowPreset = qualityPreset{
+		DenoiseImages:   false,
+		MotionSmoothing: false,
+		BlendMobiles:    false,
+		BlendPicts:      false,
+		NoCaching:       false,
+		ShaderLighting:  false,
+	}
+	standardPreset = qualityPreset{
+		DenoiseImages:   true,
+		MotionSmoothing: true,
+		BlendMobiles:    false,
+		BlendPicts:      false,
+		NoCaching:       false,
+		ShaderLighting:  true,
+	}
+	highPreset = qualityPreset{
+		DenoiseImages:   true,
+		MotionSmoothing: true,
+		BlendMobiles:    false,
+		BlendPicts:      true,
+		NoCaching:       false,
+		ShaderLighting:  true,
+	}
+	ultimatePreset = qualityPreset{
+		DenoiseImages:   true,
+		MotionSmoothing: true,
+		BlendMobiles:    true,
+		BlendPicts:      true,
+		NoCaching:       false,
+		ShaderLighting:  true,
+	}
 )
 
 func applyQualityPreset(name string) {
@@ -603,12 +609,12 @@ func applyQualityPreset(name string) {
 		return
 	}
 
-    gs.DenoiseImages = p.DenoiseImages
-    gs.MotionSmoothing = p.MotionSmoothing
-    gs.BlendMobiles = p.BlendMobiles
-    gs.BlendPicts = p.BlendPicts
-    gs.NoCaching = p.NoCaching
-    gs.shaderLighting = p.ShaderLighting
+	gs.DenoiseImages = p.DenoiseImages
+	gs.MotionSmoothing = p.MotionSmoothing
+	gs.BlendMobiles = p.BlendMobiles
+	gs.BlendPicts = p.BlendPicts
+	gs.NoCaching = p.NoCaching
+	gs.shaderLighting = p.ShaderLighting
 	if gs.NoCaching {
 		gs.precacheSounds = false
 		gs.precacheImages = false
@@ -617,9 +623,9 @@ func applyQualityPreset(name string) {
 	if denoiseCB != nil {
 		denoiseCB.Checked = gs.DenoiseImages
 	}
-    if motionCB != nil {
-        motionCB.Checked = gs.MotionSmoothing
-    }
+	if motionCB != nil {
+		motionCB.Checked = gs.MotionSmoothing
+	}
 	if animCB != nil {
 		animCB.Checked = gs.BlendMobiles
 	}
@@ -651,18 +657,18 @@ func applyQualityPreset(name string) {
 	if graphicsWin != nil {
 		graphicsWin.Refresh()
 	}
-    if debugWin != nil {
-        debugWin.Refresh()
-    }
+	if debugWin != nil {
+		debugWin.Refresh()
+	}
 }
 
 func matchesPreset(p qualityPreset) bool {
-    return gs.DenoiseImages == p.DenoiseImages &&
-        gs.MotionSmoothing == p.MotionSmoothing &&
-        gs.BlendMobiles == p.BlendMobiles &&
-        gs.BlendPicts == p.BlendPicts &&
-        gs.NoCaching == p.NoCaching &&
-        gs.shaderLighting == p.ShaderLighting
+	return gs.DenoiseImages == p.DenoiseImages &&
+		gs.MotionSmoothing == p.MotionSmoothing &&
+		gs.BlendMobiles == p.BlendMobiles &&
+		gs.BlendPicts == p.BlendPicts &&
+		gs.NoCaching == p.NoCaching &&
+		gs.shaderLighting == p.ShaderLighting
 }
 
 func detectQualityPreset() int {

--- a/ui.go
+++ b/ui.go
@@ -1975,6 +1975,21 @@ func makeSettingsWindow() {
 	}
 	left.AddItem(alwaysTopCB)
 
+	pinLocCB, pinLocEvents := eui.NewCheckbox()
+	pinLocCB.Text = "Show pin-to locations"
+	pinLocCB.Size = eui.Point{X: panelWidth, Y: 24}
+	pinLocCB.Checked = gs.ShowPinToLocations
+	pinLocEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			SettingsLock.Lock()
+			gs.ShowPinToLocations = ev.Checked
+			SettingsLock.Unlock()
+			eui.SetShowPinLocations(ev.Checked)
+			settingsDirty = true
+		}
+	}
+	left.AddItem(pinLocCB)
+
 	themeDD, themeEvents := eui.NewDropdown()
 	themeDD.Label = "Window Theme"
 	if opts, err := eui.ListThemes(); err == nil {
@@ -2044,6 +2059,32 @@ func makeSettingsWindow() {
 		}
 	}
 	left.AddItem(midMove)
+
+	inputOpenCB, inputOpenEvents := eui.NewCheckbox()
+	inputOpenCB.Text = "Input bar always open"
+	inputOpenCB.Size = eui.Point{X: panelWidth, Y: 24}
+	inputOpenCB.Checked = gs.InputBarAlwaysOpen
+	inputOpenCB.Tooltip = "Keep console input active after sending"
+	inputOpenEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			SettingsLock.Lock()
+			gs.InputBarAlwaysOpen = ev.Checked
+			SettingsLock.Unlock()
+			if gs.InputBarAlwaysOpen {
+				inputActive = true
+			} else {
+				inputActive = false
+				inputText = inputText[:0]
+				historyPos = len(inputHistory)
+			}
+			updateConsoleWindow()
+			if consoleWin != nil {
+				consoleWin.Refresh()
+			}
+			settingsDirty = true
+		}
+	}
+	left.AddItem(inputOpenCB)
 
 	keySpeedSlider, keySpeedEvents := eui.NewSlider()
 	keySpeedSlider.Label = "Keyboard Walk Speed"


### PR DESCRIPTION
## Summary
- add optional setting to show window pin-to indicators
- add setting to keep the console input bar open after sending

## Testing
- `go vet ./...` *(fails: Package alsa was not found; X11/Xrandr.h missing)*
- `go build ./...` *(fails: Package alsa was not found; gtk+-3.0 and Xrandr headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ba021cdc832aafbe6d0323dd707b