### PR TITLE
Prevent plugin command registration conflicts

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -323,6 +323,13 @@ func pluginRegisterCommand(owner, name string, handler PluginCommandHandler) {
 	}
 	key := strings.ToLower(strings.TrimPrefix(name, "/"))
 	pluginMu.Lock()
+	if _, exists := pluginCommands[key]; exists {
+		pluginMu.Unlock()
+		msg := fmt.Sprintf("[plugin] command conflict: /%s already registered", key)
+		consoleMessage(msg)
+		log.Print(msg)
+		return
+	}
 	pluginCommands[key] = handler
 	pluginCommandOwners[key] = owner
 	pluginMu.Unlock()


### PR DESCRIPTION
## Summary
- avoid overwriting existing plugin commands by logging conflicts
- add test to ensure conflicts are reported and handlers preserved

## Testing
- `go fmt plugin.go plugin_test.go`
- `go vet ./...`
- `go test ./...` *(fails: GLFW library not initialized due to missing DISPLAY)*


------
https://chatgpt.com/codex/tasks/task_e_68b0c06df264832aa5d257dbb15fc4ce