### PR TITLE
Block text logs during clmov playback

### DIFF
--- a/chat_console_log.go
+++ b/chat_console_log.go
@@ -72,6 +72,12 @@ func ensureTextLog() {
 	textLogMu.Lock()
 	defer textLogMu.Unlock()
 
+	if playingMovie {
+		textLogPath = ""
+		textLogChar = ""
+		return
+	}
+
 	// Determine the preferred character name for logging.
 	desired := strings.TrimSpace(playerName)
 	if desired == "" {


### PR DESCRIPTION
## Summary
- stop writing chat and console text logs when playing a clmov recording

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c2aecb53c0832ab09303e8859d75dd