### PR TITLE
Preserve selection highlights in player and inventory lists

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -149,6 +149,7 @@ func updateInventoryWindow() {
 	// Clear prior contents and rebuild rows as [icon][name (xN)].
 	inventoryList.Contents = nil
 	inventoryRowRefs = map[*eui.ItemData]invRef{}
+	var selectedRow *eui.ItemData
 
 	// Compute row height from actual font metrics (ascent+descent) at the
 	// exact point size used when rendering (+2px fudge for Ebiten).
@@ -308,8 +309,7 @@ func updateInventoryWindow() {
 			idxCopy = -1
 		}
 		if idCopy == selectedInvID && idxCopy == selectedInvIdx {
-			row.Filled = true
-			row.Color = accent
+			selectedRow = row
 		}
 		click := func() { handleInventoryClick(idCopy, idxCopy) }
 		icon.Action = click
@@ -343,6 +343,10 @@ func updateInventoryWindow() {
 		inventoryList.Size.Y = clientHAvail
 		inventoryList.Scroll = prevScroll
 		searchTextWindow(inventoryWin, inventoryList, inventoryWin.SearchText)
+		if selectedRow != nil {
+			selectedRow.Filled = true
+			selectedRow.Color = accent
+		}
 		inventoryWin.Refresh()
 	}
 }

--- a/players_ui.go
+++ b/players_ui.go
@@ -142,6 +142,7 @@ func updatePlayersWindow() {
 	// Layout per row: [avatar (or default/blank)] [profession (or blank)] [name]
 	playersList.Contents = nil
 	playersRowRefs = map[*eui.ItemData]string{}
+	var selectedRow *eui.ItemData
 
 	header := fmt.Sprintf("Players Online: %d", onlineCount)
 	// Include simple share summary when relevant.
@@ -186,10 +187,9 @@ func updatePlayersWindow() {
 			row.OutlineColor = labelColor(p.FriendLabel)
 		}
 
-		// Highlight if selected.
+		// Track selected row for highlight after search.
 		if p.Name == selectedPlayerName {
-			row.Filled = true
-			row.Color = accent
+			selectedRow = row
 		}
 
 		iconSize := int(rowUnits + 0.5)
@@ -290,6 +290,10 @@ func updatePlayersWindow() {
 	playersList.Size.Y = clientHAvail
 	playersList.Scroll = prevScroll
 	searchTextWindow(playersWin, playersList, playersWin.SearchText)
+	if selectedRow != nil {
+		selectedRow.Filled = true
+		selectedRow.Color = accent
+	}
 	playersWin.Refresh()
 }
 


### PR DESCRIPTION
## Summary
- keep player and inventory list selections highlighted by tracking and restoring the selected row after running the search highlighter

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils` *(fails: Unable to locate package)*
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68ba688bcf04832ab714270681023520