### PR TITLE
Add About window with attribution and license info

### DIFF
--- a/ATTRIBUTE.md
+++ b/ATTRIBUTE.md
@@ -1,34 +1,47 @@
-# Third-Party Libraries Attribution
+# Attribution
 
-This project uses the following third-party Go libraries.
+goThoom is licensed under the [MIT License](LICENSE).  
+Copyright (c) 2025 Carl Frank Otto III.
 
-| Library | Repository | License | Author(s) |
-| --- | --- | --- | --- |
-| Ebitengine | https://github.com/hajimehoshi/ebiten | Apache-2.0 | Hajime Hoshi |
-| go-humanize | https://github.com/dustin/go-humanize | MIT | Dustin Sallings |
-| piper | https://github.com/fresh-cut/piper | MIT | Amity Bell |
-| gopacket | https://github.com/google/gopacket | BSD-3-Clause | Google, Inc.; Andreas Krennmair |
-| durafmt | https://github.com/hako/durafmt | MIT | Wesley Hill |
-| rich-go | https://github.com/hugolgst/rich-go | MIT | Hugo Lageneste |
-| sizedwaitgroup | https://github.com/remeh/sizedwaitgroup | MIT | Rémy Mathieu |
-| go-meltysynth | https://github.com/sinshu/go-meltysynth | MIT | Nobuaki Tanaka |
-| dialog | https://github.com/sqweek/dialog | ISC | sqweek and contributors |
-| dark-mode-go | https://github.com/thiagokokada/dark-mode-go | MIT | Thiago Kenji Okada |
-| clipboard | https://github.com/golang-design/clipboard | MIT | Changkun Ou |
-| x/crypto | https://github.com/golang/crypto | BSD-3-Clause | The Go Authors |
-| x/text | https://github.com/golang/text | BSD-3-Clause | The Go Authors |
-| x/time | https://github.com/golang/time | BSD-3-Clause | The Go Authors |
+## Third-Party Libraries
+
+- **Ebitengine** — Apache-2.0 — Hajime Hoshi  
+  https://github.com/hajimehoshi/ebiten
+- **go-humanize** — MIT — Dustin Sallings  
+  https://github.com/dustin/go-humanize
+- **piper** — MIT — Amity Bell  
+  https://github.com/fresh-cut/piper
+- **gopacket** — BSD-3-Clause — Google, Inc.; Andreas Krennmair  
+  https://github.com/google/gopacket
+- **durafmt** — MIT — Wesley Hill  
+  https://github.com/hako/durafmt
+- **rich-go** — MIT — Hugo Lageneste  
+  https://github.com/hugolgst/rich-go
+- **sizedwaitgroup** — MIT — Rémy Mathieu  
+  https://github.com/remeh/sizedwaitgroup
+- **go-meltysynth** — MIT — Nobuaki Tanaka  
+  https://github.com/sinshu/go-meltysynth
+- **dialog** — ISC — sqweek and contributors  
+  https://github.com/sqweek/dialog
+- **dark-mode-go** — MIT — Thiago Kenji Okada  
+  https://github.com/thiagokokada/dark-mode-go
+- **clipboard** — MIT — Changkun Ou  
+  https://github.com/golang-design/clipboard
+- **x/crypto** — BSD-3-Clause — The Go Authors  
+  https://github.com/golang/crypto
+- **x/text** — BSD-3-Clause — The Go Authors  
+  https://github.com/golang/text
+- **x/time** — BSD-3-Clause — The Go Authors  
+  https://github.com/golang/time
 
 ## Fonts
 
-| Font | Repository | License | Author(s) |
-| --- | --- | --- | --- |
-| Noto Sans (Regular, Bold, Italic, BoldItalic) | https://github.com/googlefonts/noto-fonts | SIL Open Font License 1.1 | The Noto Project Authors |
+- **Noto Sans (Regular, Bold, Italic, BoldItalic)** — SIL Open Font License 1.1 — The Noto Project Authors  
+  https://github.com/googlefonts/noto-fonts
 
 ## Delta Tao Software
 
