### PR TITLE
Handle plugins missing metadata

### DIFF
--- a/plugin_invalid_test.go
+++ b/plugin_invalid_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Test that plugins missing required metadata are marked invalid and disabled.
+func TestPluginMissingMetaDisabled(t *testing.T) {
+	origDir := dataDirPath
+	dataDirPath = t.TempDir()
+	t.Cleanup(func() { dataDirPath = origDir })
+
+	plugDir := filepath.Join(dataDirPath, "plugins")
+	if err := os.MkdirAll(plugDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	src := `package main
+const PluginName = "MetaTest"
+`
+	if err := os.WriteFile(filepath.Join(plugDir, "meta.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write plugin: %v", err)
+	}
+
+	// Reset plugin state.
+	pluginMu = sync.RWMutex{}
+	pluginDisplayNames = map[string]string{}
+	pluginAuthors = map[string]string{}
+	pluginCategories = map[string]string{}
+	pluginSubCategories = map[string]string{}
+	pluginInvalid = map[string]bool{}
+	pluginDisabled = map[string]bool{}
+	pluginEnabledFor = map[string]string{}
+	pluginNames = map[string]bool{}
+
+	loadPlugins()
+	owner := "MetaTest_meta"
+	if !pluginInvalid[owner] {
+		t.Fatalf("plugin not marked invalid: %+v", pluginInvalid)
+	}
+	if !pluginDisabled[owner] {
+		t.Fatalf("plugin not disabled")
+	}
+
+	playerName = "Tester"
+	setPluginEnabled(owner, true, false)
+	if pluginEnabledFor[owner] != "" {
+		t.Fatalf("invalid plugin unexpectedly enabled: %q", pluginEnabledFor[owner])
+	}
+	if !pluginDisabled[owner] {
+		t.Fatalf("invalid plugin became enabled")
+	}
+}

--- a/ui.go
+++ b/ui.go
@@ -441,11 +441,9 @@ func refreshPluginsWindow() {
 		invalid := pluginInvalid[e.owner]
 		pluginMu.RUnlock()
 		charCB.Checked = playerName != "" && scope == playerName
+		charCB.Disabled = invalid
 		allCB.Checked = scope == "all"
-		if invalid {
-			charCB.Disabled = true
-			allCB.Disabled = true
-		}
+		allCB.Disabled = invalid
 		label := e.name
 		if cat != "" {
 			label += " [" + cat
@@ -455,14 +453,16 @@ func refreshPluginsWindow() {
 			label += "]"
 		}
 		owner := e.owner
-		charEvents.Handle = func(ev eui.UIEvent) {
-			if ev.Type == eui.EventCheckboxChanged {
-				setPluginEnabled(owner, ev.Checked, allCB.Checked)
+		if !invalid {
+			charEvents.Handle = func(ev eui.UIEvent) {
+				if ev.Type == eui.EventCheckboxChanged {
+					setPluginEnabled(owner, ev.Checked, allCB.Checked)
+				}
 			}
-		}
-		allEvents.Handle = func(ev eui.UIEvent) {
-			if ev.Type == eui.EventCheckboxChanged {
-				setPluginEnabled(owner, charCB.Checked, ev.Checked)
+			allEvents.Handle = func(ev eui.UIEvent) {
+				if ev.Type == eui.EventCheckboxChanged {
+					setPluginEnabled(owner, charCB.Checked, ev.Checked)
+				}
 			}
 		}
 		row.AddItem(charCB)
@@ -471,9 +471,7 @@ func refreshPluginsWindow() {
 		nameTxt.Text = label
 		nameTxt.FontSize = 12
 		nameTxt.Size = pluginSize
-		if invalid {
-			nameTxt.Disabled = true
-		}
+		nameTxt.Disabled = invalid
 		row.AddItem(nameTxt)
 
 		if !invalid {


### PR DESCRIPTION
## Summary
- prevent enabling plugins lacking required metadata
- disable plugin list controls when a plugin is invalid
- extend regression test ensuring invalid plugins stay disabled

## Testing
- `go vet ./...` *(fails: pkg-config cannot find gtk+-3.0)*
- `go build` *(timeout after dependency compilation)*
- `go test plugin_invalid_test.go` *(fails: undefined: dataDirPath and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b1233d199c832a8c1548db5b006a14