### PR TITLE
Add ping button in debug menu

### DIFF
--- a/network.go
+++ b/network.go
@@ -177,6 +177,22 @@ func sendPlayerInput(connection net.Conn, mouseX, mouseY int16, mouseDown bool, 
 	return sendUDPMessage(connection, packet)
 }
 
+// pingServer establishes a new TCP connection to the server and returns the
+// time taken to connect. If the connection fails, it returns 0.
+func pingServer() time.Duration {
+	if tcpConn == nil {
+		return 0
+	}
+	addr := tcpConn.RemoteAddr().String()
+	start := time.Now()
+	c, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		return 0
+	}
+	c.Close()
+	return time.Since(start)
+}
+
 // readTCPMessage reads a single length-prefixed message from the TCP connection.
 func readTCPMessage(connection net.Conn) ([]byte, error) {
 	var sizeBuf [2]byte

--- a/ui.go
+++ b/ui.go
@@ -91,6 +91,7 @@ var (
 	mobileBlendLabel *eui.ItemData
 	pictBlendLabel   *eui.ItemData
 	totalCacheLabel  *eui.ItemData
+	pingLabel        *eui.ItemData
 
 	recordBtn         *eui.ItemData
 	recordStatus      *eui.ItemData
@@ -4623,6 +4624,39 @@ func makeDebugWindow() {
 		}
 	}
 	debugFlow.AddItem(netDelaySlider)
+
+	pingLabel, _ = eui.NewText()
+	pingLabel.Text = ""
+	pingLabel.Size = eui.Point{X: width, Y: 24}
+	pingLabel.FontSize = 10
+	debugFlow.AddItem(pingLabel)
+
+	pingBtn, pingEvents := eui.NewButton()
+	pingBtn.Text = "Ping Server"
+	pingBtn.Size = eui.Point{X: width, Y: 24}
+	pingEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			pingLabel.Text = "Pinging..."
+			pingLabel.Dirty = true
+			debugWin.Refresh()
+			go func() {
+				worst := time.Duration(0)
+				for i := 0; i < 5; i++ {
+					rtt := pingServer()
+					if rtt > worst {
+						worst = rtt
+					}
+					if i < 4 {
+						time.Sleep(200 * time.Millisecond)
+					}
+				}
+				pingLabel.Text = fmt.Sprintf("Ping: %d ms", worst.Milliseconds())
+				pingLabel.Dirty = true
+				debugWin.Refresh()
+			}()
+		}
+	}
+	debugFlow.AddItem(pingBtn)
 
 	lanczosCB, lanczosEvents := eui.NewCheckbox()
 	lanczosCB.Text = "Lanczos Upscale Filter (experimental)"


### PR DESCRIPTION
## Summary
- Add ping button in debug settings to test server latency
- Show worst round-trip time over five quick connection attempts

## Testing
- `go test ./...` *(fails: command hung, terminated after timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c302894c8c832aaa02166417613263