### PR TITLE
Map inventory shortcut keys

### DIFF
--- a/game.go
+++ b/game.go
@@ -626,13 +626,15 @@ func (g *Game) Update() error {
 	hy := int16(float64(my-origY)/worldScale - float64(fieldCenterY))
 	updateWorldHover(hx, hy)
 
-	inventoryShortcutMu.RLock()
-	for idx, r := range inventoryShortcuts {
-		if k := keyForRune(r); k >= 0 && inpututil.IsKeyJustPressed(k) {
+	if keys := inpututil.AppendJustPressedKeys(nil); len(keys) > 0 {
+		lastPressedKey := keys[len(keys)-1]
+		inventoryShortcutMu.RLock()
+		idx, ok := shortcutKeyToIndex[lastPressedKey]
+		inventoryShortcutMu.RUnlock()
+		if ok {
 			triggerInventoryShortcut(idx)
 		}
 	}
-	inventoryShortcutMu.RUnlock()
 
 	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight) {
 		// Input bar menu takes precedence when right-clicking on input.

--- a/inventory_ui_sort_test.go
+++ b/inventory_ui_sort_test.go
@@ -3,12 +3,17 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
 
 func TestInventoryOrderSortedWithShortcuts(t *testing.T) {
 	resetInventory()
 	inventoryShortcutMu.Lock()
 	inventoryShortcuts = map[int]rune{}
+	shortcutKeyToIndex = map[ebiten.Key]int{}
 	inventoryShortcutMu.Unlock()
 
 	addInventoryItem(1, -1, "Banana", false)
@@ -18,6 +23,7 @@ func TestInventoryOrderSortedWithShortcuts(t *testing.T) {
 
 	inventoryShortcutMu.Lock()
 	inventoryShortcuts[1] = '1'
+	refreshShortcutKeyMapLocked()
 	inventoryShortcutMu.Unlock()
 
 	inventoryWin = nil


### PR DESCRIPTION
## Summary
- build `shortcutKeyToIndex` to map keys to inventory slots and refresh on shortcut updates
- check last pressed key once per frame to trigger inventory shortcuts without looping

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bed83e9804832a8d380d453fd78d4e