-| Resource | URL | License | Author(s) |
-| --- | --- | --- | --- |
-| Clan Lord | https://www.deltatao.com/clanlord/ | Proprietary | Delta Tao Software |
-| Clan Lord Client | https://github.com/YappyGM/ClanLordClient | Apache-2.0 | Delta Tao Software |
-
+- **Clan Lord** — Proprietary — Delta Tao Software  
+  https://www.deltatao.com/clanlord/
+- **Clan Lord Client** — Apache-2.0 — Delta Tao Software  
+  https://github.com/YappyGM/ClanLordClient

--- a/about_ui.go
+++ b/about_ui.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	_ "embed"
+	"strings"
+
+	"gothoom/eui"
+)
+
+//go:embed data/about.txt
+var aboutText string
+
+var aboutWin *eui.WindowData
+var aboutList *eui.ItemData
+var aboutLines []string
+
+func initAboutUI() {
+	if aboutWin != nil {
+		return
+	}
+	aboutWin, aboutList, _ = makeTextWindow("About", eui.HZoneCenter, eui.VZoneMiddleTop, false)
+	aboutWin.AutoSize = true
+	aboutLines = strings.Split(strings.ReplaceAll(aboutText, "\r\n", "\n"), "\n")
+	aboutWin.OnResize = func() { updateTextWindow(aboutWin, aboutList, nil, aboutLines, 15, "", monoFaceSource) }
+}
+
+func openAboutWindow(anchor *eui.ItemData) {
+	if aboutWin == nil {
+		return
+	}
+	updateTextWindow(aboutWin, aboutList, nil, aboutLines, 15, "", monoFaceSource)
+	if anchor != nil {
+		aboutWin.MarkOpenNear(anchor)
+	} else {
+		aboutWin.MarkOpen()
+	}
+	aboutWin.Refresh()
+}

--- a/data/about.txt
+++ b/data/about.txt
@@ -1,0 +1,27 @@
+goThoom is licensed under the MIT License.
+Copyright (c) 2025 Carl Frank Otto III.
+
+Third-Party Libraries:
+- Ebitengine (Apache-2.0) by Hajime Hoshi
+- go-humanize (MIT) by Dustin Sallings
+- piper (MIT) by Amity Bell
+- gopacket (BSD-3-Clause) by Google, Inc.; Andreas Krennmair
+- durafmt (MIT) by Wesley Hill
+- rich-go (MIT) by Hugo Lageneste
+- sizedwaitgroup (MIT) by Rémy Mathieu
+- go-meltysynth (MIT) by Nobuaki Tanaka
+- dialog (ISC) by sqweek and contributors
+- dark-mode-go (MIT) by Thiago Kenji Okada
+- clipboard (MIT) by Changkun Ou
+- x/crypto (BSD-3-Clause) by The Go Authors
+- x/text (BSD-3-Clause) by The Go Authors
+- x/time (BSD-3-Clause) by The Go Authors
+
+Fonts:
+- Noto Sans (Regular, Bold, Italic, BoldItalic) – SIL Open Font License 1.1
+
+Delta Tao Software:
+- Clan Lord – Proprietary – Delta Tao Software
+- Clan Lord Client – Apache-2.0 – Delta Tao Software
+
+For more details, see ATTRIBUTE.md.

--- a/ui.go
+++ b/ui.go
@@ -181,10 +181,11 @@ func initUI() {
 	makeBubbleWindow()
 	makeDebugWindow()
 	initHelpUI()
+	initAboutUI()
 	makeWindowsWindow()
 	makeInventoryWindow()
 	makePlayersWindow()
-    makeShortcutsWindow()
+	makeShortcutsWindow()
 	makeHotkeysWindow()
 	makeTriggersWindow()
 	makePluginsWindow()
@@ -245,19 +246,19 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 			return
 		}
 		r := ev.Item.DrawRect
