### PR TITLE
Keep upscale shader uniforms without altering color

### DIFF
--- a/data/shaders/upscale_lanczos.kage
+++ b/data/shaders/upscale_lanczos.kage
@@ -49,6 +49,6 @@ func Fragment(pos vec4, texCoord vec2, color vec4) vec4 {
 	if weight > 0 {
 		col /= weight
 	}
-	col *= Scale * Step // keep uniforms referenced
-	return col
+        col += 0 * (Scale + Step) // keep uniforms referenced
+        return col
 }


### PR DESCRIPTION
## Summary
- Reference Scale and Step uniforms in `upscale_lanczos.kage` without affecting color output

## Testing
- `go build -v`
- `go test ./...` *(fails: interrupted after hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fa4bc5f0832a855cb8c2334343fe