### PR TITLE
Fix Lanczos upscale shader uniforms

### DIFF
--- a/game.go
+++ b/game.go
@@ -1370,10 +1370,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		geo := ebiten.GeoM{}
 		geo.Scale(sx, sy)
 		geo.Translate(tx, ty)
-		nnScale := float32(gs.GameScale)
 		unis := map[string]any{
-			"SrcSize":    [2]float32{float32(offW) / nnScale, float32(offH) / nnScale},
-			"SampleStep": [2]float32{nnScale / float32(offW), nnScale / float32(offH)},
+			"SrcSize":    [2]float32{float32(offW), float32(offH)},
+			"SampleStep": [2]float32{1 / float32(offW), 1 / float32(offH)},
 		}
 		sop := ebiten.DrawRectShaderOptions{Uniforms: unis, Blend: ebiten.BlendCopy}
 		sop.Images[0] = worldView


### PR DESCRIPTION
## Summary
- send actual source size and normalized step to Lanczos upscale shader

## Testing
- `go build`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1731cd928832a81a0bd30c1415ae3