### PR TITLE
Add debug networking delay option

### DIFF
--- a/game.go
+++ b/game.go
@@ -2710,6 +2710,9 @@ func sendInputLoop(ctx context.Context, udpConn, tcpConn net.Conn) {
 			return
 		case <-frameCh:
 		}
+		if gs.altNetMode {
+			time.Sleep(time.Duration(gs.altNetDelay) * time.Millisecond)
+		}
 		frameMu.Lock()
 		last := lastFrameTime
 		frameMu.Unlock()

--- a/settings.go
+++ b/settings.go
@@ -132,6 +132,7 @@ var gsdef settings = settings{
 
 	vsync:          true,
 	precacheSounds: true,
+	altNetDelay:    150,
 }
 
 type settings struct {
@@ -255,6 +256,8 @@ type settings struct {
 	pictAgainDebug    bool
 	pictIDDebug       bool
 	pluginOutputDebug bool
+	altNetMode        bool
+	altNetDelay       int
 	hideMoving        bool
 	hideMobiles       bool
 	vsync             bool

--- a/ui.go
+++ b/ui.go
@@ -4572,6 +4572,33 @@ func makeDebugWindow() {
 	}
 	debugFlow.AddItem(pluginOutCB)
 
+	altNetCB, altNetEvents := eui.NewCheckbox()
+	altNetCB.Text = "Alt Networking"
+	altNetCB.Size = eui.Point{X: width, Y: 24}
+	altNetCB.Checked = gs.altNetMode
+	altNetCB.SetTooltip("Send input after a delay following server packets")
+	altNetEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.altNetMode = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(altNetCB)
+
+	netDelaySlider, netDelayEvents := eui.NewSlider()
+	netDelaySlider.Label = "Net Delay (ms)"
+	netDelaySlider.MinValue = 0
+	netDelaySlider.MaxValue = 190
+	netDelaySlider.Value = float32(gs.altNetDelay)
+	netDelaySlider.Size = eui.Point{X: width - 10, Y: 24}
+	netDelayEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.altNetDelay = int(ev.Value)
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(netDelaySlider)
+
 	lanczosCB, lanczosEvents := eui.NewCheckbox()
 	lanczosCB.Text = "Lanczos Upscale Filter (experimental)"
 	lanczosCB.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- add debug checkbox and delay slider for alternate networking
- send input after server packet with configurable wait
- store delay in settings with default 150ms

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c233b162b8832abe1780e5d4d0748c