### PR TITLE
Use standard preset for wasm default quality

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -421,7 +421,11 @@ func loadSettings() bool {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		gs = gsdef
-		applyQualityPreset("High")
+		preset := "High"
+		if isWASM {
+			preset = "Standard"
+		}
+		applyQualityPreset(preset)
 		setHighQualityResamplingEnabled(gs.HighQualityResampling)
 		settingsLoaded = false
 		return false
@@ -465,7 +469,11 @@ func loadSettings() bool {
 		settingsLoaded = true
 	} else {
 		gs = gsdef
-		applyQualityPreset("High")
+		preset := "High"
+		if isWASM {
+			preset = "Standard"
+		}
+		applyQualityPreset(preset)
 		setHighQualityResamplingEnabled(gs.HighQualityResampling)
 		settingsLoaded = false
 		return false


### PR DESCRIPTION
## Summary
- default the quality preset to Standard when running in WASM so medium settings are used

## Testing
- go test ./... *(fails: requires DISPLAY for GLFW initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68ce20d0fac0832ab561fed9652cb448