### PR TITLE
Reuse dropdown slice to avoid allocations

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -21,6 +21,8 @@ const shadowAlphaDivisor = 16
 var dumpDone bool
 var zoneIndicatorWin *windowData
 
+var dropdownReuse []openDropdown
+
 var drawImageOptionsPool = sync.Pool{New: func() any { return &ebiten.DrawImageOptions{} }}
 
 func acquireDrawImageOptions() *ebiten.DrawImageOptions {
@@ -69,7 +71,10 @@ func itemFace(item *itemData, size float32) text.Face {
 // Call this from your Ebiten Draw function.
 func Draw(screen *ebiten.Image) {
 	zoneIndicatorWin = nil
-	dropdowns := []openDropdown{}
+	dropdowns := dropdownReuse[:0]
+	if cap(dropdowns) < len(windows) {
+		dropdowns = make([]openDropdown, 0, len(windows))
+	}
 	for _, win := range windows {
 		if !win.Open {
 			continue
@@ -111,6 +116,7 @@ func Draw(screen *ebiten.Image) {
 	if hoveredItem != nil && hoveredItem.Tooltip != "" {
 		drawTooltip(screen, hoveredItem)
 	}
+	dropdownReuse = dropdowns
 
 	if DumpMode && !dumpDone {
 		if err := DumpCachedImages(); err != nil {

--- a/eui/render_dropdown_test.go
+++ b/eui/render_dropdown_test.go
@@ -1,0 +1,53 @@
+package eui
+
+import "testing"
+
+// collectDropdownsForTest mirrors the dropdown collection logic in Draw without rendering.
+func collectDropdownsForTest() []openDropdown {
+	dropdowns := dropdownReuse[:0]
+	if cap(dropdowns) < len(windows) {
+		dropdowns = make([]openDropdown, 0, len(windows))
+	}
+	for _, win := range windows {
+		if !win.Open {
+			continue
+		}
+		win.collectDropdowns(&dropdowns)
+	}
+	dropdownReuse = dropdowns
+	return dropdowns
+}
+
+func TestDropdownSliceAdjustsWithWindowChanges(t *testing.T) {
+	oldWindows := windows
+	oldReuse := dropdownReuse
+	defer func() {
+		windows = oldWindows
+		dropdownReuse = oldReuse
+	}()
+
+	i1 := &itemData{ItemType: ITEM_DROPDOWN, Open: true, DrawRect: rect{}}
+	w1 := &windowData{Open: true, Contents: []*itemData{i1}}
+	i2 := &itemData{ItemType: ITEM_DROPDOWN, Open: true, DrawRect: rect{}}
+	w2 := &windowData{Open: true, Contents: []*itemData{i2}}
+
+	windows = []*windowData{w1}
+	if dds := collectDropdownsForTest(); len(dds) != 1 {
+		t.Fatalf("expected 1 dropdown, got %d", len(dds))
+	}
+
+	windows = []*windowData{w1, w2}
+	if dds := collectDropdownsForTest(); len(dds) != 2 {
+		t.Fatalf("expected 2 dropdowns, got %d", len(dds))
+	}
+
+	windows = []*windowData{w1}
+	if dds := collectDropdownsForTest(); len(dds) != 1 {
+		t.Fatalf("expected 1 dropdown after removal, got %d", len(dds))
+	}
+
+	windows = nil
+	if dds := collectDropdownsForTest(); len(dds) != 0 {
+		t.Fatalf("expected 0 dropdowns after clearing windows, got %d", len(dds))
+	}
+}


### PR DESCRIPTION
## Summary
- preallocate dropdown slice based on window count and reuse it each frame to avoid allocations
- add tests to ensure dropdown collection resets correctly when windows change

## Testing
- `apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils`
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go test ./eui -run TestDropdownSliceAdjustsWithWindowChanges -count=1` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bed85183f8832ab5bdce3eef265743