-        options := []string{
-            "Hotkeys",
-            "Shortcuts",
-            "Triggers",
-            "Scripts",
-        }
+		options := []string{
+			"Hotkeys",
+			"Shortcuts",
+			"Triggers",
+			"Scripts",
+		}
 		eui.ShowContextMenu(options, r.X0, r.Y1, func(i int) {
 			switch i {
 			case 0:
 				hotkeysWin.ToggleNear(actionsBtn)
-            case 1:
-                refreshShortcutsList()
-                shortcutsWin.ToggleNear(actionsBtn)
+			case 1:
+				refreshShortcutsList()
+				shortcutsWin.ToggleNear(actionsBtn)
 			case 2:
 				refreshTriggersList()
 				triggersWin.ToggleNear(actionsBtn)
@@ -351,8 +352,8 @@ func makePluginsWindow() {
 	if pluginsWin != nil {
 		return
 	}
-    pluginsWin = eui.NewWindow()
-    pluginsWin.Title = "Scripts"
+	pluginsWin = eui.NewWindow()
+	pluginsWin.Title = "Scripts"
 	pluginsWin.Closable = true
 	pluginsWin.Resizable = false
 	pluginsWin.AutoSize = true
@@ -386,11 +387,11 @@ func makePluginsWindow() {
 	buttonsBottom.AddItem(refreshBtn)
 
 	openBtn, oh := eui.NewButton()
-    openBtn.Text = "Open scripts folder"
+	openBtn.Text = "Open scripts folder"
 	openBtn.Size = eui.Point{X: 160, Y: 24}
 	oh.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
-            open.Run(userScriptsDir())
+			open.Run(userScriptsDir())
 		}
 	}
 	buttonsBottom.AddItem(openBtn)
@@ -425,25 +426,25 @@ func refreshPluginsWindow() {
 	legend.AddItem(plugTxt)
 	pluginsList.AddItem(legend)
 
-    type entry struct {
-        owner   string
-        name    string
-        cat     string
-        sub     string
-        invalid bool
-    }
-    pluginMu.RLock()
-    cats := make(map[string][]entry)
-    for o, n := range pluginDisplayNames {
-        cats[pluginCategories[o]] = append(cats[pluginCategories[o]], entry{
-            owner:   o,
-            name:    n,
-            cat:     pluginCategories[o],
-            sub:     pluginSubCategories[o],
-            invalid: pluginInvalid[o],
-        })
-    }
-    pluginMu.RUnlock()
+	type entry struct {
+		owner   string
+		name    string
+		cat     string
+		sub     string
+		invalid bool
+	}
+	pluginMu.RLock()
+	cats := make(map[string][]entry)
+	for o, n := range pluginDisplayNames {
+		cats[pluginCategories[o]] = append(cats[pluginCategories[o]], entry{
+			owner:   o,
+			name:    n,
+			cat:     pluginCategories[o],
+			sub:     pluginSubCategories[o],
+			invalid: pluginInvalid[o],
+		})
+	}
+	pluginMu.RUnlock()
 	var catList []string
 	for c := range cats {
 		catList = append(catList, c)
@@ -476,56 +477,56 @@ func refreshPluginsWindow() {
 			charCB.Size = checkSize
 			allCB, allEvents := eui.NewCheckbox()
 			allCB.Size = checkSize
-            // Consider LastCharacter before login so the per-character
-            // checkbox reflects the saved preference.
-            effChar := playerName
-            if effChar == "" {
-                effChar = gs.LastCharacter
-            }
-            label := e.name
-            if e.sub != "" {
-                label += " [" + e.sub + "]"
-            }
-            owner := e.owner
-            pluginMu.RLock()
-            scope := pluginEnabledFor[owner]
-            pluginMu.RUnlock()
-            charCB.Checked = effChar != "" && scope.Chars != nil && scope.Chars[effChar]
-            charCB.Disabled = e.invalid || effChar == ""
-            allCB.Checked = scope.All
-            allCB.Disabled = e.invalid
-            click := func() { selectPlugin(owner) }
+			// Consider LastCharacter before login so the per-character
+			// checkbox reflects the saved preference.
+			effChar := playerName
+			if effChar == "" {
+				effChar = gs.LastCharacter
+			}
+			label := e.name
+			if e.sub != "" {
+				label += " [" + e.sub + "]"
+			}
+			owner := e.owner
+			pluginMu.RLock()
+			scope := pluginEnabledFor[owner]
+			pluginMu.RUnlock()
+			charCB.Checked = effChar != "" && scope.Chars != nil && scope.Chars[effChar]
+			charCB.Disabled = e.invalid || effChar == ""
+			allCB.Checked = scope.All
+			allCB.Disabled = e.invalid
+			click := func() { selectPlugin(owner) }
 			if selectedPlugin == owner {
 				row.Filled = true
 				if pluginsWin != nil && pluginsWin.Theme != nil {
 					row.Color = pluginsWin.Theme.Button.SelectedColor
 				}
 			}
-            if !e.invalid {
-                charEvents.Handle = func(ev eui.UIEvent) {
-                    if ev.Type == eui.EventCheckboxChanged {
-                        // Character/all are mutually exclusive. Prioritize the
-                        // clicked box and clear the other to reflect scope.
-                        if ev.Checked {
-                            setPluginEnabled(owner, true, false)
-                        } else {
-                            // Unchecking character when not selecting "all" disables.
-                            setPluginEnabled(owner, false, allCB.Checked)
-                        }
-                    }
-                }
-                allEvents.Handle = func(ev eui.UIEvent) {
-                    if ev.Type == eui.EventCheckboxChanged {
-                        if ev.Checked {
-                            setPluginEnabled(owner, false, true)
-                        } else {
-                            // Unchecking "All" should fully disable the plugin,
-                            // regardless of the per-character box state.
-                            clearPluginScope(owner)
-                        }
-                    }
-                }
-            }
+			if !e.invalid {
+				charEvents.Handle = func(ev eui.UIEvent) {
+					if ev.Type == eui.EventCheckboxChanged {
+						// Character/all are mutually exclusive. Prioritize the
+						// clicked box and clear the other to reflect scope.
+						if ev.Checked {
+							setPluginEnabled(owner, true, false)
+						} else {
+							// Unchecking character when not selecting "all" disables.
+							setPluginEnabled(owner, false, allCB.Checked)
+						}
+					}
+				}
+				allEvents.Handle = func(ev eui.UIEvent) {
+					if ev.Type == eui.EventCheckboxChanged {
+						if ev.Checked {
+							setPluginEnabled(owner, false, true)
+						} else {
+							// Unchecking "All" should fully disable the plugin,
+							// regardless of the per-character box state.
+							clearPluginScope(owner)
+						}
+					}
+				}
+			}
 			row.AddItem(charCB)
 			row.AddItem(allCB)
 			nameTxt, _ := eui.NewText()
@@ -629,21 +630,21 @@ func refreshPluginDetails() {
 		}
 		catLabel += sub
 	}
-    line("Category: " + catLabel)
-    line("Status: " + status)
+	line("Category: " + catLabel)
+	line("Status: " + status)
 	errText := "None"
 	if invalid {
 		errText = "Invalid plugin"
 	}
 	line("Errors: " + errText)
 
-    shortcutMu.RLock()
-    m := shortcutMaps[owner]
-    shortcutMu.RUnlock()
-    if len(m) == 0 {
-        line("Shortcuts: none")
-    } else {
-        line("Shortcuts:")
+	shortcutMu.RLock()
+	m := shortcutMaps[owner]
+	shortcutMu.RUnlock()
+	if len(m) == 0 {
+		line("Shortcuts: none")
+	} else {
+		line("Shortcuts:")
 		type pair struct{ short, full string }
 		var list []pair
 		for k, v := range m {
@@ -1943,7 +1944,7 @@ func makeLoginWindow() {
 		}
 	}
 
-	verFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Size: eui.Point{X: 200, Y: 24}}
+	verFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Size: eui.Point{X: 260, Y: 24}}
 	verLabel, _ := eui.NewText()
 	verLabel.Text = fmt.Sprintf("goThoom test %4d", appVersion)
 	verLabel.FontSize = 13
@@ -1963,6 +1964,17 @@ func makeLoginWindow() {
 		}
 	}
 	verFlow.AddItem(changeBtn)
+
+	aboutBtn, aboutEvents := eui.NewButton()
+	aboutBtn.Text = "About"
+	aboutBtn.Size = eui.Point{X: 60, Y: 24}
+	aboutBtn.FontSize = 10
+	aboutEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			openAboutWindow(ev.Item)
+		}
+	}
+	verFlow.AddItem(aboutBtn)
 
 	loginFlow.AddItem(connBtn)
 	loginFlow.AddItem(demoBtn)
@@ -2608,34 +2620,34 @@ func makeSettingsWindow() {
 	}
 	right.AddItem(bubbleOpSlider)
 
-    bubbleBaseLifeSlider, bubbleBaseLifeEvents := eui.NewSlider()
-    bubbleBaseLifeSlider.Label = "Base Bubble Life (s)"
-    bubbleBaseLifeSlider.MinValue = 1
-    bubbleBaseLifeSlider.MaxValue = 5
-    bubbleBaseLifeSlider.Value = float32(gs.BubbleBaseLife)
-    bubbleBaseLifeSlider.Size = eui.Point{X: panelWidth - 10, Y: 24}
-    bubbleBaseLifeEvents.Handle = func(ev eui.UIEvent) {
-        if ev.Type == eui.EventSliderChanged {
-            gs.BubbleBaseLife = float64(ev.Value)
-            settingsDirty = true
-        }
-    }
-    right.AddItem(bubbleBaseLifeSlider)
+	bubbleBaseLifeSlider, bubbleBaseLifeEvents := eui.NewSlider()
+	bubbleBaseLifeSlider.Label = "Base Bubble Life (s)"
+	bubbleBaseLifeSlider.MinValue = 1
+	bubbleBaseLifeSlider.MaxValue = 5
+	bubbleBaseLifeSlider.Value = float32(gs.BubbleBaseLife)
+	bubbleBaseLifeSlider.Size = eui.Point{X: panelWidth - 10, Y: 24}
+	bubbleBaseLifeEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.BubbleBaseLife = float64(ev.Value)
+			settingsDirty = true
+		}
+	}
+	right.AddItem(bubbleBaseLifeSlider)
 
