### PR TITLE
Avoid logging network drop errors and recover panics

### DIFF
--- a/game.go
+++ b/game.go
@@ -2503,6 +2503,11 @@ func noteFrame() {
 }
 
 func sendInputLoop(ctx context.Context, udpConn, tcpConn net.Conn) {
+	defer func() {
+		if r := recover(); r != nil {
+			logPanic(r)
+		}
+	}()
 	// nextReliable determines when to send the next keep-alive packet via
 	// the reliable channel to preserve NAT mappings.
 	var nextReliable time.Time
@@ -2541,15 +2546,19 @@ func sendInputLoop(ctx context.Context, udpConn, tcpConn net.Conn) {
 			err = sendPlayerInput(udpConn, s.mouseX, s.mouseY, s.mouseDown, false)
 		}
 		if err != nil {
-			logError("send player input: %v", err)
+			// ignore errors from dead connections
 		}
 	}
 }
 
 func udpReadLoop(ctx context.Context, conn net.Conn) {
+	defer func() {
+		if r := recover(); r != nil {
+			logPanic(r)
+		}
+	}()
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-			logError("udp deadline: %v", err)
 			return
 		}
 		m, err := readUDPMessage(conn)
@@ -2562,7 +2571,6 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 					continue
 				}
 			}
-			logError("udp read error: %v", err)
 			handleDisconnect()
 			return
 		}
@@ -2633,10 +2641,14 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 }
 
 func tcpReadLoop(ctx context.Context, conn net.Conn) {
+	defer func() {
+		if r := recover(); r != nil {
+			logPanic(r)
+		}
+	}()
 loop:
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-			logError("set read deadline: %v", err)
 			break
 		}
 		m, err := readTCPMessage(conn)
@@ -2649,7 +2661,6 @@ loop:
 					continue
 				}
 			}
-			logError("read error: %v", err)
 			handleDisconnect()
 			break
 		}

--- a/network.go
+++ b/network.go
@@ -57,11 +57,9 @@ func sendTCPMessage(connection net.Conn, payload []byte) error {
 	var size [2]byte
 	binary.BigEndian.PutUint16(size[:], uint16(len(payload)))
 	if err := writeAll(connection, size[:]); err != nil {
-		logError("send tcp size: %v", err)
 		return err
 	}
 	if err := writeAll(connection, payload); err != nil {
-		logError("send tcp payload: %v", err)
 		return err
 	}
 	tag := binary.BigEndian.Uint16(payload[:2])
@@ -76,7 +74,6 @@ func sendUDPMessage(connection net.Conn, payload []byte) error {
 	binary.BigEndian.PutUint16(size[:], uint16(len(payload)))
 	buf := append(size[:], payload...)
 	if err := writeAll(connection, buf); err != nil {
-		logError("send udp payload: %v", err)
 		return err
 	}
 	tag := binary.BigEndian.Uint16(payload[:2])
@@ -194,7 +191,6 @@ func readTCPMessage(connection net.Conn) ([]byte, error) {
 	sz := binary.BigEndian.Uint16(sizeBuf[:])
 	buf := make([]byte, sz)
 	if _, err := io.ReadFull(connection, buf); err != nil {
-		logError("read tcp payload: %v", err)
 		return nil, err
 	}
 	tag := binary.BigEndian.Uint16(buf[:2])


### PR DESCRIPTION
## Summary
- stop logging send/read failures when network connection dies
- wrap network goroutines with recover and panic logging

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package alsa not found)*
- `go build ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package alsa not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58cec6164832a8665055e6e4e1403