### PR TITLE
Gradually ramp alt network delay after login

### DIFF
--- a/game_test.go
+++ b/game_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestStopWalkIfOutside(t *testing.T) {
 	old := gs.ClickToToggle
@@ -36,5 +39,31 @@ func TestContinueHeldWalk(t *testing.T) {
 	}
 	if !continueHeldWalk(inputState{}, true, true, 2, false) {
 		t.Fatalf("walk should start when mouse is held inside game")
+	}
+}
+
+func TestAltNetDelay(t *testing.T) {
+	full := 100 * time.Millisecond
+	var start time.Time
+
+	if d, s := altNetDelay(1, start, time.Now(), full); d != 0 || !s.IsZero() {
+		t.Fatalf("frame 1 got delay %v start %v", d, s)
+	}
+
+	now := time.Now()
+	if d, s := altNetDelay(3, start, now, full); d != 0 || s.IsZero() {
+		t.Fatalf("frame 3 got delay %v start %v", d, s)
+	} else {
+		start = s
+	}
+
+	half := start.Add(1500 * time.Millisecond)
+	if d, _ := altNetDelay(4, start, half, full); d < 49*time.Millisecond || d > 51*time.Millisecond {
+		t.Fatalf("half ramp got %v", d)
+	}
+
+	end := start.Add(3 * time.Second)
+	if d, _ := altNetDelay(10, start, end, full); d != full {
+		t.Fatalf("end ramp got %v want %v", d, full)
 	}
 }


### PR DESCRIPTION
## Summary
- Start alt network delay at 0 for two frames and ramp to the configured value over three seconds
- Test ramping logic for alt network delay

## Testing
- `go test ./...` *(fails: command hung and was interrupted in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eb428510832aa50629318a339118