### PR TITLE
Fix go vet warnings and format hotkeys

### DIFF
--- a/chat_tts_blocklist_test.go
+++ b/chat_tts_blocklist_test.go
@@ -60,14 +60,16 @@ func TestHandleNoTTSList(t *testing.T) {
 	origList := gs.ChatTTSBlocklist
 	gs.ChatTTSBlocklist = []string{"foo", "bar"}
 	syncTTSBlocklist()
-	origLog := consoleLog
-	consoleLog = messageLog{max: maxMessages}
+	origEntries, origMax := consoleLog.entries, consoleLog.max
+	consoleLog.entries = nil
+	consoleLog.max = maxMessages
 	handleNoTTSCommand("list")
 	msgs := getConsoleMessages()
 	if len(msgs) != 1 || msgs[0] != "TTS blocklist: foo, bar" {
 		t.Fatalf("got %v", msgs)
 	}
-	consoleLog = origLog
+	consoleLog.entries = origEntries
+	consoleLog.max = origMax
 	gs.ChatTTSBlocklist = origList
 	syncTTSBlocklist()
 }

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -262,9 +262,9 @@ func makeHotkeysWindow() {
 	root.AddItem(flow)
 
 	btnRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
-    addBtn, addEvents := eui.NewButton()
-    addBtn.Text = "+"
-    addBtn.Tooltip = "Create a new hotkey"
+	addBtn, addEvents := eui.NewButton()
+	addBtn.Text = "+"
+	addBtn.Tooltip = "Create a new hotkey"
 	addBtn.Size = eui.Point{X: 20, Y: 20}
 	addBtn.FontSize = 14
 	addEvents.Handle = func(ev eui.UIEvent) {
@@ -331,9 +331,9 @@ func refreshHotkeysList() {
 			}
 		}
 		row.AddItem(btn)
-        delBtn, delEvents := eui.NewButton()
-        delBtn.Text = "x"
-        delBtn.Tooltip = "Remove this hotkey"
+		delBtn, delEvents := eui.NewButton()
+		delBtn.Text = "x"
+		delBtn.Tooltip = "Remove this hotkey"
 		delBtn.Size = eui.Point{X: 20, Y: 20}
 		delBtn.FontSize = 10
 		delEvents.Handle = func(ev eui.UIEvent) {
@@ -472,9 +472,9 @@ func openHotkeyEditor(idx int) {
 	hotkeyComboText.Size = eui.Point{X: 200, Y: 20}
 	hotkeyComboText.FontSize = 12
 	row.AddItem(hotkeyComboText)
-    hotkeyRecordBtn, recordEvents := eui.NewButton()
-    hotkeyRecordBtn.Text = "Record"
-    hotkeyRecordBtn.Tooltip = "Capture a key/mouse combo"
+	hotkeyRecordBtn, recordEvents := eui.NewButton()
+	hotkeyRecordBtn.Text = "Record"
+	hotkeyRecordBtn.Tooltip = "Capture a key/mouse combo"
 	hotkeyRecordBtn.Size = eui.Point{X: 60, Y: 20}
 	hotkeyRecordBtn.FontSize = 12
 	recordEvents.Handle = func(ev eui.UIEvent) {
@@ -502,9 +502,9 @@ func openHotkeyEditor(idx int) {
 	hotkeyCmdInputs = nil
 
 	// Row to add a command input
-    addCmdRow, addCmdEvents := eui.NewButton()
-    addCmdRow.Text = "+"
-    addCmdRow.Tooltip = "Add another command line"
+	addCmdRow, addCmdEvents := eui.NewButton()
+	addCmdRow.Text = "+"
+	addCmdRow.Tooltip = "Add another command line"
 	addCmdRow.Size = eui.Point{X: 20, Y: 20}
 	addCmdRow.FontSize = 14
 	addCmdEvents.Handle = func(ev eui.UIEvent) {

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-    "encoding/json"
-    "os"
-    "path/filepath"
-    "strings"
-    "testing"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 
-    "github.com/hajimehoshi/ebiten/v2"
-    "golang.org/x/image/font/gofont/goregular"
-    "gothoom/eui"
+	"github.com/hajimehoshi/ebiten/v2"
+	"golang.org/x/image/font/gofont/goregular"
+	"gothoom/eui"
 )
 
 // Test that closing the hotkey editor clears the reference and allows reopening.
@@ -249,14 +249,14 @@ func TestHotkeyEditorWrapsAndResizes(t *testing.T) {
 
 // Test that @right.clicked in commands expands to the last right-clicked mobile name.
 func TestApplyHotkeyVars(t *testing.T) {
-    // Populate lastClickByButton for right-click
-    lastClickByButtonMu.Lock()
-    lastClickByButton[ebiten.MouseButtonRight] = ClickInfo{OnMobile: true, Mobile: Mobile{Name: "Target"}}
-    lastClickByButtonMu.Unlock()
-    got, ok := applyHotkeyVars("/use @right.clicked")
-    if !ok || got != "/use Target" {
-        t.Fatalf("got %q, ok %v", got, ok)
-    }
+	// Populate lastClickByButton for right-click
+	lastClickByButtonMu.Lock()
+	lastClickByButton[ebiten.MouseButtonRight] = ClickInfo{OnMobile: true, Mobile: Mobile{Name: "Target"}}
+	lastClickByButtonMu.Unlock()
+	got, ok := applyHotkeyVars("/use @right.clicked")
+	if !ok || got != "/use Target" {
+		t.Fatalf("got %q, ok %v", got, ok)
+	}
 }
 
 // Test that @hovered in commands expands to the currently hovered mobile name.
@@ -272,12 +272,12 @@ func TestApplyHotkeyVarsHovered(t *testing.T) {
 
 // Test that commands referencing @right.clicked don't fire without a target.
 func TestApplyHotkeyVarsNoClicked(t *testing.T) {
-    lastClickByButtonMu.Lock()
-    delete(lastClickByButton, ebiten.MouseButtonRight)
-    lastClickByButtonMu.Unlock()
-    if got, ok := applyHotkeyVars("/use @right.clicked"); ok || got != "" {
-        t.Fatalf("got %q, ok %v", got, ok)
-    }
+	lastClickByButtonMu.Lock()
+	delete(lastClickByButton, ebiten.MouseButtonRight)
+	lastClickByButtonMu.Unlock()
+	if got, ok := applyHotkeyVars("/use @right.clicked"); ok || got != "" {
+		t.Fatalf("got %q, ok %v", got, ok)
+	}
 }
 
 // Test that commands referencing @hovered don't fire without a target.
@@ -422,9 +422,9 @@ func TestPluginRemoveHotkeyClearsState(t *testing.T) {
 		pluginDisabled = origDisabled
 		pluginInvalid = origInvalid
 	})
-    origEnabledPlugins := pluginEnabledFor
-    pluginEnabledFor = map[string]pluginScope{}
-    t.Cleanup(func() { pluginEnabledFor = origEnabledPlugins })
+	origEnabledPlugins := pluginEnabledFor
+	pluginEnabledFor = map[string]pluginScope{}
+	t.Cleanup(func() { pluginEnabledFor = origEnabledPlugins })
 
 	makeHotkeysWindow()
 

--- a/labels.go
+++ b/labels.go
@@ -176,5 +176,5 @@ func labelColor(i int) eui.Color {
 		return eui.Color{}
 	}
 	c := labelColors[i-1]
-	return eui.Color{c.R, c.G, c.B, c.A}
+	return eui.Color{R: c.R, G: c.G, B: c.B, A: c.A}
 }


### PR DESCRIPTION
## Summary
- format hotkey handlers and tests with gofmt
- use keyed fields in labelColor to satisfy go vet
- avoid copying messageLog in TTS blocklist tests

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b59f0a3be4832a85694330cbad55d1