### PR TITLE
Add list option to notts command

### DIFF
--- a/chat_tts_blocklist.go
+++ b/chat_tts_blocklist.go
@@ -38,8 +38,18 @@ func isTTSBlocked(name string) bool {
 
 func handleNoTTSCommand(args string) {
 	fields := strings.Fields(args)
+	if len(fields) == 1 && strings.ToLower(fields[0]) == "list" {
+		ttsBlocklistMu.RLock()
+		if len(gs.ChatTTSBlocklist) == 0 {
+			consoleMessage("TTS blocklist is empty.")
+		} else {
+			consoleMessage("TTS blocklist: " + strings.Join(gs.ChatTTSBlocklist, ", "))
+		}
+		ttsBlocklistMu.RUnlock()
+		return
+	}
 	if len(fields) != 2 {
-		consoleMessage("Usage: /notts add|remove <name>")
+		consoleMessage("Usage: /notts add|remove <name> or /notts list")
 		return
 	}
 	action := strings.ToLower(fields[0])
@@ -76,6 +86,6 @@ func handleNoTTSCommand(args string) {
 		settingsDirty = true
 		consoleMessage("Removed " + name + " from the TTS blocklist.")
 	default:
-		consoleMessage("Usage: /notts add|remove <name>")
+		consoleMessage("Usage: /notts add|remove <name> or /notts list")
 	}
 }

--- a/chat_tts_blocklist_test.go
+++ b/chat_tts_blocklist_test.go
@@ -61,3 +61,19 @@ func TestHandleNoTTSCommand(t *testing.T) {
 	gs.ChatTTSBlocklist = orig
 	syncTTSBlocklist()
 }
+
+func TestHandleNoTTSList(t *testing.T) {
+	origList := gs.ChatTTSBlocklist
+	gs.ChatTTSBlocklist = []string{"foo", "bar"}
+	syncTTSBlocklist()
+	origLog := consoleLog
+	consoleLog = messageLog{max: maxMessages}
+	handleNoTTSCommand("list")
+	msgs := getConsoleMessages()
+	if len(msgs) != 1 || msgs[0] != "TTS blocklist: foo, bar" {
+		t.Fatalf("got %v", msgs)
+	}
+	consoleLog = origLog
+	gs.ChatTTSBlocklist = origList
+	syncTTSBlocklist()
+}


### PR DESCRIPTION
## Summary
- support `/notts list` to display the TTS blocklist
- test listing current TTS blocklist

## Testing
- `go vet ./...` *(fails: spellcheck_words.txt: no matching files found)*
- `golangci-lint run` *(fails: Go language version used to build golangci-lint is lower than targeted Go version 1.25)*
- `go test ./...` *(fails: missing X11 headers and spellcheck_words.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c612e3cc832a8a15dd224d7cf547