### PR TITLE
Remove redundant stopRecording function

### DIFF
--- a/movie_recorder.go
+++ b/movie_recorder.go
@@ -128,17 +128,3 @@ func (m *movieRecorder) Close() error {
 	m.f = nil
 	return err
 }
-
-func stopRecording() {
-	if recorder == nil {
-		return
-	}
-	if err := recorder.Close(); err != nil {
-		logError("stop recording: %v", err)
-	}
-	recorder = nil
-	wroteLoginBlocks = false
-	if recordStatus != nil {
-		recordStatus.Text = ""
-	}
-}


### PR DESCRIPTION
## Summary
- remove duplicate stopRecording helper from movie_recorder.go to resolve compile-time redeclaration

## Testing
- `golangci-lint run` (fails: assignment mismatch in inventory_error_test.go)
- `go vet ./...` (fails: assignment mismatch in inventory_error_test.go)
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68b5729c7d08832abe247118d5cbfc6c