### PR TITLE
Fix Lanczos upscale sampling stride

### DIFF
--- a/game.go
+++ b/game.go
@@ -1370,9 +1370,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		geo := ebiten.GeoM{}
 		geo.Scale(sx, sy)
 		geo.Translate(tx, ty)
+		scale := float32(gs.GameScale)
 		unis := map[string]any{
-			"SrcSize":    [2]float32{float32(offW), float32(offH)},
-			"SampleStep": [2]float32{1 / float32(offW), 1 / float32(offH)},
+			"SrcSize":    [2]float32{float32(offW) / scale, float32(offH) / scale},
+			"SampleStep": [2]float32{scale / float32(offW), scale / float32(offH)},
 		}
 		sop := ebiten.DrawRectShaderOptions{Uniforms: unis, Blend: ebiten.BlendCopy}
 		sop.Images[0] = worldView


### PR DESCRIPTION
## Summary
- compute Lanczos shader stride using `GameScale`

## Testing
- `go test ./...` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c16893688c832ab7b7ad1c587bad5e