### PR TITLE
Prevent duplicate hotkey bindings

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -628,6 +628,26 @@ func finishHotkeyEdit(save bool) {
 			}
 		}
 		if combo != "" {
+			hotkeysMu.RLock()
+			for i, hk := range hotkeys {
+				if i == editingHotkey {
+					continue
+				}
+				if strings.EqualFold(hk.Combo, combo) {
+					hotkeysMu.RUnlock()
+					name := hk.Name
+					if name == "" {
+						name = hk.Plugin
+					}
+					if name == "" {
+						name = "another hotkey"
+					}
+					showPopup("Error", fmt.Sprintf("%s already bound to %s", combo, name), []popupButton{{Text: "OK"}})
+					return
+				}
+			}
+			hotkeysMu.RUnlock()
+
 			hk := Hotkey{Name: name, Combo: combo, Commands: cmds}
 			hotkeysMu.Lock()
 			if editingHotkey >= 0 && editingHotkey < len(hotkeys) {

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/image/font/gofont/goregular"
+	"gothoom/eui"
 )
 
 // Test that closing the hotkey editor clears the reference and allows reopening.
@@ -92,6 +95,26 @@ func TestHotkeyEmptyCommandSaved(t *testing.T) {
 	if hotkeyEditWin != nil {
 		hotkeyEditWin.Close()
 	}
+}
+
+// Test that attempting to bind a duplicate combo results in an error and no save.
+func TestHotkeyDuplicateComboError(t *testing.T) {
+	if err := eui.EnsureFontSource(goregular.TTF); err != nil {
+		t.Fatalf("ensure font: %v", err)
+	}
+	hotkeys = []Hotkey{{Combo: "Ctrl-A"}}
+
+	openHotkeyEditor(-1)
+	hotkeyComboText.Text = "Ctrl-A"
+	finishHotkeyEdit(true)
+
+	if len(hotkeys) != 1 {
+		t.Fatalf("duplicate hotkey saved")
+	}
+	if hotkeyEditWin == nil {
+		t.Fatalf("editor closed despite duplicate combo")
+	}
+	hotkeyEditWin.Close()
 }
 
 // Test that editing a hotkey with no name still saves changes.


### PR DESCRIPTION
## Summary
- show an error popup when trying to save a hotkey with a combo already in use
- add regression test for duplicate hotkey combos

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run -a go test -run HotkeyDuplicateComboError`


------
https://chatgpt.com/codex/tasks/task_e_68b14064677c832a98368f025bdbe7ad