### PR TITLE
Fix chat bubble tail background color

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -211,18 +211,15 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	fillColor := color.RGBA64{R: uint16(bgR), G: uint16(bgG), B: uint16(bgB), A: uint16(bgA)}
 	borderColor := color.RGBA64{R: uint16(bdR), G: uint16(bdG), B: uint16(bdB), A: uint16(bdA)}
 
+	if !far && !noArrow {
+		tailOp := &vector.DrawPathOptions{AntiAlias: true}
+		tailOp.ColorScale.ScaleWithColor(fillColor)
+		vector.FillPath(screen, &tail, nil, tailOp)
+	}
 	if bubbleType != kBubblePonder {
 		fillOp := &vector.DrawPathOptions{AntiAlias: true}
 		fillOp.ColorScale.ScaleWithColor(fillColor)
 		vector.FillPath(screen, &body, nil, fillOp)
-	}
-	if !far && !noArrow {
-		tailOp := &vector.DrawPathOptions{
-			AntiAlias: true,
-			Blend:     ebiten.BlendCopy,
-		}
-		tailOp.ColorScale.ScaleWithColor(fillColor)
-		vector.FillPath(screen, &tail, nil, tailOp)
 	}
 	if bubbleType != kBubblePonder {
 		var outline vector.Path

--- a/bubble_test.go
+++ b/bubble_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
 
 func TestAdjustBubbleRectNoTail(t *testing.T) {
 	sw, sh := 100, 100
@@ -10,5 +14,30 @@ func TestAdjustBubbleRectNoTail(t *testing.T) {
 	_, _, _, bottom := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, true)
 	if bottom != y {
 		t.Fatalf("expected bottom %d, got %d", y, bottom)
+	}
+}
+
+func TestBubbleTailMatchesBackground(t *testing.T) {
+	orig := gs
+	gs = gsdef
+	gs.GameScale = 1
+	gs.BubbleScale = 1
+	gs.BubbleOpacity = 0.8
+	initFont()
+	t.Cleanup(func() {
+		gs = orig
+		initFont()
+	})
+
+	screen := ebiten.NewImage(gameAreaSizeX, gameAreaSizeY)
+	border, bg, text := bubbleColors(kBubbleNormal)
+	drawBubble(screen, "tail test", 200, 200, kBubbleNormal, false, false, border, bg, text)
+
+	sampleX, sampleY := 200, 195
+	gotR, gotG, gotB, gotA := screen.At(sampleX, sampleY).RGBA()
+	wantR, wantG, wantB, wantA := bg.RGBA()
+	if gotR != wantR || gotG != wantG || gotB != wantB || gotA != wantA {
+		t.Fatalf("tail pixel mismatch at (%d,%d): got (%#x,%#x,%#x,%#x), want (%#x,%#x,%#x,%#x)",
+			sampleX, sampleY, gotR, gotG, gotB, gotA, wantR, wantG, wantB, wantA)
 	}
 }


### PR DESCRIPTION
## Summary
- render bubble tails with standard blending so they inherit the bubble background instead of appearing black
- add a regression test that samples the tail to ensure it uses the expected background color

## Testing
- go test ./... *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68f7fcdae918832a80f01fd9d0c70e57