### PR TITLE
Pre-initialize synth during login

### DIFF
--- a/login.go
+++ b/login.go
@@ -214,6 +214,7 @@ func fetchRandomDemoCharacter(clVersion int) (string, error) {
 // It runs the network loops and blocks until the context is canceled.
 func login(ctx context.Context, clVersion int) error {
 	resetDrawState()
+	go setupSynthOnce.Do(setupSynth)
 	for {
 		imagesVersion, err := readKeyFileVersion(filepath.Join(dataDirPath, CL_ImagesFile))
 		imagesMissing := false


### PR DESCRIPTION
## Summary
- initialize synth asynchronously when logging in to avoid first notification hitch

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go test ./...` *(hangs, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c2afbf7e28832aba96c7bcae8d2895