### PR TITLE
Fix window snapping anchor handling

### DIFF
--- a/eui/drag_test.go
+++ b/eui/drag_test.go
@@ -61,3 +61,37 @@ func TestDragUnsnapThreshold(t *testing.T) {
 		t.Fatalf("window snapped after moving away")
 	}
 }
+
+func TestSnapToWindowWithSnapAnchor(t *testing.T) {
+	screenWidth = 100
+	screenHeight = 100
+	uiScale = 1
+	windowSnapping = true
+
+	base := &windowData{Position: point{20, 0}, Size: point{10, 10}, Open: true}
+	win := &windowData{Size: point{10, 10}, Open: true}
+	windows = []*windowData{base, win}
+	defer func() { windows = nil }()
+
+	if !snapToCorner(win) {
+		t.Fatalf("expected window to snap to corner")
+	}
+
+	dragWindowMove(win, point{X: 9, Y: 0})
+	if !win.snapAnchorActive {
+		t.Fatalf("snap anchor deactivated too soon")
+	}
+
+	snapped := false
+	if !win.snapAnchorActive {
+		snapped = snapToCorner(win)
+	}
+	if !snapped && snapToWindow(win) {
+		win.clampToScreen()
+	}
+
+	expected := point{X: base.Position.X - win.Size.X, Y: 0}
+	if win.Position != expected {
+		t.Fatalf("expected snap to window at %+v, got %+v", expected, win.Position)
+	}
+}

--- a/eui/input.go
+++ b/eui/input.go
@@ -274,12 +274,12 @@ func Update() error {
 				}
 				win.clampToScreen()
 				if windowSnapping && win.zone == nil {
+					snapped := false
 					if !win.snapAnchorActive {
-						if !snapToCorner(win) {
-							if snapToWindow(win) {
-								win.clampToScreen()
-							}
-						}
+						snapped = snapToCorner(win)
+					}
+					if !snapped && snapToWindow(win) {
+						win.clampToScreen()
 					}
 				}
 				if dragPart != PART_BAR {

--- a/ui.go
+++ b/ui.go
@@ -2452,33 +2452,33 @@ func makeSettingsWindow() {
 	left.AddItem(label)
 
 	/*
-		tilingCB, tilingEvents := eui.NewCheckbox()
-		tilingCB.Text = "Tiling window mode (buggy)"
-		tilingCB.Size = eui.Point{X: panelWidth, Y: 24}
-		tilingCB.Checked = gs.WindowTiling
-		tilingCB.Tooltip = "Prevent windows from overlapping"
-		tilingEvents.Handle = func(ev eui.UIEvent) {
-			if ev.Type == eui.EventCheckboxChanged {
-				gs.WindowTiling = ev.Checked
-				eui.SetWindowTiling(ev.Checked)
-				settingsDirty = true
+			tilingCB, tilingEvents := eui.NewCheckbox()
+			tilingCB.Text = "Tiling window mode (buggy)"
+			tilingCB.Size = eui.Point{X: panelWidth, Y: 24}
+			tilingCB.Checked = gs.WindowTiling
+			tilingCB.Tooltip = "Prevent windows from overlapping"
+			tilingEvents.Handle = func(ev eui.UIEvent) {
+				if ev.Type == eui.EventCheckboxChanged {
+					gs.WindowTiling = ev.Checked
+					eui.SetWindowTiling(ev.Checked)
+					settingsDirty = true
+				}
 			}
-		}
-		right.AddItem(tilingCB)
+			right.AddItem(tilingCB)
 
-		snapCB, snapEvents := eui.NewCheckbox()
-		snapCB.Text = "Window snapping (buggy)"
-		snapCB.Size = eui.Point{X: panelWidth, Y: 24}
-		snapCB.Checked = gs.WindowSnapping
-		snapCB.Tooltip = "Snap windows to edges and others"
-		snapEvents.Handle = func(ev eui.UIEvent) {
-			if ev.Type == eui.EventCheckboxChanged {
-				gs.WindowSnapping = ev.Checked
-				eui.SetWindowSnapping(ev.Checked)
-				settingsDirty = true
+	               snapCB, snapEvents := eui.NewCheckbox()
+	               snapCB.Text = "Window snapping"
+	               snapCB.Size = eui.Point{X: panelWidth, Y: 24}
+	               snapCB.Checked = gs.WindowSnapping
+	               snapCB.Tooltip = "Snap windows to edges and others"
+			snapEvents.Handle = func(ev eui.UIEvent) {
+				if ev.Type == eui.EventCheckboxChanged {
+					gs.WindowSnapping = ev.Checked
+					eui.SetWindowSnapping(ev.Checked)
+					settingsDirty = true
+				}
 			}
-		}
-		right.AddItem(snapCB)
+			right.AddItem(snapCB)
 	*/
 
 	if showUIScale {


### PR DESCRIPTION
## Summary
- allow snapping to other windows even when an existing snap anchor is active
- add regression test for snapping with active anchor
- update settings UI to remove "buggy" label from window snapping

## Testing
- `timeout 20s go test ./eui -run TestSnapToWindowWithSnapAnchor -count=1 -v` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `sudo apt-get update` *(fails: repository requests hang)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48931718832a80facd590761e800