### PR TITLE
Fix input bar mouse insertion

### DIFF
--- a/console_ui.go
+++ b/console_ui.go
@@ -28,7 +28,7 @@ func updateConsoleWindow() {
 	if inputFlow != nil && len(inputFlow.Contents) > 0 {
 		inputItem := inputFlow.Contents[0]
 		inputItem.Focused = inputActive
-		inputItem.CursorPos = inputPos
+		inputItem.CursorPos = wrappedCursorPos(inputItem.Text, inputPos)
 	}
 	if messagesFlow != nil {
 		// Scroll to bottom on new text; clamp occurs on Refresh.

--- a/game.go
+++ b/game.go
@@ -591,7 +591,8 @@ func (g *Game) Update() error {
 	eui.Update() //We really need this to return eaten clicks
 	typingElsewhere := typingInUI()
 	if inputActive && inputFlow != nil && len(inputFlow.Contents) > 0 {
-		inputPos = inputFlow.Contents[0].CursorPos
+		item := inputFlow.Contents[0]
+		inputPos = plainCursorPos(item.Text, item.CursorPos)
 	}
 	checkPluginMods()
 	updateNotifications()

--- a/input_cursor.go
+++ b/input_cursor.go
@@ -1,0 +1,37 @@
+package main
+
+// wrappedCursorPos converts a plain text cursor position to the equivalent
+// index in a wrapped string that may contain newline characters.
+func wrappedCursorPos(text string, plain int) int {
+	rs := []rune(text)
+	plainCount := 0
+	for i, r := range rs {
+		if r == '\n' {
+			continue
+		}
+		if plainCount == plain {
+			return i
+		}
+		plainCount++
+	}
+	return len(rs)
+}
+
+// plainCursorPos converts a cursor index in a wrapped string back to the
+// position in the underlying plain text (with newlines removed).
+func plainCursorPos(text string, wrapped int) int {
+	rs := []rune(text)
+	if wrapped < 0 {
+		wrapped = 0
+	}
+	if wrapped > len(rs) {
+		wrapped = len(rs)
+	}
+	plain := 0
+	for i := 0; i < wrapped; i++ {
+		if rs[i] != '\n' {
+			plain++
+		}
+	}
+	return plain
+}


### PR DESCRIPTION
## Summary
- translate cursor positions between wrapped display text and plain input text
- update input handling so mouse clicks insert at the correct position

## Testing
- `go fmt input_cursor.go game.go console_ui.go`
- `go vet ./...` (fails: gothoom/eui.Color struct literal uses unkeyed fields)
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2c56ecb3c832aaeaa9008294f61b9