### PR TITLE
Handle nil list in searchTextWindow

### DIFF
--- a/text_window.go
+++ b/text_window.go
@@ -295,6 +295,13 @@ func showSpellSuggestions(t *eui.ItemData) {
 // adds markers to the scrollbar for quick navigation. It clears highlights when
 // the query is empty.
 func searchTextWindow(win *eui.WindowData, list *eui.ItemData, query string) {
+	if list == nil {
+		if win != nil {
+			win.Refresh()
+		}
+		return
+	}
+
 	q := strings.ToLower(query)
 	total := len(list.Contents)
 	var marks []float32


### PR DESCRIPTION
## Summary
- prevent `searchTextWindow` from panicking when the list is nil

## Testing
- `xvfb-run go test -run TestParseGameStatePictureTableOrder -count=1`
- `xvfb-run go test .`


------
https://chatgpt.com/codex/tasks/task_e_68bf144dffb4832a9fc7ad2ae49434e7