### PR TITLE
Add WriteBlock to movie recorder

### DIFF
--- a/game.go
+++ b/game.go
@@ -2577,13 +2577,19 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 			if !wroteLoginBlocks {
 				if tag == 2 { // first draw state
 					if len(loginGameState) > 0 {
-						recorder.AddBlock(gameStateBlock(loginGameState), flagGameState)
+						if err := recorder.WriteBlock(gameStateBlock(loginGameState), flagGameState); err != nil {
+							logError("record block: %v", err)
+						}
 					}
 					if len(loginMobileData) > 0 {
-						recorder.AddBlock(loginMobileData, flagMobileData)
+						if err := recorder.WriteBlock(loginMobileData, flagMobileData); err != nil {
+							logError("record block: %v", err)
+						}
 					}
 					if len(loginPictureTable) > 0 {
-						recorder.AddBlock(loginPictureTable, flagPictureTable)
+						if err := recorder.WriteBlock(loginPictureTable, flagPictureTable); err != nil {
+							logError("record block: %v", err)
+						}
 					}
 					wroteLoginBlocks = true
 					if err := recorder.WriteFrame(m, flags); err != nil {
@@ -2659,13 +2665,19 @@ loop:
 			if !wroteLoginBlocks {
 				if tag == 2 { // first draw state
 					if len(loginGameState) > 0 {
-						recorder.AddBlock(gameStateBlock(loginGameState), flagGameState)
+						if err := recorder.WriteBlock(gameStateBlock(loginGameState), flagGameState); err != nil {
+							logError("record block: %v", err)
+						}
 					}
 					if len(loginMobileData) > 0 {
-						recorder.AddBlock(loginMobileData, flagMobileData)
+						if err := recorder.WriteBlock(loginMobileData, flagMobileData); err != nil {
+							logError("record block: %v", err)
+						}
 					}
 					if len(loginPictureTable) > 0 {
-						recorder.AddBlock(loginPictureTable, flagPictureTable)
+						if err := recorder.WriteBlock(loginPictureTable, flagPictureTable); err != nil {
+							logError("record block: %v", err)
+						}
 					}
 					wroteLoginBlocks = true
 					if err := recorder.WriteFrame(m, flags); err != nil {

--- a/movie_recorder.go
+++ b/movie_recorder.go
@@ -24,10 +24,8 @@ type frameHead struct {
 }
 
 type movieRecorder struct {
-	f        *os.File
-	head     fileHead
-	preFlags uint16
-	preData  []byte
+	f    *os.File
+	head fileHead
 }
 
 const macEpochDelta = 2082844800
@@ -70,14 +68,6 @@ func (m *movieRecorder) writeHeader() error {
 	return err
 }
 
-func (m *movieRecorder) AddBlock(data []byte, flag uint16) {
-	if len(data) == 0 {
-		return
-	}
-	m.preData = append(m.preData, data...)
-	m.preFlags |= flag
-}
-
 func gameStateBlock(payload []byte) []byte {
 	buf := make([]byte, 24+len(payload))
 	binary.BigEndian.PutUint32(buf[12:], uint32(len(payload)))
@@ -93,7 +83,7 @@ func (m *movieRecorder) WriteFrame(data []byte, flags uint16) error {
 		Signature: movieSignature,
 		Frame:     m.head.Frames,
 		Size:      uint16(len(data)),
-		Flags:     flags | m.preFlags,
+		Flags:     flags,
 	}
 	m.head.Frames++
 	buf := make([]byte, 12)
@@ -104,12 +94,31 @@ func (m *movieRecorder) WriteFrame(data []byte, flags uint16) error {
 	if _, err := m.f.Write(buf); err != nil {
 		return err
 	}
-	if len(m.preData) > 0 {
-		if _, err := m.f.Write(m.preData); err != nil {
-			return err
-		}
-		m.preData = nil
-		m.preFlags = 0
+	_, err := m.f.Write(data)
+	return err
+}
+
+func (m *movieRecorder) WriteBlock(data []byte, flag uint16) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if m.f == nil {
+		return os.ErrClosed
+	}
+	fh := frameHead{
+		Signature: movieSignature,
+		Frame:     m.head.Frames,
+		Size:      0,
+		Flags:     flag,
+	}
+	m.head.Frames++
+	buf := make([]byte, 12)
+	binary.BigEndian.PutUint32(buf[0:], fh.Signature)
+	binary.BigEndian.PutUint32(buf[4:], uint32(fh.Frame))
+	binary.BigEndian.PutUint16(buf[8:], fh.Size)
+	binary.BigEndian.PutUint16(buf[10:], fh.Flags)
+	if _, err := m.f.Write(buf); err != nil {
+		return err
 	}
 	_, err := m.f.Write(data)
 	return err


### PR DESCRIPTION
## Summary
- support standalone login blocks with new `WriteBlock`
- simplify frame writing and remove pre-frame buffer logic
- record login blocks sequentially before first draw frame

## Testing
- `sudo apt-get install -y ./apt/*.deb` *(fails: Unable to correct problems, you have held broken packages)*
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa' not found)*
- `go build` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b57d8ca04c832a9d7785bafe02adeb