### PR TITLE
Fix NPC chat detection for multi-word names

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -98,11 +98,20 @@ func isSelfChatMessage(msg string) bool {
 // canonical form. It returns an empty string if no name could be parsed.
 func chatSpeaker(msg string) string {
 	m := strings.TrimSpace(msg)
+	if m == "" {
+		return ""
+	}
 	if strings.HasPrefix(m, "(") {
 		if end := strings.IndexByte(m, ')'); end > 1 {
 			return utfFold(strings.TrimSpace(m[1:end]))
 		}
 		m = strings.TrimPrefix(m, "(")
+	}
+	lower := strings.ToLower(m)
+	for _, sep := range []string{" says", " yells", " whispers", " asks", " exclaims"} {
+		if idx := strings.Index(lower, sep); idx > 0 {
+			return utfFold(strings.TrimSpace(m[:idx]))
+		}
 	}
 	if i := strings.IndexByte(m, ' '); i > 0 {
 		return utfFold(m[:i])

--- a/chat_messages_test.go
+++ b/chat_messages_test.go
@@ -56,6 +56,8 @@ func TestChatSpeakerNPCWithDescriptor(t *testing.T) {
 		{"(Town Crier) says, hello", "Town Crier"},
 		{"(Boat Seller) yells, boats", "Boat Seller"},
 		{"Goblin says, hi", "Goblin"},
+		{"Captain Barnac says Ah, Malcom.", "Captain Barnac"},
+		{"High Priestess Aria whispers, hush.", "High Priestess Aria"},
 	}
 	for _, c := range cases {
 		if got := chatSpeaker(c.msg); got != c.want {


### PR DESCRIPTION
## Summary
- restore the Yes Boats script to use only the NPC chat hook
- improve chat speaker parsing to keep multi-word NPC names intact
- cover the updated parsing with additional unit tests

## Testing
- go test ./... *(fails: missing pkg-config entries for alsa, Xrandr, and gtk+-3.0 development headers)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ebaacc10832ab32317a810ab2bb7