### PR TITLE
Fix undefined joystick event handler variables

### DIFF
--- a/joystick.go
+++ b/joystick.go
@@ -17,11 +17,16 @@ import (
 var (
 	joystickWin           *eui.WindowData
 	controllerDD          *eui.ItemData
+	controllerEvents      *eui.EventHandler
 	axesText, buttonsText *eui.ItemData
 	walkStickDD           *eui.ItemData
+	walkEvents            *eui.EventHandler
 	cursorStickDD         *eui.ItemData
+	cursorEvents          *eui.EventHandler
 	walkDeadzoneSlider    *eui.ItemData
+	walkDZEvents          *eui.EventHandler
 	cursorDeadzoneSlider  *eui.ItemData
+	cursorDZEvents        *eui.EventHandler
 	click1Input           *eui.ItemData
 	click2Input           *eui.ItemData
 	click3Input           *eui.ItemData


### PR DESCRIPTION
## Summary
- declare joystick dropdown and slider event handler variables

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68bf41290658832a9d187193984e79b1