### PR TITLE
Redraw windows on accent color change

### DIFF
--- a/eui/accent_color_test.go
+++ b/eui/accent_color_test.go
@@ -14,3 +14,26 @@ func TestSetAccentColorUpdatesNamedColor(t *testing.T) {
 		t.Fatalf("named accent %v does not match accent color %v", c, AccentColor())
 	}
 }
+
+// Test that setting the accent color marks all windows dirty so they redraw.
+func TestSetAccentColorMarksWindowsDirty(t *testing.T) {
+	oldWindows := windows
+	oldNamed := namedColors
+	defer func() {
+		windows = oldWindows
+		namedColors = oldNamed
+	}()
+
+	win1 := &windowData{Open: true}
+	win2 := &windowData{Open: true}
+	windows = []*windowData{win1, win2}
+	namedColors = map[string]Color{}
+
+	SetAccentColor(NewColor(0, 0, 255, 255))
+
+	for i, w := range windows {
+		if !w.Dirty {
+			t.Fatalf("window %d not marked dirty", i)
+		}
+	}
+}

--- a/eui/theme.go
+++ b/eui/theme.go
@@ -203,6 +203,7 @@ func SetAccentColor(c Color) {
 	if namedColors != nil {
 		namedColors["accent"] = AccentColor()
 	}
+	markAllDirty()
 }
 
 // SetAccentSaturation updates the saturation component of the accent color and
@@ -212,4 +213,5 @@ func SetAccentSaturation(s float64) {
 	if namedColors != nil {
 		namedColors["accent"] = AccentColor()
 	}
+	markAllDirty()
 }


### PR DESCRIPTION
## Summary
- ensure changing accent color marks all windows/items dirty
- add regression test for accent color redrawing

## Testing
- `go test ./...` *(fails: X11/alsa/gtk packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba719c1e18832a955352db80982188