### PR TITLE
Handle NPC chat fallback in yes boats script

### DIFF
--- a/scripts/yes_boats.go
+++ b/scripts/yes_boats.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"strings"
 	"time"
 
 	"gt"
@@ -28,6 +29,10 @@ var (
 func Init() {
 	// React when an NPC message contains this phrase (case‑insensitive).
 	gt.NPCChat("my fine boats", sendYes)
+	// Some ferrymen NPCs fail to register as NPC chat because of how their
+	// names are formatted, so fall back to the general chat stream and
+	// filter by the speaker ourselves.
+	gt.Chat("my fine boats", sendYesIfNPC)
 }
 
 func sendYes(msg string) {
@@ -43,4 +48,46 @@ func sendYes(msg string) {
 	}
 	lastYes = now
 	gt.Run("/whisper yes")
+}
+
+func sendYesIfNPC(msg string) {
+	if !speakerIsNPC(msg) {
+		return
+	}
+	sendYes(msg)
+}
+
+func speakerIsNPC(msg string) bool {
+	name := strings.ToLower(strings.TrimSpace(extractSpeaker(msg)))
+	if name == "" {
+		return false
+	}
+	for _, p := range gt.Players() {
+		if strings.ToLower(p.Name) == name && p.IsNPC {
+			return true
+		}
+	}
+	return false
+}
+
+func extractSpeaker(msg string) string {
+	m := strings.TrimSpace(msg)
+	if m == "" {
+		return ""
+	}
+	if strings.HasPrefix(m, "(") {
+		if end := strings.IndexByte(m, ')'); end > 1 {
+			return strings.TrimSpace(m[1:end])
+		}
+	}
+	lower := strings.ToLower(m)
+	for _, sep := range []string{" says", " yells", " whispers", " asks", " exclaims"} {
+		if idx := strings.Index(lower, sep); idx > 0 {
+			return strings.TrimSpace(m[:idx])
+		}
+	}
+	if i := strings.IndexByte(m, ' '); i > 0 {
+		return strings.TrimSpace(m[:i])
+	}
+	return m
 }


### PR DESCRIPTION
## Summary
- watch general chat for the ferryman phrase so multi-word NPC names still trigger the script
- gate the fallback handler behind an NPC check by parsing the speaker name against known NPCs

## Testing
- go test ./... *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ebaacc10832ab32317a810ab2bb7