### PR TITLE
Decouple BeWho tracking from general presence

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -66,29 +66,28 @@ func parseBackendInfo(data []byte) {
 	p.Race = race
 	p.Gender = gender
 	p.Class = class
-	p.Clan = clan
+	p.clan = clan
 	p.LastSeen = time.Now()
 	p.Offline = false
-	bwChanged := !p.BeWho
-	p.BeWho = true
+	p.Seen = true
 	changedNames := make([]string, 0, 1)
 	if playerName != "" {
-        if name == playerName {
-            myClan := clan
-            for _, pl := range players {
-                sc := sameRealClan(pl.Clan, myClan)
-                if pl.SameClan != sc {
-                    pl.SameClan = sc
-                    changedNames = append(changedNames, pl.Name)
-                }
-            }
-        } else if me, ok := players[playerName]; ok {
-            sc := sameRealClan(me.Clan, p.Clan)
-            if p.SameClan != sc {
-                p.SameClan = sc
-                changedNames = append(changedNames, p.Name)
-            }
-        }
+		if name == playerName {
+			myClan := clan
+			for _, pl := range players {
+				sc := sameRealClan(pl.clan, myClan)
+				if pl.SameClan != sc {
+					pl.SameClan = sc
+					changedNames = append(changedNames, pl.Name)
+				}
+			}
+		} else if me, ok := players[playerName]; ok {
+			sc := sameRealClan(me.clan, p.clan)
+			if p.SameClan != sc {
+				p.SameClan = sc
+				changedNames = append(changedNames, p.Name)
+			}
+		}
 	}
 	playerCopy := *p
 	playersMu.Unlock()
@@ -97,9 +96,6 @@ func parseBackendInfo(data []byte) {
 	notifyPlayerHandlers(playerCopy)
 	for _, nm := range changedNames {
 		killNameTagCacheFor(nm)
-	}
-	if bwChanged {
-		playersPersistDirty = true
 	}
 
 	if playerName != "" && strings.EqualFold(name, playerName) {
@@ -145,15 +141,15 @@ func parseBackendShare(data []byte) {
 			players[name] = p
 		}
 		changed := !p.Sharee
-		bwChanged := !p.BeWho
-        if me, ok := players[playerName]; ok {
-            sc := sameRealClan(me.Clan, p.Clan)
-            if p.SameClan != sc {
-                p.SameClan = sc
-                changed = true
-            }
-        }
-		p.BeWho = true
+		seenChanged := !p.Seen
+		if me, ok := players[playerName]; ok {
+			sc := sameRealClan(me.clan, p.clan)
+			if p.SameClan != sc {
+				p.SameClan = sc
+				changed = true
+			}
+		}
+		p.Seen = true
 		p.Sharee = true
 		p.LastSeen = time.Now()
 		playerCopy := *p
@@ -161,7 +157,7 @@ func parseBackendShare(data []byte) {
 		if changed {
 			killNameTagCacheFor(name)
 		}
-		if bwChanged {
+		if seenChanged {
 			playersPersistDirty = true
 		}
 		notifyPlayerHandlers(playerCopy)
@@ -174,15 +170,15 @@ func parseBackendShare(data []byte) {
 			players[name] = p
 		}
 		changed := !p.Sharing
-		bwChanged := !p.BeWho
-        if me, ok := players[playerName]; ok {
-            sc := sameRealClan(me.Clan, p.Clan)
-            if p.SameClan != sc {
-                p.SameClan = sc
-                changed = true
-            }
-        }
-		p.BeWho = true
+		seenChanged := !p.Seen
+		if me, ok := players[playerName]; ok {
+			sc := sameRealClan(me.clan, p.clan)
+			if p.SameClan != sc {
+				p.SameClan = sc
+				changed = true
+			}
+		}
+		p.Seen = true
 		p.Sharing = true
 		p.LastSeen = time.Now()
 		playerCopy := *p
@@ -190,7 +186,7 @@ func parseBackendShare(data []byte) {
 		if changed {
 			killNameTagCacheFor(name)
 		}
-		if bwChanged {
+		if seenChanged {
 			playersPersistDirty = true
 		}
 		notifyPlayerHandlers(playerCopy)
@@ -240,27 +236,29 @@ func parseBackendWho(data []byte) {
 			newCount++
 		}
 		if gm >= 0 {
-			p.GMLevel = gm
+			p.gmLevel = gm
 		}
 		p.LastSeen = time.Now()
 		p.Offline = false
-		bwChanged := !p.BeWho
+		bwChanged := !p.beWho
+		seenChanged := !p.Seen
 		scChanged := false
-        if me, ok := players[playerName]; ok {
-            sc := sameRealClan(me.Clan, p.Clan)
-            if p.SameClan != sc {
-                p.SameClan = sc
-                scChanged = true
-            }
-        }
-		p.BeWho = true
+		if me, ok := players[playerName]; ok {
+			sc := sameRealClan(me.clan, p.clan)
+			if p.SameClan != sc {
+				p.SameClan = sc
+				scChanged = true
+			}
+		}
+		p.beWho = true
+		p.Seen = true
 		playerCopy := *p
 		playersMu.Unlock()
 		notifyPlayerHandlers(playerCopy)
 		if scChanged {
 			killNameTagCacheFor(name)
 		}
-		if bwChanged {
+		if bwChanged || seenChanged {
 			playersPersistDirty = true
 		}
 		queueInfoRequest(name)

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -8,11 +8,11 @@
 // into the Yaegi interpreter by the client at runtime.
 //
 // Notes
-// - These stubs are never called by the compiled client binary.
-// - Keep names and signatures in sync with the runtime export table in
-//   plugin.go (search for exportsForPlugin).
-// - This package is intentionally tiny: it has zero dependencies and
-//   returns zero values.
+//   - These stubs are never called by the compiled client binary.
+//   - Keep names and signatures in sync with the runtime export table in
+//     plugin.go (search for exportsForPlugin).
+//   - This package is intentionally tiny: it has zero dependencies and
+//     returns zero values.
 package gt
 
 import "time"
@@ -134,13 +134,11 @@ type Player struct {
 	Race       string
 	Gender     string
 	Class      string
-	Clan       string
 	PictID     uint16
 	Colors     []byte
 	IsNPC      bool
 	Sharee     bool
 	Sharing    bool
-	GMLevel    int
 	Friend     bool
 	Blocked    bool
 	Ignored    bool
@@ -150,7 +148,7 @@ type Player struct {
 	KillerName string
 	Bard       bool
 	SameClan   bool
-	BeWho      bool
+	Seen       bool
 	LastSeen   time.Time
 	Offline    bool
 }

--- a/info_queue.go
+++ b/info_queue.go
@@ -24,7 +24,7 @@ func queueInfoRequest(name string) {
 	p, ok := players[name]
 	playersMu.RUnlock()
 	if ok {
-		if p.Class != "" && p.Gender != "" && p.Race != "" && p.Clan != "" {
+		if p.Class != "" && p.Gender != "" && p.Race != "" && p.clan != "" {
 			return // no need
 		}
 	}

--- a/player.go
+++ b/player.go
@@ -13,13 +13,13 @@ type Player struct {
 	Race        string
 	Gender      string
 	Class       string
-	Clan        string
+	clan        string
 	PictID      uint16
 	Colors      []byte
 	IsNPC       bool // entry represents an NPC
 	Sharee      bool // we are sharing to this player
 	Sharing     bool // player is sharing to us
-	GMLevel     int  // parsed from be-who; not rendered
+	gmLevel     int  // parsed from be-who; not rendered
 	Friend      bool // marked as friend
 	FriendLabel int  // effective label/color (0-7)
 	LocalLabel  int  // character-specific label
@@ -32,7 +32,8 @@ type Player struct {
 	KillerName  string
 	Bard        bool // true if player is in the Bards' Guild
 	SameClan    bool // true if player is in our clan
-	BeWho       bool // true if player has been enumerated
+	beWho       bool // true if player has been enumerated via /be-who
+	Seen        bool // true if player has been observed
 	// Presence tracking
 	LastSeen time.Time // last time we observed any activity/info for this player
 	Offline  bool      // explicitly observed as offline/logged off
@@ -87,16 +88,16 @@ func updatePlayerAppearance(name string, pictID uint16, colors []byte, isNPC boo
 	// Seeing a player on screen implies they are present now.
 	p.LastSeen = time.Now()
 	p.Offline = false
-	bwChanged := !p.BeWho
-	p.BeWho = true
-    prevSC := p.SameClan
-    if me, ok := players[playerName]; ok {
-        p.SameClan = sameRealClan(me.Clan, p.Clan)
-    }
+	seenChanged := !p.Seen
+	p.Seen = true
+	prevSC := p.SameClan
+	if me, ok := players[playerName]; ok {
+		p.SameClan = sameRealClan(me.clan, p.clan)
+	}
 	playerCopy := *p
 	playersMu.Unlock()
 	playersDirty = true
-	if bwChanged || prevSC != p.SameClan {
+	if seenChanged || prevSC != p.SameClan {
 		playersPersistDirty = true
 	}
 	if prevSC != p.SameClan {

--- a/players_persist.go
+++ b/players_persist.go
@@ -28,6 +28,7 @@ type persistPlayer struct {
 	Bard        bool   `json:"bard,omitempty"`
 	SameClan    bool   `json:"same_clan,omitempty"`
 	BeWho       bool   `json:"bewho,omitempty"`
+	Seen        bool   `json:"seen,omitempty"`
 	ColorsHex   string `json:"colors,omitempty"` // hex of [count][colors...]
 	FellWhere   string `json:"fell_where,omitempty"`
 	FellTime    int64  `json:"fell_time,omitempty"`
@@ -70,7 +71,7 @@ func loadPlayersPersist() {
 		playersMu.Lock()
 		pr.Gender = p.Gender
 		pr.Class = p.Class
-		pr.Clan = p.Clan
+		pr.Clan = p.clan
 		pr.PictID = p.PictID
 		// Decode ColorsHex: optional hex of [count][bytes]
 		if p.ColorsHex != "" {
@@ -85,12 +86,13 @@ func loadPlayersPersist() {
 			}
 		}
 		pr.Dead = p.Dead
-		pr.GMLevel = p.GMLevel
+		pr.GMLevel = p.gmLevel
 		pr.GlobalLabel = p.GlobalLabel
 		applyPlayerLabel(pr)
 		pr.Bard = p.Bard
 		pr.SameClan = p.SameClan
-		pr.BeWho = p.BeWho
+		pr.BeWho = p.beWho
+		pr.Seen = p.Seen
 		pr.FellWhere = p.FellWhere
 		if p.FellTime != 0 {
 			pr.FellTime = time.Unix(p.FellTime, 0)
@@ -152,17 +154,18 @@ func savePlayersPersist() {
 			Name:        p.Name,
 			Gender:      p.Gender,
 			Class:       p.Class,
-			Clan:        p.Clan,
+			Clan:        p.clan,
 			PictID:      p.PictID,
 			Dead:        p.Dead,
-			GMLevel:     p.GMLevel,
+			GMLevel:     p.gmLevel,
 			Friend:      friend,
 			GlobalLabel: p.GlobalLabel,
 			Blocked:     blocked,
 			Ignored:     ignored,
 			Bard:        p.Bard,
 			SameClan:    p.SameClan,
-			BeWho:       p.BeWho,
+			BeWho:       p.beWho,
+			Seen:        p.Seen,
 			ColorsHex:   hex,
 			FellWhere:   p.FellWhere,
 			FellTime:    ft,

--- a/players_ui.go
+++ b/players_ui.go
@@ -95,7 +95,7 @@ func updatePlayersWindow() {
 	if playerName != "" {
 		playersMu.RLock()
 		if me, ok := players[playerName]; ok {
-			myClan = me.Clan
+			myClan = me.clan
 		}
 		playersMu.RUnlock()
 	}
@@ -167,7 +167,7 @@ func updatePlayersWindow() {
 		if p.Sharing {
 			tags = append(tags, ">")
 		}
-		if sameRealClan(p.Clan, myClan) {
+		if sameRealClan(p.clan, myClan) {
 			tags = append(tags, "*")
 		}
 		if len(tags) > 0 {

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -33,19 +33,19 @@ func parseWhoText(raw []byte, s string) bool {
 		p := getPlayer(name)
 		playersMu.Lock()
 		prevSC := p.SameClan
-		prevBW := p.BeWho
-        if me, ok := players[playerName]; ok {
-            p.SameClan = sameRealClan(me.Clan, p.Clan)
-        }
+		prevSeen := p.Seen
+		if me, ok := players[playerName]; ok {
+			p.SameClan = sameRealClan(me.clan, p.clan)
+		}
 		p.LastSeen = time.Now()
 		p.Offline = false
-		p.BeWho = true
+		p.Seen = true
 		playerCopy := *p
 		playersMu.Unlock()
 		if prevSC != p.SameClan {
 			killNameTagCacheFor(name)
 		}
-		if !prevBW {
+		if !prevSeen {
 			playersPersistDirty = true
 		}
 		notifyPlayerHandlers(playerCopy)
@@ -91,15 +91,15 @@ func parseShareText(raw []byte, s string) bool {
 						p.Sharee = false
 						changedPlayer = true
 					}
-                    if me, ok := players[playerName]; ok {
-                        sc := sameRealClan(me.Clan, p.Clan)
-                        if p.SameClan != sc {
-                            p.SameClan = sc
-                            changedPlayer = true
-                        }
-                    }
-					if !p.BeWho {
-						p.BeWho = true
+					if me, ok := players[playerName]; ok {
+						sc := sameRealClan(me.clan, p.clan)
+						if p.SameClan != sc {
+							p.SameClan = sc
+							changedPlayer = true
+						}
+					}
+					if !p.Seen {
+						p.Seen = true
 						playersPersistDirty = true
 					}
 					if changedPlayer {
@@ -141,15 +141,15 @@ func parseShareText(raw []byte, s string) bool {
 					p.Sharee = true
 					added = append(added, *p)
 				}
-                if me, ok := players[playerName]; ok {
-                    sc := sameRealClan(me.Clan, p.Clan)
-                    if p.SameClan != sc {
-                        p.SameClan = sc
-                        added = append(added, *p)
-                    }
-                }
-				if !p.BeWho {
-					p.BeWho = true
+				if me, ok := players[playerName]; ok {
+					sc := sameRealClan(me.clan, p.clan)
+					if p.SameClan != sc {
+						p.SameClan = sc
+						added = append(added, *p)
+					}
+				}
+				if !p.Seen {
+					p.Seen = true
 					playersPersistDirty = true
 				}
 			}
@@ -201,15 +201,15 @@ func parseShareText(raw []byte, s string) bool {
 				p.Sharee = true
 				changed = true
 			}
-            if me, ok := players[playerName]; ok {
-                sc := sameRealClan(me.Clan, p.Clan)
-                if p.SameClan != sc {
-                    p.SameClan = sc
-                    changed = true
-                }
-            }
-			if !p.BeWho {
-				p.BeWho = true
+			if me, ok := players[playerName]; ok {
+				sc := sameRealClan(me.clan, p.clan)
+				if p.SameClan != sc {
+					p.SameClan = sc
+					changed = true
+				}
+			}
+			if !p.Seen {
+				p.Seen = true
 				playersPersistDirty = true
 			}
 			if changed {
@@ -243,15 +243,15 @@ func parseShareText(raw []byte, s string) bool {
 					p.Sharee = false
 					changedPlayer = true
 				}
-                if me, ok := players[playerName]; ok {
-                    sc := sameRealClan(me.Clan, p.Clan)
-                    if p.SameClan != sc {
-                        p.SameClan = sc
-                        changedPlayer = true
-                    }
-                }
-				if !p.BeWho {
-					p.BeWho = true
+				if me, ok := players[playerName]; ok {
+					sc := sameRealClan(me.clan, p.clan)
+					if p.SameClan != sc {
+						p.SameClan = sc
+						changedPlayer = true
+					}
+				}
+				if !p.Seen {
+					p.Seen = true
 					playersPersistDirty = true
 				}
 				if changedPlayer {
@@ -323,14 +323,14 @@ func parseShareText(raw []byte, s string) bool {
 					changedPlayer = true
 				}
 				if me, ok := players[playerName]; ok {
-					sc := me.Clan != "" && p.Clan != "" && strings.EqualFold(p.Clan, me.Clan)
+					sc := me.clan != "" && p.clan != "" && strings.EqualFold(p.clan, me.clan)
 					if p.SameClan != sc {
 						p.SameClan = sc
 						changedPlayer = true
 					}
 				}
-				if !p.BeWho {
-					p.BeWho = true
+				if !p.Seen {
+					p.Seen = true
 					playersPersistDirty = true
 				}
 				if changedPlayer {
@@ -543,15 +543,15 @@ func parseBardText(raw []byte, s string) bool {
 		s = strings.TrimSpace(s[2:])
 	}
 
-    // Prefer explicit BEPP tags for music, but also allow permissive detection
-    // since some servers/messages may omit the tag yet include a "/music/..."
-    // payload or a leading "play" form.
-    hasMu := bytes.Contains(raw, []byte{0xC2, 'm', 'u'}) || bytes.Contains(raw, []byte{0xC2, 'b', 'a'})
-    if hasMu || strings.Contains(s, "/music/") || strings.HasPrefix(s, "play ") || strings.HasPrefix(s, "play/") {
-        if parseMusicCommand(s, raw) {
-            return true
-        }
-    }
+	// Prefer explicit BEPP tags for music, but also allow permissive detection
+	// since some servers/messages may omit the tag yet include a "/music/..."
+	// payload or a leading "play" form.
+	hasMu := bytes.Contains(raw, []byte{0xC2, 'm', 'u'}) || bytes.Contains(raw, []byte{0xC2, 'b', 'a'})
+	if hasMu || strings.Contains(s, "/music/") || strings.HasPrefix(s, "play ") || strings.HasPrefix(s, "play/") {
+		if parseMusicCommand(s, raw) {
+			return true
+		}
+	}
 
 	phrases := []struct {
 		suffix string
@@ -773,24 +773,24 @@ func parseMusicCommand(s string, raw []byte) bool {
 // classic client uses a special "/m_interrupt" directive for this purpose.
 // Returns true if handled and output should be suppressed.
 func parseInterruptCommand(s string) bool {
-    ss := strings.TrimSpace(s)
-    if ss == "" {
-        return false
-    }
-    // Normalize common leading markers that may prefix system lines.
-    if strings.HasPrefix(ss, "* ") {
-        ss = strings.TrimSpace(ss[2:])
-    }
-    if strings.HasPrefix(ss, "¥ ") {
-        ss = strings.TrimSpace(ss[2:])
-    }
-    // Only act on a standalone interrupt directive, not arbitrary substrings.
-    if ss == "/m_interrupt" || strings.HasPrefix(ss, "/m_interrupt ") {
-        stopAllMusic()
-        clearTuneQueue()
-        return true
-    }
-    return false
+	ss := strings.TrimSpace(s)
+	if ss == "" {
+		return false
+	}
+	// Normalize common leading markers that may prefix system lines.
+	if strings.HasPrefix(ss, "* ") {
+		ss = strings.TrimSpace(ss[2:])
+	}
+	if strings.HasPrefix(ss, "¥ ") {
+		ss = strings.TrimSpace(ss[2:])
+	}
+	// Only act on a standalone interrupt directive, not arbitrary substrings.
+	if ss == "/m_interrupt" || strings.HasPrefix(ss, "/m_interrupt ") {
+		stopAllMusic()
+		clearTuneQueue()
+		return true
+	}
+	return false
 }
 
 // truncate helps keep debug output short


### PR DESCRIPTION
## Summary
- separate observed state from /be-who enumeration using new `Seen` flag
- avoid setting `BeWho` in share/who parsing and backend info/share handlers
- persist and expose the new `Seen` field
- stop exporting `Clan`, `GMLevel`, and `BeWho` to plugins

## Testing
- `go test ./...` *(fails: missing modules and Go version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b58e524424832aac51f6230f2c00b1