### PR TITLE
Add search to players and inventory windows

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -83,6 +83,8 @@ func makeInventoryWindow() {
 		return
 	}
 	inventoryWin, inventoryList, _ = makeTextWindow("Inventory", eui.HZoneLeft, eui.VZoneMiddleTop, true)
+	inventoryWin.Searchable = true
+	inventoryWin.OnSearch = func(s string) { searchTextWindow(inventoryWin, inventoryList, s) }
 	// Ensure layout updates immediately on resize to avoid gaps.
 	inventoryWin.OnResize = func() { updateInventoryWindow() }
 	updateInventoryWindow()
@@ -341,6 +343,7 @@ func updateInventoryWindow() {
 		inventoryList.Size.X = clientWAvail
 		inventoryList.Size.Y = clientHAvail
 		inventoryList.Scroll = prevScroll
+		searchTextWindow(inventoryWin, inventoryList, inventoryWin.SearchText)
 		inventoryWin.Refresh()
 	}
 }

--- a/players_ui.go
+++ b/players_ui.go
@@ -287,6 +287,7 @@ func updatePlayersWindow() {
 	}
 	playersList.Size.X = clientWAvail
 	playersList.Size.Y = clientHAvail
+	searchTextWindow(playersWin, playersList, playersWin.SearchText)
 	playersWin.Refresh()
 }
 

--- a/ui.go
+++ b/ui.go
@@ -4716,6 +4716,8 @@ func makePlayersWindow() {
 	// Use the common text window scaffold to get an inner scrollable list
 	// and consistent padding/behavior with Inventory/Chat windows.
 	playersWin, playersList, _ = makeTextWindow("Players", eui.HZoneRight, eui.VZoneTop, false)
+	playersWin.Searchable = true
+	playersWin.OnSearch = func(s string) { searchTextWindow(playersWin, playersList, s) }
 	// Restore saved geometry if present, otherwise keep defaults from helper.
 	if gs.PlayersWindow.Size.X > 0 && gs.PlayersWindow.Size.Y > 0 {
 		playersWin.Size = eui.Point{X: float32(gs.PlayersWindow.Size.X), Y: float32(gs.PlayersWindow.Size.Y)}


### PR DESCRIPTION
## Summary
- enable search boxes in players and inventory windows
- highlight matching rows when searching

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba59435594832a9fbc1d8b2b5391e0