### PR TITLE
Capture clmov flags and add roundtrip test

### DIFF
--- a/movie.go
+++ b/movie.go
@@ -22,8 +22,10 @@ var gameFrame int
 var movieRevision int32
 
 type movieFrame struct {
-	data  []byte
-	index int32
+	data    []byte
+	index   int32
+	flags   uint16
+	preData []byte
 }
 
 func parseMovie(path string, clientVersion int) ([]movieFrame, error) {
@@ -74,10 +76,9 @@ func parseMovie(path string, clientVersion int) ([]movieFrame, error) {
 		lastFrame = frame
 		size := int(binary.BigEndian.Uint16(data[pos+8 : pos+10]))
 		flags := binary.BigEndian.Uint16(data[pos+10 : pos+12])
-		//logDebug("frame %d index=%d size=%d flags=0x%x", frameNum, frame, size, flags)
 		pos += 12
+		preStart := pos
 		if flags&flagGameState != 0 {
-			//logDebug("GameState block at %d", pos)
 			if pos+24 > len(data) {
 				break
 			}
@@ -91,11 +92,9 @@ func parseMovie(path string, clientVersion int) ([]movieFrame, error) {
 			pos = end
 		}
 		if flags&flagMobileData != 0 {
-			//logDebug("MobileData table at %d", pos)
 			pos = parseMobileTable(data, pos, version, revision)
 		}
 		if flags&flagPictureTable != 0 {
-			//logDebug("PictureTable at %d", pos)
 			if pos+2 > len(data) {
 				break
 			}
@@ -117,17 +116,18 @@ func parseMovie(path string, clientVersion int) ([]movieFrame, error) {
 				pos += 4
 			}
 			stateMu.Lock()
-			// Preserve on-disk ordering for pictAgain semantics.
 			state.pictures = pics
 			stateMu.Unlock()
 		}
+		preData := append([]byte(nil), data[preStart:pos]...)
 		if size > 0 {
 			if pos+size > len(data) {
 				break
 			}
-			frames = append(frames, movieFrame{data: append([]byte(nil), data[pos:pos+size]...), index: frame})
+			frames = append(frames, movieFrame{data: append([]byte(nil), data[pos:pos+size]...), index: frame, flags: flags, preData: preData})
 			pos += size
 		} else {
+			frames = append(frames, movieFrame{index: frame, flags: flags, preData: preData})
 			idx := bytes.Index(data[pos:], sign)
 			if idx < 0 {
 				break

--- a/movie_recorder_test.go
+++ b/movie_recorder_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRecordRoundTrip(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	moviePath := filepath.Join(filepath.Dir(file), "clmovFiles", "test.clMov")
+	orig, err := os.ReadFile(moviePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(orig) < 24 {
+		t.Fatalf("short file")
+	}
+	head := fileHead{
+		Signature:    binary.BigEndian.Uint32(orig[0:4]),
+		Version:      binary.BigEndian.Uint16(orig[4:6]),
+		Len:          binary.BigEndian.Uint16(orig[6:8]),
+		Frames:       int32(binary.BigEndian.Uint32(orig[8:12])),
+		StartTime:    binary.BigEndian.Uint32(orig[12:16]),
+		Revision:     int32(binary.BigEndian.Uint32(orig[16:20])),
+		OldestReader: int32(binary.BigEndian.Uint32(orig[20:24])),
+	}
+	frames, err := parseMovie(moviePath, 0)
+	if err != nil {
+		t.Fatalf("parseMovie: %v", err)
+	}
+	tmp := filepath.Join(t.TempDir(), "roundtrip.clMov")
+	mr, err := newMovieRecorder(tmp, int(head.Version), int(head.Revision))
+	if err != nil {
+		t.Fatalf("newMovieRecorder: %v", err)
+	}
+	mr.head.StartTime = head.StartTime
+	mr.head.OldestReader = head.OldestReader
+	if err := mr.writeHeader(); err != nil {
+		t.Fatalf("writeHeader: %v", err)
+	}
+	const blockFlags = flagGameState | flagMobileData | flagPictureTable
+	for _, fr := range frames {
+		if len(fr.data) == 0 {
+			if err := mr.WriteBlock(fr.preData, fr.flags); err != nil {
+				t.Fatalf("WriteBlock: %v", err)
+			}
+			continue
+		}
+		if len(fr.preData) > 0 {
+			mr.AddBlock(fr.preData, fr.flags&blockFlags)
+		}
+		if err := mr.WriteFrame(fr.data, fr.flags&^blockFlags); err != nil {
+			t.Fatalf("WriteFrame: %v", err)
+		}
+	}
+	if err := mr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	rec, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("ReadFile(tmp): %v", err)
+	}
+	if !bytes.Equal(orig, rec) {
+		t.Fatalf("recording mismatch: %d vs %d bytes", len(orig), len(rec))
+	}
+}


### PR DESCRIPTION
## Summary
- Retain frame flags and pre-block bytes when parsing `.clMov` movies
- Add regression test to re-record a known movie and compare bytes for round-trip fidelity

## Testing
- `go vet .` *(fails: inventory_error_test.go:11:12: assignment mismatch: 1 variable but parseDrawState returns 3 values)*
- `go build`
- `go test` *(fails: inventory_error_test.go:11:12: assignment mismatch: 1 variable but parseDrawState returns 3 values)*

------
https://chatgpt.com/codex/tasks/task_e_68b58bc7d618832a96c21edddf71ff92