### PR TITLE
Add joystick stick selection and visual input display

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -113,6 +113,8 @@ var gsdef settings = settings{
 	NotifiedVersion:       0,
 	JoystickBindings:      map[string]ebiten.GamepadButton{},
 	JoystickEnabled:       false,
+	JoystickWalkStick:     0,
+	JoystickCursorStick:   1,
 	ThrottleSounds:        true,
 	ShaderLighting:        true,
 	NightEffect:           true,
@@ -218,8 +220,10 @@ type settings struct {
 	WindowSnapping        bool
 	ShowPinToLocations    bool
 
-	JoystickEnabled  bool
-	JoystickBindings map[string]ebiten.GamepadButton
+	JoystickEnabled     bool
+	JoystickBindings    map[string]ebiten.GamepadButton
+	JoystickWalkStick   int
+	JoystickCursorStick int
 
 	WindowWidth  int
 	WindowHeight int


### PR DESCRIPTION
## Summary
- allow choosing joystick sticks for walking and cursor
- add UI to bind click buttons and show live input states

## Testing
- `go test ./...` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2ee24ab8832ab41b195ca8369a0b