-    // Life added per word in a bubble
-    bubblePerWordSlider, bubblePerWordEvents := eui.NewSlider()
-    bubblePerWordSlider.Label = "Bubble Life per Word (s)"
-    bubblePerWordSlider.MinValue = 0
-    bubblePerWordSlider.MaxValue = 2
-    bubblePerWordSlider.Value = float32(gs.BubbleLifePerWord)
-    bubblePerWordSlider.Size = eui.Point{X: panelWidth - 10, Y: 24}
-    bubblePerWordEvents.Handle = func(ev eui.UIEvent) {
-        if ev.Type == eui.EventSliderChanged {
-            gs.BubbleLifePerWord = float64(ev.Value)
-            settingsDirty = true
-        }
-    }
-    right.AddItem(bubblePerWordSlider)
+	// Life added per word in a bubble
+	bubblePerWordSlider, bubblePerWordEvents := eui.NewSlider()
+	bubblePerWordSlider.Label = "Bubble Life per Word (s)"
+	bubblePerWordSlider.MinValue = 0
+	bubblePerWordSlider.MaxValue = 2
+	bubblePerWordSlider.Value = float32(gs.BubbleLifePerWord)
+	bubblePerWordSlider.Size = eui.Point{X: panelWidth - 10, Y: 24}
+	bubblePerWordEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.BubbleLifePerWord = float64(ev.Value)
+			settingsDirty = true
+		}
+	}
+	right.AddItem(bubblePerWordSlider)
 
 	fadePicsCB, fadePicsEvents := eui.NewCheckbox()
 	fadePicsCB.Text = "Fade objects obscuring mobiles"


### PR DESCRIPTION
## Summary
- add About window accessible from login screen
- show project license and third-party attributions
- reformat ATTRIBUTE.md into bullet lists

## Testing
- `go vet ./...` *(fails: unkeyed fields in labels.go, lock copy in tests)*
- `golangci-lint run` *(fails: Go version 1.24 < target 1.25)*
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68b56697f07c832a941891b11a3bf558