### PR TITLE
Fix NPC chat trigger detection for descriptor names

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -98,7 +98,12 @@ func isSelfChatMessage(msg string) bool {
 // canonical form. It returns an empty string if no name could be parsed.
 func chatSpeaker(msg string) string {
 	m := strings.TrimSpace(msg)
-	m = strings.TrimPrefix(m, "(")
+	if strings.HasPrefix(m, "(") {
+		if end := strings.IndexByte(m, ')'); end > 1 {
+			return utfFold(strings.TrimSpace(m[1:end]))
+		}
+		m = strings.TrimPrefix(m, "(")
+	}
 	if i := strings.IndexByte(m, ' '); i > 0 {
 		return utfFold(m[:i])
 	}

--- a/chat_messages_test.go
+++ b/chat_messages_test.go
@@ -47,3 +47,19 @@ func TestChatMessageIgnored(t *testing.T) {
 		t.Fatalf("expected no messages")
 	}
 }
+
+func TestChatSpeakerNPCWithDescriptor(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want string
+	}{
+		{"(Town Crier) says, hello", "Town Crier"},
+		{"(Boat Seller) yells, boats", "Boat Seller"},
+		{"Goblin says, hi", "Goblin"},
+	}
+	for _, c := range cases {
+		if got := chatSpeaker(c.msg); got != c.want {
+			t.Fatalf("chatSpeaker(%q) = %q; want %q", c.msg, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- ensure `chatSpeaker` returns the full descriptor name for NPC messages wrapped in parentheses
- cover descriptor-based NPC chat parsing with a unit test

## Testing
- go test ./... *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e747fd48832aa41b258b5e4b4c35