### PR TITLE
Optimize dropdown rendering by pooling draw options

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -33,6 +33,18 @@ func releaseDrawImageOptions(op *ebiten.DrawImageOptions) {
 	drawImageOptionsPool.Put(op)
 }
 
+var textDrawOptionsPool = sync.Pool{New: func() any { return &text.DrawOptions{} }}
+
+func acquireTextDrawOptions() *text.DrawOptions {
+	op := textDrawOptionsPool.Get().(*text.DrawOptions)
+	*op = text.DrawOptions{DrawImageOptions: ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}}
+	return op
+}
+
+func releaseTextDrawOptions(op *text.DrawOptions) {
+	textDrawOptionsPool.Put(op)
+}
+
 type openDropdown struct {
 	item   *itemData
 	offset point
@@ -1706,9 +1718,11 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 			}
 			drawRoundRect(subImg, &roundRect{Size: maxSize, Position: point{X: offset.X, Y: y}, Fillet: item.Fillet, Filled: true, Color: col})
 		}
-		td := ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
+		td := acquireDrawImageOptions()
 		td.GeoM.Translate(float64(offset.X+item.BorderPad+item.Padding+currentStyle.TextPadding*uiScale), float64(y+optionH/2))
-		tdo := &text.DrawOptions{DrawImageOptions: td, LayoutOptions: loo}
+		tdo := acquireTextDrawOptions()
+		tdo.DrawImageOptions = *td
+		tdo.LayoutOptions = loo
 		if i < item.HeaderCount {
 			// Render headers with disabled text color.
 			tdo.ColorScale.ScaleWithColor(style.DisabledColor)
@@ -1716,6 +1730,8 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 			tdo.ColorScale.ScaleWithColor(style.TextColor)
 		}
 		text.Draw(subImg, item.Options[i], face, tdo)
+		releaseTextDrawOptions(tdo)
+		releaseDrawImageOptions(td)
 	}
 
 	if len(item.Options) > visible {


### PR DESCRIPTION
## Summary
- add pools for `ebiten.DrawImageOptions` and `text.DrawOptions`
- reuse pooled options in dropdown rendering to avoid allocations

## Testing
- `go test ./...` *(fails: command hung without output)*
- `go test ./... -run TestNonExistent -count=1` *(fails: command hung without output)*
- `go build ./...` *(fails: command hung without output)*

------
https://chatgpt.com/codex/tasks/task_e_68bec911e944832a9f80c1324564a51c