### PR TITLE
Refresh inventory and players icons after CL_Images load

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1655,6 +1655,11 @@ func makeDownloadsWindow() {
 				img.DenoiseSharpness = gs.DenoiseSharpness
 				img.DenoiseAmount = gs.DenoiseAmount
 				clImages = img
+				// Refresh windows that depend on CL_Images now that
+				// the archive is available so icons appear without
+				// requiring a manual resize.
+				inventoryDirty = true
+				playersDirty = true
 			}
 
 			clSounds, err = clsnd.Load(filepath.Join("data/CL_Sounds"))


### PR DESCRIPTION
## Summary
- Refresh inventory and players windows once CL_Images finishes loading so icons show without resizing

## Testing
- `go test ./...` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory; Package alsa not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5976098bc832a9b77abc962088601