### PR TITLE
Show real-time gamepad input and improve joystick bindings

### DIFF
--- a/game.go
+++ b/game.go
@@ -690,6 +690,10 @@ func (g *Game) Update() error {
 		}
 	}
 
+	if joystickWin != nil && joystickWin.IsOpen() {
+		updateJoystickWindow()
+	}
+
 	if inventoryDirty {
 		updateInventoryWindow()
 		updateHandsWindow()


### PR DESCRIPTION
## Summary
- display live axis values and pressed buttons in joystick window
- update controller dropdown when gamepads connect or disconnect
- allow binding actions by pressing a gamepad button

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68bf294d9650832abd78c3a82a134291