### PR TITLE
Precompute name tag styling for mobiles

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -19,12 +19,14 @@ import (
 
 // frameDescriptor describes an on-screen descriptor.
 type frameDescriptor struct {
-	Index  uint8
-	Type   uint8
-	PictID uint16
-	Name   string
-	Colors []byte
-	Plane  int
+	Index        uint8
+	Type         uint8
+	PictID       uint16
+	Name         string
+	Colors       []byte
+	Plane        int
+	NameTagStyle uint8
+	LabelColor   color.RGBA
 }
 
 type framePicture struct {

--- a/game.go
+++ b/game.go
@@ -438,9 +438,37 @@ func captureDrawSnapshot() drawSnapshot {
 		deadMobs: append([]frameMobile(nil), state.deadMobs...),
 	}
 
+	playerCache := map[string]struct {
+		style uint8
+		label color.RGBA
+	}{}
+	playersMu.RLock()
 	for idx, d := range state.descriptors {
+		if d.Name != "" {
+			ps, ok := playerCache[d.Name]
+			if !ok {
+				ps.style = styleRegular
+				if p, ok := players[d.Name]; ok {
+					if p.Sharing && p.Sharee {
+						ps.style = styleBoldItalic
+					} else if p.Sharing {
+						ps.style = styleBold
+					} else if p.Sharee {
+						ps.style = styleItalic
+					}
+					if gs.NameTagLabelColors && p.FriendLabel > 0 && p.FriendLabel <= len(labelColors) {
+						lc := labelColors[p.FriendLabel-1]
+						ps.label = color.RGBA{lc.R, lc.G, lc.B, 0}
+					}
+				}
+				playerCache[d.Name] = ps
+			}
+			d.NameTagStyle = ps.style
+			d.LabelColor = ps.label
+		}
 		snap.descriptors[idx] = d
 	}
+	playersMu.RUnlock()
 	if len(state.bubbles) > 0 {
 		curFrame := frameCounter
 		kept := state.bubbles[:0]
@@ -1909,18 +1937,7 @@ func drawMobileNameTag(screen *ebiten.Image, snap drawSnapshot, m frameMobile, a
 		}
 		offset := float64(size) * gs.GameScale / 2
 		if d.Name != "" {
-			style := styleRegular
-			playersMu.RLock()
-			if p, ok := players[d.Name]; ok {
-				if p.Sharing && p.Sharee {
-					style = styleBoldItalic
-				} else if p.Sharing {
-					style = styleBold
-				} else if p.Sharee {
-					style = styleItalic
-				}
-			}
-			playersMu.RUnlock()
+			style := d.NameTagStyle
 			if m.nameTag != nil && m.nameTagKey.FontGen == fontGen && m.nameTagKey.Opacity == nameAlpha && m.nameTagKey.Text == d.Name && m.nameTagKey.Colors == m.Colors && m.nameTagKey.Style == style {
 				top := y + int(offset)
 				left := x - int(float64(m.nameTagW)/2)
@@ -1929,13 +1946,9 @@ func drawMobileNameTag(screen *ebiten.Image, snap drawSnapshot, m frameMobile, a
 				screen.DrawImage(m.nameTag, op)
 			} else {
 				textClr, bgClr, frameClr := mobileNameColors(m.Colors)
-				if gs.NameTagLabelColors {
-					playersMu.RLock()
-					if p, ok := players[d.Name]; ok && p.FriendLabel > 0 && p.FriendLabel <= len(labelColors) {
-						lc := labelColors[p.FriendLabel-1]
-						frameClr = color.RGBA{lc.R, lc.G, lc.B, frameClr.A}
-					}
-					playersMu.RUnlock()
+				if d.LabelColor != (color.RGBA{}) {
+					lc := d.LabelColor
+					frameClr = color.RGBA{lc.R, lc.G, lc.B, frameClr.A}
 				}
 				bgClr.A = nameAlpha
 				frameClr.A = nameAlpha


### PR DESCRIPTION
## Summary
- Precompute name tag style and label color in draw snapshots
- Store style and label color on frame descriptors
- Use cached values when rendering mobile name tags to avoid locking

## Testing
- `go build ./...`
- `go test ./...` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b931acbf04832aa4e09d408ece3327