### PR TITLE
cache theme and style paths

### DIFF
--- a/eui/public.go
+++ b/eui/public.go
@@ -156,13 +156,19 @@ func ListStyles() ([]string, error) { return listStyles() }
 func CurrentThemeName() string { return currentThemeName }
 
 // SetCurrentThemeName updates the active theme name.
-func SetCurrentThemeName(name string) { currentThemeName = name }
+func SetCurrentThemeName(name string) {
+	currentThemeName = name
+	updateThemePath()
+}
 
 // CurrentStyleName returns the active style theme name.
 func CurrentStyleName() string { return currentStyleName }
 
 // SetCurrentStyleName updates the active style theme name.
-func SetCurrentStyleName(name string) { currentStyleName = name }
+func SetCurrentStyleName(name string) {
+	currentStyleName = name
+	updateStylePath()
+}
 
 // AccentSaturation returns the current accent color saturation value.
 func AccentSaturation() float64 { return accentSaturation }
@@ -174,11 +180,11 @@ func AccentColor() Color {
 
 // ClearFocus removes focus from the provided item if it is currently focused.
 func ClearFocus(it *ItemData) {
-    if focusedItem == it {
-        focusedItem.Focused = false
-        focusedItem.markDirty()
-        focusedItem = nil
-    }
+	if focusedItem == it {
+		focusedItem.Focused = false
+		focusedItem.markDirty()
+		focusedItem = nil
+	}
 }
 
 // SetActiveSearchForTest sets the active search window for tests.
@@ -186,8 +192,8 @@ func ClearFocus(it *ItemData) {
 // is activated. It exists so external tests can simulate an active
 // search without poking unexported symbols.
 func SetActiveSearchForTest(win *WindowData) {
-    activeSearch = win
-    if win != nil {
-        win.searchOpen = true
-    }
+	activeSearch = win
+	if win != nil {
+		win.searchOpen = true
+	}
 }

--- a/eui/style.go
+++ b/eui/style.go
@@ -135,7 +135,7 @@ func LoadStyle(name string) error {
 	if err := json.Unmarshal(data, currentStyle); err != nil {
 		return err
 	}
-	currentStyleName = name
+	SetCurrentStyleName(name)
 	if currentTheme != nil {
 		applyStyleToTheme(currentTheme)
 		applyStyleToItems(currentTheme)

--- a/eui/theme.go
+++ b/eui/theme.go
@@ -115,7 +115,7 @@ func LoadTheme(name string) error {
 			currentTheme.Slider.SelectedColor = col
 		}
 	}
-	currentThemeName = name
+	SetCurrentThemeName(name)
 	applyStyleToTheme(currentTheme)
 	updateThemeReferences(oldTheme, currentTheme)
 	applyStyleToItems(currentTheme)

--- a/eui/watchers.go
+++ b/eui/watchers.go
@@ -11,6 +11,8 @@ var (
 	themeModTime time.Time
 	styleModTime time.Time
 	modCheckTime time.Time
+	themePath    string
+	stylePath    string
 	// AutoReload enables automatic reloading of theme and style files
 	// when they are modified on disk, only use this for quickly iterating when designing your own themes.
 	AutoReload bool
@@ -18,22 +20,30 @@ var (
 
 func init() {
 	modCheckTime = time.Now()
+	updateThemePath()
+	updateStylePath()
 	refreshThemeMod()
 	refreshStyleMod()
 }
 
+func updateThemePath() {
+	themePath = filepath.Join(os.Getenv("PWD"), "themes", "palettes", currentThemeName+".json")
+}
+
 func refreshThemeMod() {
-	path := filepath.Join(os.Getenv("PWD"), "themes", "palettes", currentThemeName+".json")
-	if info, err := os.Stat(path); err == nil {
+	if info, err := os.Stat(themePath); err == nil {
 		themeModTime = info.ModTime()
 	} else {
 		themeModTime = time.Time{}
 	}
 }
 
+func updateStylePath() {
+	stylePath = filepath.Join(os.Getenv("PWD"), "themes", "styles", currentStyleName+".json")
+}
+
 func refreshStyleMod() {
-	path := filepath.Join(os.Getenv("PWD"), "themes", "styles", currentStyleName+".json")
-	if info, err := os.Stat(path); err == nil {
+	if info, err := os.Stat(stylePath); err == nil {
 		styleModTime = info.ModTime()
 	} else {
 		styleModTime = time.Time{}
@@ -48,8 +58,7 @@ func checkThemeStyleMods() {
 		return
 	}
 	modCheckTime = time.Now()
-	path := filepath.Join(os.Getenv("PWD"), "themes", "palettes", currentThemeName+".json")
-	if info, err := os.Stat(path); err == nil {
+	if info, err := os.Stat(themePath); err == nil {
 		if info.ModTime().After(themeModTime) {
 			log.Println("Palette reload")
 			if err := LoadTheme(currentThemeName); err != nil {
@@ -61,8 +70,7 @@ func checkThemeStyleMods() {
 		log.Println("Unable to stat " + currentThemeName + ": " + err.Error())
 	}
 
-	path = filepath.Join(os.Getenv("PWD"), "themes", "styles", currentStyleName+".json")
-	if info, err := os.Stat(path); err == nil {
+	if info, err := os.Stat(stylePath); err == nil {
 		if info.ModTime().After(styleModTime) {
 			log.Println("Style theme reload")
 			if err := LoadStyle(currentStyleName); err != nil {


### PR DESCRIPTION
## Summary
- cache theme and style file paths at init for reuse
- refresh cached paths when theme or style names change

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bec91b18a4832a82320327ecb8fd1b