### PR TITLE
Show caps lock warning on password inputs

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -28,15 +28,26 @@ var (
 	inputBuf []rune
 )
 
+var (
+	ShiftPressed          bool
+	CapsLockToggleHandler func()
+)
+
 // Update processes input and updates window state.
 // Programs embedding the UI can call this from their Ebiten Update handler.
 func Update() error {
 	checkThemeStyleMods()
 
 	shiftPressed := ebiten.IsKeyPressed(ebiten.KeyShift) || ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight)
+	ShiftPressed = shiftPressed
 	ctrlPressed := ebiten.IsKeyPressed(ebiten.KeyControl) || ebiten.IsKeyPressed(ebiten.KeyControlLeft) || ebiten.IsKeyPressed(ebiten.KeyControlRight)
 	altPressed := ebiten.IsKeyPressed(ebiten.KeyAlt) || ebiten.IsKeyPressed(ebiten.KeyAltLeft) || ebiten.IsKeyPressed(ebiten.KeyAltRight)
 	metaPressed := ebiten.IsKeyPressed(ebiten.KeyMeta) || ebiten.IsKeyPressed(ebiten.KeyMetaLeft) || ebiten.IsKeyPressed(ebiten.KeyMetaRight)
+	if inpututil.IsKeyJustPressed(ebiten.KeyCapsLock) {
+		if CapsLockToggleHandler != nil {
+			CapsLockToggleHandler()
+		}
+	}
 	_ = altPressed
 	_ = metaPressed
 


### PR DESCRIPTION
## Summary
- Track shift key and Caps Lock presses in the EUI input system
- Display a red Caps Lock warning for password fields when typed case doesn't match shift state
- Clear warnings when Caps Lock toggles or password fields reset

## Testing
- `go test ./...` *(fails: compile: version "go1.24.3" does not match go tool version "go1.25.0")*

------
https://chatgpt.com/codex/tasks/task_e_68bf014c6674832ab531a024209db43b