### PR TITLE
Handle input bar cursor and movement keys

### DIFF
--- a/console_ui.go
+++ b/console_ui.go
@@ -25,6 +25,11 @@ func updateConsoleWindow() {
 
 	msgs := getConsoleMessages()
 	updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg, nil)
+	if inputFlow != nil && len(inputFlow.Contents) > 0 {
+		inputItem := inputFlow.Contents[0]
+		inputItem.Focused = inputActive
+		inputItem.CursorPos = inputPos
+	}
 	if messagesFlow != nil {
 		// Scroll to bottom on new text; clamp occurs on Refresh.
 		if scrollit {

--- a/plugin.go
+++ b/plugin.go
@@ -687,6 +687,7 @@ func pluginSetInputText(text string) {
 	inputMu.Lock()
 	inputText = []rune(text)
 	inputActive = true
+	inputPos = len(inputText)
 	inputMu.Unlock()
 }
 

--- a/ui.go
+++ b/ui.go
@@ -2294,6 +2294,7 @@ func makeSettingsWindow() {
 			} else {
 				inputActive = false
 				inputText = inputText[:0]
+				inputPos = 0
 				historyPos = len(inputHistory)
 			}
 			updateConsoleWindow()


### PR DESCRIPTION
## Summary
- Track cursor position in console input and support left/right arrow editing
- Skip movement hotkeys while any text field is focused or input bar is active
- Keep plugin and settings helpers in sync with new input cursor logic

## Testing
- `go vet ./...` *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*
- `go build ./...` *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*
- `go test ./...` *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found; X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a8a84b24832a8621818b716acd3b