### PR TITLE
Ensure WASD stop persists until network send

### DIFF
--- a/game.go
+++ b/game.go
@@ -998,16 +998,6 @@ func (g *Game) Update() error {
 
 	updateHotkeyRecording()
 	checkHotkeys()
-	if keyStopFrames > 0 {
-		if keyWalk {
-			keyStopFrames = 0
-		} else {
-			inputMu.Lock()
-			latestInput = inputState{mouseX: 0, mouseY: 0, mouseDown: true}
-			inputMu.Unlock()
-			keyStopFrames--
-		}
-	}
 
 	return nil
 }
@@ -2529,6 +2519,10 @@ func sendInputLoop(ctx context.Context, udpConn, tcpConn net.Conn) {
 		}
 		inputMu.Lock()
 		s := latestInput
+		if keyStopFrames > 0 {
+			s = inputState{mouseX: 0, mouseY: 0, mouseDown: true}
+			keyStopFrames--
+		}
 		inputMu.Unlock()
 
 		reliable := false


### PR DESCRIPTION
## Summary
- move stop-frame handling from frame updates to network send loop to preserve WASD stop

## Testing
- `golangci-lint run` *(fails: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25))*
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa', required by 'virtual:world', not found)*
- `go build` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b57d8446a0832a8d99bd9bcfb6a5cc